### PR TITLE
Prefer `app.ts` instead of `mod.ts` as an entrypoint of denops plugin

### DIFF
--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -4,15 +4,42 @@ function! denops#plugin#register(plugin, script) abort
 endfunction
 
 function! denops#plugin#discover() abort
+  let plugins = {}
+  call s:gather_plugins(plugins)
+  call s:gather_plugins_deprecated(plugins)
+  for [name, script] in items(plugins)
+    call denops#plugin#register(name, script)
+  endfor
+endfunction
+
+function! s:gather_plugins(plugins) abort
+  for runtimepath in split(&runtimepath, ',')
+    let path = expand(runtimepath)
+    let expr = denops#util#join_path(path, 'denops', '*', 'app.ts')
+    for script in glob(expr, 1, 1, 1)
+      let name = fnamemodify(script, ':h:t')
+      if name[:0] ==# '@' || has_key(a:plugins, name)
+        continue
+      endif
+      call extend(a:plugins, { name : script })
+    endfor
+  endfor
+endfunction
+
+function! s:gather_plugins_deprecated(plugins) abort
   for runtimepath in split(&runtimepath, ',')
     let path = expand(runtimepath)
     let expr = denops#util#join_path(path, 'denops', '*', 'mod.ts')
     for script in glob(expr, 1, 1, 1)
       let name = fnamemodify(script, ':h:t')
-      if name[:0] ==# '@'
+      if name[:0] ==# '@' || has_key(a:plugins, name)
         continue
       endif
-      call denops#plugin#register(name, script)
+      call denops#error(printf(
+            \ 'The plugin `%s` still use `mod.ts` which has deprecated in favor of `app.ts`.',
+            \ name,
+            \))
+      call extend(a:plugins, { name : script })
     endfor
   endfor
 endfunction


### PR DESCRIPTION
Close #36

After this PR is merged, the following warning message will be shown

```
[denops] The plugin `helloworld` still use `mod.ts` which has deprecated in favor of `app.ts`
```

Plugin authors should rename `mod.ts` to `app.ts` to avoid above warning message.