### PR TITLE
Add inspect flag

### DIFF
--- a/autoload/denops/script.vim
+++ b/autoload/denops/script.vim
@@ -16,6 +16,7 @@ function! denops#script#start(name, script, ...) abort
         \ 'on_stderr': { -> 0},
         \ 'on_exit': { status, context -> denops#error(context.error) },
         \ 'env': g:denops#script#env,
+        \ 'inspector': 0,
         \ 'raw_options': {},
         \}, a:0 ? a:1 : {})
   " Validation
@@ -32,6 +33,9 @@ function! denops#script#start(name, script, ...) abort
   let args += remove(options, 'deno_args')
   if !g:denops#script#typecheck
     let args += ['--no-check']
+  endif
+  if options.inspector
+    let args += ['--inspect']
   endif
   let args += [a:script]
   let args += remove(options, 'script_args')

--- a/autoload/denops/script.vim
+++ b/autoload/denops/script.vim
@@ -16,7 +16,6 @@ function! denops#script#start(name, script, ...) abort
         \ 'on_stderr': { -> 0},
         \ 'on_exit': { status, context -> denops#error(context.error) },
         \ 'env': g:denops#script#env,
-        \ 'inspector': 0,
         \ 'raw_options': {},
         \}, a:0 ? a:1 : {})
   " Validation
@@ -33,9 +32,6 @@ function! denops#script#start(name, script, ...) abort
   let args += remove(options, 'deno_args')
   if !g:denops#script#typecheck
     let args += ['--no-check']
-  endif
-  if options.inspector
-    let args += ['--inspect']
   endif
   let args += [a:script]
   let args += remove(options, 'script_args')

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -57,6 +57,7 @@ function! s:on_channel_opened(script, options, channel) abort
         \ 'script_args': ['--mode=' . s:engine, '--address=' . a:channel.address],
         \ 'on_stdout': a:options.on_stdout,
         \ 'on_stderr': a:options.on_stderr,
+        \ 'inspector': g:denops#server#inspecter_enabled,
         \})
   return a:channel
 endfunction
@@ -104,3 +105,5 @@ augroup denops_server_internal
   autocmd!
   autocmd User DenopsReady :
 augroup END
+
+let g:denops#server#inspecter_enabled = get(g:, 'denops#server#inspecter_enabled', 0)

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -110,4 +110,4 @@ augroup denops_server_internal
   autocmd User DenopsReady :
 augroup END
 
-let g:denops#server#inspecter_enabled = get(g:, 'denops#server#inspecter_enabled', 0)
+let g:denops#server#enable_inspector = get(g:, 'denops#server#enable_inspector', 0)

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -54,7 +54,7 @@ endfunction
 
 function! s:on_channel_opened(script, options, channel) abort
   let deno_args = g:denops#script#deno_args
-  if g:denops#server#inspecter_enabled
+  if g:denops#server#enable_inspector
     let deno_args += ['--inspect']
   endif
   call denops#script#start('server', a:script, {

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -53,11 +53,15 @@ function! s:on_server_ready(channel) abort
 endfunction
 
 function! s:on_channel_opened(script, options, channel) abort
+  let deno_args = g:denops#script#deno_args
+  if g:denops#server#inspecter_enabled
+    let deno_args += ['--inspect']
+  endif
   call denops#script#start('server', a:script, {
+        \ 'deno_args': deno_args,
         \ 'script_args': ['--mode=' . s:engine, '--address=' . a:channel.address],
         \ 'on_stdout': a:options.on_stdout,
         \ 'on_stderr': a:options.on_stderr,
-        \ 'inspector': g:denops#server#inspecter_enabled,
         \})
   return a:channel
 endfunction


### PR DESCRIPTION
# About

Now I'm trying to add the feature for inspector and can run inspector now.
I'm simply add `--inspector` flag to callback hooked by `on_channel_opened` if `g:denops#server#inspector_enabled` is `true`.

# How to demonstrate

1. Set `let g:denops#server#inspector_enabled = 1`.
2. Add loop (non-exited process) in any denops plugin.
  - I tried it with `Deno.listen` as [my demo](https://github.com/kkiyama117/denops-helloworld.vim) does.
3. Open `v8 inspector`. (like `chrome://inspect`)
4. Open vim and select target of inspector. (`deno - main` is `denops.vim`'s one and each worker is denops plugins' ones.)
5. Run command (like `:DenopsEcho`) and then script is loaded
6. Add breakpoint or click `Pause on Exception` button e.t.c.

# Remained issues

- vim has no v8 inspector protocol implementation, so we need to choose or create plugin for it if avoid using any other editor and browser.
- Add breakpoint by chrome inspector may not work correctly (in my own environment)
- msgpack-rtc may cause error and stop runtime if `Pause on Exception` is enabled