### PR TITLE
Support lazy loading feature

### DIFF
--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -1,14 +1,16 @@
-function! denops#plugin#register(name, script) abort
+function! denops#plugin#register(name, script, ...) abort
   let meta = denops#util#meta()
-  call denops#util#debug(printf('register `%s` plugin as `%s` (%s)', a:name, a:script, meta))
-  return denops#server#channel#notify('invoke', ['register', [a:name, a:script, meta]])
+  let options = s:options(a:0 > 0 ? a:1 : {})
+  return s:register(a:name, a:script, meta, options)
 endfunction
 
-function! denops#plugin#discover() abort
+function! denops#plugin#discover(...) abort
+  let meta = denops#util#meta()
+  let options = s:options(a:0 > 0 ? a:1 : {})
   let plugins = {}
   call s:gather_plugins(plugins)
   for [name, script] in items(plugins)
-    call denops#plugin#register(name, script)
+    call s:register(name, script, meta, options)
   endfor
 endfunction
 
@@ -24,4 +26,17 @@ function! s:gather_plugins(plugins) abort
       call extend(a:plugins, { name : script })
     endfor
   endfor
+endfunction
+
+function! s:options(base) abort
+  let default = {
+        \ 'reload': v:false,
+        \}
+  return extend(default, a:base)
+endfunction
+
+function! s:register(name, script, meta, options) abort
+  let args = [a:name, a:script, a:meta, a:options]
+  call denops#util#debug(printf('register plugin: %s', args))
+  return denops#server#channel#notify('invoke', ['register', args])
 endfunction

--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -1,7 +1,13 @@
-function! denops#plugin#register(name, script, ...) abort
+function! denops#plugin#register(name, ...) abort
+  if a:0 is# 0 || type(a:1) is# v:t_dict
+    let options = s:options(a:0 > 0 ? a:1 : {})
+    let script = s:find_plugin(a:name)
+  else
+    let script = a:1
+    let options = s:options(a:0 > 1 ? a:2 : {})
+  endif
   let meta = denops#util#meta()
-  let options = s:options(a:0 > 0 ? a:1 : {})
-  return s:register(a:name, a:script, meta, options)
+  return s:register(a:name, script, meta, options)
 endfunction
 
 function! denops#plugin#discover(...) abort
@@ -16,8 +22,7 @@ endfunction
 
 function! s:gather_plugins(plugins) abort
   for runtimepath in split(&runtimepath, ',')
-    let path = expand(runtimepath)
-    let expr = denops#util#join_path(path, 'denops', '*', 'main.ts')
+    let expr = denops#util#join_path(expand(runtimepath), 'denops', '*', 'main.ts')
     for script in glob(expr, 1, 1, 1)
       let name = fnamemodify(script, ':h:t')
       if name[:0] ==# '@' || has_key(a:plugins, name)
@@ -39,4 +44,16 @@ function! s:register(name, script, meta, options) abort
   let args = [a:name, a:script, a:meta, a:options]
   call denops#util#debug(printf('register plugin: %s', args))
   return denops#server#channel#notify('invoke', ['register', args])
+endfunction
+
+function! s:find_plugin(name) abort
+  for runtimepath in split(&runtimepath, ',')
+    let script = denops#util#join_path(expand(runtimepath), 'denops', a:name, 'main.ts')
+    let name = fnamemodify(script, ':h:t')
+    if name[:0] ==# '@' || !filereadable(script)
+      continue
+    endif
+    return script
+  endfor
+  throw printf('No denops plugin for "%s" exists', a:name)
 endfunction

--- a/denops/@denops-private/service/host/invoker.ts
+++ b/denops/@denops-private/service/host/invoker.ts
@@ -1,6 +1,10 @@
 import { Service } from "../service.ts";
 import { Meta } from "../../../@denops/denops.ts";
 
