### PR TITLE
Automatically load denops plugin and skip typecheck

### DIFF
--- a/autoload/denops.vim
+++ b/autoload/denops.vim
@@ -23,14 +23,19 @@ function! denops#error(...) abort
   echohl None
 endfunction
 
-function! denops#register(plugin, script) abort
-  return denops#server#notify('register', [a:plugin, a:script])
-endfunction
-
 function! denops#notify(plugin, method, params) abort
   return denops#server#notify('dispatch', [a:plugin, a:method, a:params])
 endfunction
 
 function! denops#request(plugin, method, params) abort
   return denops#server#request('dispatch', [a:plugin, a:method, a:params])
+endfunction
+
+" DEPRECATED
+function! denops#register(plugin, script) abort
+  call denops#error(join([
+        \ "The denops#register() is deprecated.\n",
+        \ "Create 'mod.ts' file on an arbitrary directory under 'denops' in 'runtimepath'.\n",
+        \ printf("In your case, move '%s' to 'denops/%s/mod.ts' under 'runtimepath'.", a:script, a:plugin),
+        \], ''))
 endfunction

--- a/autoload/denops/script.vim
+++ b/autoload/denops/script.vim
@@ -30,6 +30,9 @@ function! denops#script#start(name, script, ...) abort
   " Construct context
   let args = [remove(options, 'deno'), 'run']
   let args += remove(options, 'deno_args')
+  if !g:denops#script#typecheck
+    let args += ['--no-check']
+  endif
   let args += [a:script]
   let args += remove(options, 'script_args')
   let context = {
@@ -112,8 +115,13 @@ augroup denos_script_internal
 augroup END
 
 let g:denops#script#deno = get(g:, 'denops#script#deno', exepath('deno'))
-let g:denops#script#deno_args = get(g:, 'denops#script#deno_args', ['-q', '--unstable', '-A'])
+let g:denops#script#deno_args = get(g:, 'denops#script#deno_args', [
+      \ '-q',
+      \ '--unstable',
+      \ '-A',
+      \])
 let g:denops#script#env = get(g:, 'denops#script#env', {
       \ 'NO_COLOR': 1,
       \})
 let g:denops#script#max_restart = get(g:, 'denops#script#max_restart', 5)
+let g:denops#script#typecheck = get(g:, 'denops#script#typecheck', 0)

--- a/denops/denops/cli/server.ts
+++ b/denops/denops/cli/server.ts
@@ -2,6 +2,7 @@ import { flags } from "../deps.ts";
 import { Service } from "../service.ts";
 import { createVim } from "../host/vim.ts";
 import { createNeovim } from "../host/nvim.ts";
+import { iterPlugins, Plugin, runPlugin } from "../plugin.ts";
 
 const options = flags.parse(Deno.args);
 const mode = options.mode ?? "neovim";
@@ -12,7 +13,14 @@ const conn = await Deno.connect(address);
 
 // Create host and start communication
 const createHost = mode === "vim" ? createVim : createNeovim;
+const service = new Service();
 const host = createHost(conn, conn);
-const service = new Service(host);
 host.registerService(service);
+
+// Load plugins
+for await (const plugin of iterPlugins(host)) {
+  Service.register(service, plugin.name, runPlugin(host, plugin));
+}
+
+// Listen forever
 await host.waitClosed();

--- a/denops/denops/deps.ts
+++ b/denops/denops/deps.ts
@@ -1,4 +1,6 @@
 export * as flags from "https://deno.land/std@0.86.0/flags/mod.ts";
