### PR TITLE
:+1: Expose only types to improve backward compatibility

### DIFF
--- a/denops/@denops-private/denops.ts
+++ b/denops/@denops-private/denops.ts
@@ -1,0 +1,46 @@
+import { Context, Denops, Meta } from "../@denops/denops.ts";
+import { Dispatcher, Session } from "../@denops/deps.ts";
+
+export class DenopsImpl implements Denops {
+  readonly name: string;
+  readonly meta: Meta;
+  #session: Session;
+
+  constructor(
+    name: string,
+    meta: Meta,
+    session: Session,
+  ) {
+    this.name = name;
+    this.meta = meta;
+    this.#session = session;
+  }
+
+  get dispatcher(): Dispatcher {
+    return this.#session.dispatcher;
+  }
+
+  set dispatcher(dispatcher: Dispatcher) {
+    this.#session.dispatcher = dispatcher;
+  }
+
+  async call(fn: string, ...args: unknown[]): Promise<unknown> {
+    return await this.#session.call("call", fn, ...args);
+  }
+
+  async cmd(cmd: string, ctx: Context = {}): Promise<void> {
+    await this.#session.call("call", "denops#api#cmd", cmd, ctx);
+  }
+
+  async eval(expr: string, ctx: Context = {}): Promise<unknown> {
+    return await this.#session.call("call", "denops#api#eval", expr, ctx);
+  }
+
+  async dispatch(
+    name: string,
+    fn: string,
+    ...args: unknown[]
+  ): Promise<unknown> {
+    return await this.#session.call("dispatch", name, fn, ...args);
+  }
+}

--- a/denops/@denops-private/service/worker/script.ts
+++ b/denops/@denops-private/service/worker/script.ts
@@ -10,6 +10,7 @@ import {
   WorkerWriter,
 } from "../deps.ts";
 import { Denops, Meta } from "../../../@denops/denops.ts";
+import { DenopsImpl } from "../../../@denops-private/denops.ts";
 
 // deno-lint-ignore no-explicit-any
 const worker = self as any as Worker;
@@ -28,7 +29,7 @@ async function main(name: string, script: string, meta: Meta): Promise<void> {
       },
     }),
     async (session) => {
-      const denops = new Denops(name, meta, session);
+      const denops: Denops = new DenopsImpl(name, meta, session);
       await mod.main(denops);
       await session.waitClosed();
     },

--- a/denops/@denops/denops.ts
+++ b/denops/@denops/denops.ts
@@ -1,4 +1,4 @@
-import { Dispatcher, Session } from "./deps.ts";
+import { Dispatcher } from "./deps.ts";
 
 /**
  * Context which is expanded to the local namespace (l:)
@@ -15,28 +15,21 @@ export type Meta = {
 /**
  * Denpos is a facade instance visible from each denops plugins.
  */
-export class Denops {
+export interface Denops {
+  /**
+   * Denops instance name which uses to communicate with vim.
+   */
   readonly name: string;
+
+  /**
+   * Environment meta information.
+   */
   readonly meta: Meta;
-  #session: Session;
 
-  constructor(
-    name: string,
-    meta: Meta,
-    session: Session,
-  ) {
-    this.name = name;
-    this.meta = meta;
-    this.#session = session;
-  }
-
-  get dispatcher(): Dispatcher {
-    return this.#session.dispatcher;
-  }
-
-  set dispatcher(dispatcher: Dispatcher) {
-    this.#session.dispatcher = dispatcher;
-  }
+  /**
+   * User defined API name and method map which is used to dispatch API request
+   */
+  dispatcher: Dispatcher;
 
   /**
    * Call an arbitrary function of Vim/Neovim and return the result
@@ -44,9 +37,7 @@ export class Denops {
    * @param fn: A function name of Vim/Neovim.
    * @param args: Arguments of the function.
    */
-  async call(fn: string, ...args: unknown[]): Promise<unknown> {
-    return await this.#session.call("call", fn, ...args);
-  }
+  call(fn: string, ...args: unknown[]): Promise<unknown>;
 
   /**
    * Execute an arbitrary command of Vim/Neovim under a given context.
@@ -54,9 +45,7 @@ export class Denops {
    * @param cmd: A command expression to be executed.
    * @param ctx: A context object which is expanded to the local namespace (l:)
    */
-  async cmd(cmd: string, ctx: Context = {}): Promise<void> {
-    await this.#session.call("call", "denops#api#cmd", cmd, ctx);
-  }
+  cmd(cmd: string, ctx?: Context): Promise<void>;
 
   /**
    * Evaluate an arbitrary expression of Vim/Neovim under a given context and return the result.
@@ -64,9 +53,7 @@ export class Denops {
    * @param expr: An expression to be evaluated.
    * @param ctx: A context object which is expanded to the local namespace (l:)
    */
-  async eval(expr: string, ctx: Context = {}): Promise<unknown> {
-    return await this.#session.call("call", "denops#api#eval", expr, ctx);
-  }
+  eval(expr: string, ctx?: Context): Promise<unknown>;
 
   /**
    * Dispatch an arbitrary function of an arbitrary plugin and return the result.
@@ -75,11 +62,5 @@ export class Denops {
    * @param fn: A function name in the API registration.
    * @param args: Arguments of the function.
    */
-  async dispatch(
-    name: string,
-    fn: string,
-    ...args: unknown[]
-  ): Promise<unknown> {
-    return await this.#session.call("dispatch", name, fn, ...args);
-  }
+  dispatch(name: string, fn: string, ...args: unknown[]): Promise<unknown>;
 }

--- a/denops/@denops/test/tester.ts
+++ b/denops/@denops/test/tester.ts
@@ -1,5 +1,6 @@
 import { path, Session, Timeout, using } from "../deps_test.ts";
 import { Denops, Meta } from "../denops.ts";
+import { DenopsImpl } from "../../@denops-private/denops.ts";
 import { DENOPS_TEST_NVIM, DENOPS_TEST_VIM, run } from "./runner.ts";
 
 const DEFAULT_TIMEOUT = 1000;
@@ -57,7 +58,7 @@ async function withDenops(
       }),
       async (session) => {
         const meta = await session.call("call", "denops#util#meta") as Meta;
-        const denops = new Denops("@test", meta, session);
+        const denops: Denops = new DenopsImpl("@test", meta, session);
         const runner = async () => {
           await main(denops);
         };


### PR DESCRIPTION
Currently, denops.vim exposes `Denops` identifier. It is a `class` so sometimes third-party modules get a type mismatch error by internal implementation details.

This PR aims to solve the problem by expose only `Denops` ***type***,