+export type RegisterOptions = {
+  reload?: boolean;
+};
+
 export class Invoker {
   #service: Service;
 
@@ -8,8 +12,13 @@ export class Invoker {
     this.#service = service;
   }
 
-  register(name: string, script: string, meta: Meta): void {
-    this.#service.register(name, script, meta);
+  register(
+    name: string,
+    script: string,
+    meta: Meta,
+    options: RegisterOptions,
+  ): void {
+    this.#service.register(name, script, meta, options);
   }
 
   dispatch(name: string, fn: string, args: unknown[]): Promise<unknown> {

--- a/denops/@denops-private/service/service.ts
+++ b/denops/@denops-private/service/service.ts
@@ -8,7 +8,7 @@ import {
   WorkerWriter,
 } from "./deps.ts";
 import { Host } from "./host/base.ts";
-import { Invoker } from "./host/invoker.ts";
+import { Invoker, RegisterOptions } from "./host/invoker.ts";
 import { Meta } from "../../@denops/denops.ts";
 
 const workerScript = "./worker/script.ts";
@@ -26,10 +26,19 @@ export class Service {
     this.#host.register(new Invoker(this));
   }
 
-  register(name: string, script: string, meta: Meta): void {
+  register(
+    name: string,
+    script: string,
+    meta: Meta,
+    options: RegisterOptions,
+  ): void {
     if (name in this.#plugins) {
-      const { worker } = this.#plugins[name];
-      worker.terminate();
+      if (options.reload) {
+        const { worker } = this.#plugins[name];
+        worker.terminate();
+      } else {
+        throw new Error(`A denops plugin '${name}' has already registered`);
+      }
     }
     const worker = new Worker(
       new URL(workerScript, import.meta.url).href,

--- a/denops/@denops-private/service/worker/script.ts
+++ b/denops/@denops-private/service/worker/script.ts
@@ -30,7 +30,17 @@ async function main(name: string, script: string, meta: Meta): Promise<void> {
     }),
     async (session) => {
       const denops: Denops = new DenopsImpl(name, meta, session);
+      await denops.call(
+        "execute",
+        `doautocmd <nomodeline> User DenopsPluginPre:${name}`,
+        "",
+      );
       await mod.main(denops);
+      await denops.call(
+        "execute",
+        `doautocmd <nomodeline> User DenopsPluginPost:${name}`,
+        "",
+      );
       await session.waitClosed();
     },
   );

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -93,6 +93,11 @@ denops#request_async({plugin}, {method}, {params}, {success}, {failure})
 denops#server#start()
 	Start denops "channel" server and "service" server asynchronously.
 	It will skip internal process if servers are already running.
+	It is automatically called 1) on |VimEnter| autocmd when denops is
+	in |runtimepath| during Vim startup, 2) immediately when denops is
+	added to |runtimepath| after Vim startup.
+	It will invoke |User| |DenopsReady| autocmd to discover denops plugins.
+	See |denops#plugin#discover()| for detail.
 
 						*denops#server#stop()*
 denops#server#stop()
@@ -127,7 +132,8 @@ denops#plugin#discover([{options}])
 	Discover denops plugins from |runtimepath| and register.
 	It gathers "main.ts" under "denops/*" directories under |runtimepath|
 	if the middle directory does not starts from "@".
-	This is automatically called on |VimEnter| autocmd.
+	This is automatically called on |User| |DenopsReady| autocmd invoked by
+	|denops#server#start()|.
 	See |denops#plugin#register()| for {options}.
 
 						*denops#callback#add()*

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -132,6 +132,10 @@ denops#plugin#register({name}[, {script}[, {options}]])
 >
 	call denops#plugin#register('helloworld', { 'reload': v:true })
 <
+	It invokes |User| |DenopsPluginPre|:{name} just before denops execute
+	a "main" function of the plugin and |User| |DenopsPluginPost|:{name}
+	just after denops execute a "main" function of the plugin.
+
 						*denops#plugin#discover()*
 denops#plugin#discover([{options}])
 	Discover denops plugins from |runtimepath| and register.
@@ -160,10 +164,15 @@ denops#callback#clear()
 -----------------------------------------------------------------------------
 AUTOCMD						*denops-autocmd*
 
-*DenopsReady*
+DenopsReady						*DenopsReady*
 	Invoked when a denops "service" service become ready. Note that it is
 	not mean that all of denops plugins are ready.
 
+DenopsPluginPre:{name}					*DenopsPluginPre*
+	Invoked just before denops call a "main" function of a plugin {name}.
+
+DenopsPluginPost:{name}					*DenopsPluginPost*
+	Invoked just after denops called a "main" function of a plugin {name}.
 
 =============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -111,16 +111,24 @@ denops#server#status()
 	"running"	Servers are running.
 
 						*denops#plugin#register()*
-denops#plugin#register({name}, {script})
+denops#plugin#register({name}, {script}[, {options}])
 	Register denops plugin. Use this function to register denops plugins
 	which is not discovered by |denops#plugin#discover()|.
+	The following attributes are available on {options}.
+
+	"reload"	|v:true| to reload a {name} plugin if it has already
+			registered.
+
+	It throws an error when a {name} plugin has already registered unless
+	"reload" {options} is specified.
 
 						*denops#plugin#discover()*
-denops#plugin#discover()
+denops#plugin#discover([{options}])
 	Discover denops plugins from |runtimepath| and register.
 	It gathers "main.ts" under "denops/*" directories under |runtimepath|
 	if the middle directory does not starts from "@".
 	This is automatically called on |VimEnter| autocmd.
+	See |denops#plugin#register()| for {options}.
 
 						*denops#callback#add()*
 denops#callback#add({callback})

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -116,17 +116,22 @@ denops#server#status()
 	"running"	Servers are running.
 
 						*denops#plugin#register()*
-denops#plugin#register({name}, {script}[, {options}])
+denops#plugin#register({name}[, {script}[, {options}]])
 	Register denops plugin. Use this function to register denops plugins
 	which is not discovered by |denops#plugin#discover()|.
+	When a {script} is omitted, a "denops/{name}/main.ts" file is searched
+	from |runtimepath| like discover.
 	The following attributes are available on {options}.
 
 	"reload"	|v:true| to reload a {name} plugin if it has already
 			registered.
 
 	It throws an error when a {name} plugin has already registered unless
-	"reload" {options} is specified.
-
+	"reload" {options} is specified. So use a "reload" option to reload
+	registered plugin like:
+>
+	call denops#plugin#register('helloworld', { 'reload': v:true })
+<
 						*denops#plugin#discover()*
 denops#plugin#discover([{options}])
 	Discover denops plugins from |runtimepath| and register.

--- a/plugin/denops.vim
+++ b/plugin/denops.vim
@@ -13,6 +13,8 @@ endif
 augroup denops_plugin_internal
   autocmd!
   autocmd User DenopsReady call denops#plugin#discover()
+  autocmd User DenopsPluginPre:* :
+  autocmd User DenopsPluginPost:* :
 augroup END
 
 if has('vim_starting')

--- a/plugin/denops.vim
+++ b/plugin/denops.vim
@@ -12,6 +12,14 @@ endif
 
 augroup denops_plugin_internal
   autocmd!
-  autocmd VimEnter * call denops#server#start()
   autocmd User DenopsReady call denops#plugin#discover()
 augroup END
+
+if has('vim_starting')
+  augroup denops_plugin_internal_startup
+    autocmd!
+    autocmd VimEnter * call denops#server#start()
+  augroup END
+else
+  call denops#server#start()
+endif


### PR DESCRIPTION
To support #75 

See https://github.com/vim-denops/denops.vim/pull/76/files#diff-2dac928d77c51b449506e022e27ca2cf8424241df3bec2a51658ff86ac76cd22 for detail.

### How to enable lazy loading denops itself

Nothing needs to be done. Denops automatically detect if it's loaded after vim startup or not and automatically start server properly

### How to enable lazy loading on denops plugins

Call `denops#plugin#register('{name}')` with `silent!` like

```vim
silent! call denops#plugin#register('ddc.vim')
```