+export * as path from "https://deno.land/std@0.86.0/path/mod.ts";
+export * as fs from "https://deno.land/std@0.86.0/fs/mod.ts";
 
 export type {
   Dispatcher,

--- a/denops/denops/host/nvim.ts
+++ b/denops/denops/host/nvim.ts
@@ -18,16 +18,6 @@ class Neovim extends AbstractHost {
 
   registerService(service: Service): void {
     const dispatcher: DispatcherFrom<Service> = {
-      async register(name: unknown, script: unknown): Promise<unknown> {
-        if (typeof name !== "string") {
-          throw new Error(`'name' in 'register()' of host must be a string`);
-        }
-        if (typeof script !== "string") {
-          throw new Error(`'script' in 'register()' of host must be a string`);
-        }
-        return await service.register(name, script);
-      },
-
       async dispatch(
         name: unknown,
         fn: unknown,

--- a/denops/denops/host/vim.ts
+++ b/denops/denops/host/vim.ts
@@ -51,10 +51,7 @@ export function createVim(
 }
 
 async function dispatch(service: Service, expr: unknown): Promise<unknown> {
-  if (isRegisterMessage(expr)) {
-    const [_, name, script] = expr;
-    return await service.register(name, script);
-  } else if (isDispatchMessage(expr)) {
+  if (isDispatchMessage(expr)) {
     const [_, name, fn, args] = expr;
     return await service.dispatch(name, fn, args);
   } else {
@@ -64,19 +61,7 @@ async function dispatch(service: Service, expr: unknown): Promise<unknown> {
   }
 }
 
-type RegisterMessage = ["register", string, string];
-
 type DispatchMessage = ["dispatch", string, string, unknown[]];
-
-function isRegisterMessage(data: unknown): data is RegisterMessage {
-  return (
-    Array.isArray(data) &&
-    data.length === 3 &&
-    data[0] === "register" &&
-    typeof data[1] === "string" &&
-    typeof data[2] === "string"
-  );
-}
 
 function isDispatchMessage(data: unknown): data is DispatchMessage {
   return (

--- a/denops/denops/mod.ts
+++ b/denops/denops/mod.ts
@@ -1,3 +1,0 @@
-export * from "./context.ts";
-export * from "./service.ts";
-export * as host from "./host/mod.ts";

--- a/denops/denops/plugin.ts
+++ b/denops/denops/plugin.ts
@@ -1,0 +1,104 @@
+import { Host } from "./host/base.ts";
+import {
+  Api,
+  DispatcherFrom,
+  fs,
+  isContext,
+  path,
+  Session,
+  WorkerReader,
+  WorkerWriter,
+} from "./deps.ts";
+
+export interface Plugin {
+  readonly name: string;
+  readonly script: string;
+}
+
+async function runtimepath(host: Host): Promise<string[]> {
+  const rtp = await host.eval("&runtimepath", {});
+  if (typeof rtp !== "string") {
+    throw new Error("runtimepath is not a string");
+  }
+  return rtp.split(",");
+}
+
+export async function* iterPlugins(
+  host: Host,
+): AsyncGenerator<Plugin, void, unknown> {
+  const rtp = await runtimepath(host);
+  for (const root of rtp) {
+    for await (
+      const entry of fs.expandGlob(
+        path.join(root, "denops", "*", "mod.ts"),
+      )
+    ) {
+      const name = path.basename(path.dirname(entry.path));
+      yield {
+        name,
+        script: entry.path,
+      };
+    }
+  }
+}
+
+export function runPlugin(host: Host, plugin: Plugin): Session {
+  const dispatcher: DispatcherFrom<Api> = {
+    async cmd(cmd: unknown, context: unknown): Promise<void> {
+      if (typeof cmd !== "string") {
+        throw new Error(
+          `'cmd' in 'cmd()' of '${plugin.name}' plugin must be a string`,
+        );
+      }
+      if (!isContext(context)) {
+        throw new Error(
+          `'context' in 'cmd()' of '${plugin.name}' plugin must be a context object`,
+        );
+      }
+      await host.cmd(cmd, context);
+    },
+
+    async eval(expr: unknown, context: unknown): Promise<unknown> {
+      if (typeof expr !== "string") {
+        throw new Error(
+          `'expr' in 'eval()' of '${plugin.name}' plugin must be a string`,
+        );
+      }
+      if (!isContext(context)) {
+        throw new Error(
+          `'context' in 'eval()' of '${plugin.name}' plugin must be a context object`,
+        );
+      }
+      return await host.eval(expr, context);
+    },
+
+    async call(func: unknown, ...args: unknown[]): Promise<unknown> {
+      if (typeof func !== "string") {
+        throw new Error(
+          `'func' in 'call()' of '${plugin.name}' plugin must be a string`,
+        );
+      }
+      return await host.call(func, ...args);
+    },
+  };
+
+  const worker = new Worker(new URL(plugin.script, import.meta.url).href, {
+    name: plugin.name,
+    type: "module",
+    deno: {
+      namespace: true,
+    },
+  });
+  const reader = new WorkerReader(worker);
+  const writer = new WorkerWriter(worker);
+  const session = new Session(reader, writer, dispatcher);
+
+  session
+    .listen()
+    .then()
+    .catch((e: Error) => {
+      console.error("Plugin server is closed with error:", e);
+    });
+
+  return session;
+}

--- a/denops/denops/service.ts
+++ b/denops/denops/service.ts
@@ -1,31 +1,14 @@
-import { Host } from "./host/base.ts";
-import {
-  Api,
-  DispatcherFrom,
-  isContext,
-  Session,
-  WorkerReader,
-  WorkerWriter,
-} from "./deps.ts";
+import { Session } from "./deps.ts";
 
 export class Service {
   #plugins: { [key: string]: Session };
-  #host: Host;
 
-  constructor(host: Host) {
+  constructor() {
     this.#plugins = {};
-    this.#host = host;
   }
 
-  register(name: string, script: string): Promise<void> {
-    try {
-      this.#plugins[name] = runPlugin(name, script, this.#host);
-      return Promise.resolve();
-    } catch (e) {
-      // NOTE:
-      // Vim/Neovim does not handle JavaScript Error instance thus use string instead
-      throw `${e.stack ?? e}`;
-    }
+  static register(service: Service, name: string, session: Session): void {
+    service.#plugins[name] = session;
   }
 
   async dispatch(name: string, fn: string, args: unknown[]): Promise<unknown> {
@@ -41,65 +24,4 @@ export class Service {
       throw `${e.stack ?? e.toString()}`;
     }
   }
-}
-
-function runPlugin(name: string, script: string, host: Host): Session {
-  const dispatcher: DispatcherFrom<Api> = {
-    async cmd(cmd: unknown, context: unknown): Promise<void> {
-      if (typeof cmd !== "string") {
-        throw new Error(
-          `'cmd' in 'cmd()' of '${name}' plugin must be a string`,
-        );
-      }
-      if (!isContext(context)) {
-        throw new Error(
-          `'context' in 'cmd()' of '${name}' plugin must be a context object`,
-        );
-      }
-      await host.cmd(cmd, context);
-    },
-
-    async eval(expr: unknown, context: unknown): Promise<unknown> {
-      if (typeof expr !== "string") {
-        throw new Error(
-          `'expr' in 'eval()' of '${name}' plugin must be a string`,
-        );
-      }
-      if (!isContext(context)) {
-        throw new Error(
-          `'context' in 'eval()' of '${name}' plugin must be a context object`,
-        );
-      }
-      return await host.eval(expr, context);
-    },
-
-    async call(func: unknown, ...args: unknown[]): Promise<unknown> {
-      if (typeof func !== "string") {
-        throw new Error(
-          `'func' in 'call()' of '${name}' plugin must be a string`,
-        );
-      }
-      return await host.call(func, ...args);
-    },
-  };
-
-  const worker = new Worker(new URL(script, import.meta.url).href, {
-    name,
-    type: "module",
-    deno: {
-      namespace: true,
-    },
-  });
-  const reader = new WorkerReader(worker);
-  const writer = new WorkerWriter(worker);
-  const session = new Session(reader, writer, dispatcher);
-
-  session
-    .listen()
-    .then()
-    .catch((e: Error) => {
-      console.error("Plugin server is closed with error:", e);
-    });
-
-  return session;
 }


### PR DESCRIPTION
## Plugin autoload

Now `denops#register()` has deprecated and `mod.ts` files under `denops/xxxxx` directories are loaded as denops plugin automatically.

## Do NOT perform typecheck

Deno is a bit slow with typecheck. While typecheck is only required during development, denops disable typecheck in default

https://user-images.githubusercontent.com/546312/108794387-02c0d400-75c9-11eb-8789-6df063d559dd.mp4

