### PR TITLE
Add `dispatch` to allow plugins to call APIs of other plugins

### DIFF
--- a/denops/denops/deps.ts
+++ b/denops/denops/deps.ts
@@ -11,9 +11,10 @@ export { Session } from "https://deno.land/x/msgpack_rpc@v2.7/mod.ts";
 export type { Message as VimMessage } from "https://deno.land/x/vim_channel_command@v0.3/mod.ts";
 export { Session as VimSession } from "https://deno.land/x/vim_channel_command@v0.3/mod.ts";
 
-export type { Api, Context } from "https://deno.land/x/denops@v0.10/mod.ts";
-export { Denops, isContext } from "https://deno.land/x/denops@v0.10/mod.ts";
 export {
   WorkerReader,
   WorkerWriter,
 } from "https://deno.land/x/workerio@v1.1/mod.ts";
+
+export type { Api, Context } from "https://deno.land/x/denops@v0.11/mod.ts";
+export { Denops, isContext } from "https://deno.land/x/denops@v0.11/mod.ts";

--- a/denops/denops/plugin.ts
+++ b/denops/denops/plugin.ts
@@ -17,6 +17,29 @@ export interface Plugin {
 export function runPlugin(service: Service, plugin: Plugin): Session {
   const host = service.host;
   const dispatcher: DispatcherFrom<Api> = {
+    async dispatch(
+      name: unknown,
+      method: unknown,
+      params: unknown,
+    ): Promise<unknown> {
+      if (typeof name !== "string") {
+        throw new Error(
+          `'name' in 'dispatch()' of '${plugin.name}' plugin must be a string`,
+        );
+      }
+      if (typeof method !== "string") {
+        throw new Error(
+          `'method' in 'dispatch()' of '${plugin.name}' plugin must be a string`,
+        );
+      }
+      if (!Array.isArray(params)) {
+        throw new Error(
+          `'params' in 'dispatch()' of '${plugin.name}' plugin must be an array`,
+        );
+      }
+      return await service.dispatch(name, method, params);
+    },
+
     async call(func: unknown, ...args: unknown[]): Promise<unknown> {
       if (typeof func !== "string") {
         throw new Error(

--- a/denops/denops/service.ts
+++ b/denops/denops/service.ts
@@ -11,11 +11,15 @@ export class Service {
     this.#host = host;
   }
 
+  get host(): Host {
+    return this.#host;
+  }
+
   register(name: string, script: string): void {
     if (this.#plugins[name]) {
       return;
     }
-    const session = runPlugin(this.#host, {
+    const session = runPlugin(this, {
       name,
       script,
     });


### PR DESCRIPTION
A new API `dispatch` is added. This is useful for plugin developers who would like to allow 3rd party plugins of the plugin (e.g. Custom source of fuzzy finder like Denite, fzf, telescope, whatever).

The `dispatch` only provides a way to call APIs of other plugins. For example, if you'd like to call an API `echo` of a plugin `alpha` from a plugin `beta`, you can use the following code

```typescript
// From `beta`
await denops.dispatch('alpha', 'echo', []);
```

Note that the plugin `alpha` **must be loaded** prior to call the function above.

Close #30 