### PR TITLE
Add type check to CI

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -15,6 +15,18 @@ on:
       - main
 
 jobs:
+  typecheck:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: denoland/setup-deno@main
+        with:
+          deno-version: ${{ env.DENO_VERSION }}
+      - name: Type check
+        run: |
+          deno test --unstable --no-run denops/**/*.ts
+
   lint:
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
Added a job to do type checking because type checking was not being done in CI.
Currently, there is no subcommand dedicated to type checking, so we use `test --no-run` .