### PR TITLE
🐛  URL specifier for Worker is not supported on Deno v1.11.2

### DIFF
--- a/denops/@denops-private/service/service.ts
+++ b/denops/@denops-private/service/service.ts
@@ -30,7 +30,7 @@ export class Service {
       worker.terminate();
     }
     const worker = new Worker(
-      new URL(workerScript, import.meta.url),
+      new URL(workerScript, import.meta.url).href,
       {
         name,
         type: "module",


### PR DESCRIPTION
Denops should support Deno v1.11.0+ so use string instead

https://github.com/denoland/deno/commit/a8e4fc15e516299e9bfc466ae3b2711b6ce2fcd3