### PR TITLE
👍  Stop using `timeout` module which cause `TS2304`

### DIFF
--- a/denops/@denops/deps_test.ts
+++ b/denops/@denops/deps_test.ts
@@ -1,3 +1,2 @@
 export * from "https://deno.land/std@0.100.0/testing/asserts.ts#^";
-
-export { Timeout } from "https://deno.land/x/timeout@2.4/mod.ts";
+export { deferred } from "https://deno.land/std@0.100.0/async/mod.ts#^";

--- a/denops/@denops/test/tester.ts
+++ b/denops/@denops/test/tester.ts
@@ -1,7 +1,7 @@
 import { path, Session, using } from "../deps.ts";
-import { Timeout } from "../deps_test.ts";
 import { Denops, DenopsImpl, Meta } from "../denops.ts";
 import { DENOPS_TEST_NVIM, DENOPS_TEST_VIM, run } from "./runner.ts";
+import { timeout } from "./timeout.ts";
 
 const DEFAULT_TIMEOUT = 1000;
 
@@ -63,7 +63,7 @@ async function withDenops(
         const runner = async () => {
           await main(denops);
         };
-        await Timeout.race([runner()], options.timeout ?? DEFAULT_TIMEOUT);
+        await timeout(runner(), options.timeout ?? DEFAULT_TIMEOUT);
       },
     );
   } finally {

--- a/denops/@denops/test/timeout.ts
+++ b/denops/@denops/test/timeout.ts
@@ -1,0 +1,15 @@
+import { deferred } from "../deps_test.ts";
+
+export class TimeoutError extends Error {
+  constructor() {
+    super("Timeout");
+    this.name = "TimeoutError";
+  }
+}
+
+export function timeout<T>(p: Promise<T>, delay: number): Promise<T> {
+  const d = deferred<never>();
+  const t = setTimeout(() => d.reject(new TimeoutError()), delay);
+  p.finally(() => clearTimeout(t));
+  return Promise.race([p, d]);
+}

--- a/denops/@denops/test/timeout_test.ts
+++ b/denops/@denops/test/timeout_test.ts
@@ -1,0 +1,18 @@
+import { assertEquals, assertThrowsAsync, deferred } from "../deps_test.ts";
+import { timeout, TimeoutError } from "./timeout.ts";
+
+Deno.test("timeout() return fulfilled promise", async () => {
+  const p = deferred();
+  const t = setTimeout(() => p.resolve("Hello"), 100);
+  const result = await timeout(p, 1000);
+  assertEquals(result, "Hello");
+  clearTimeout(t);
+});
+Deno.test("timeout() throws TimeoutError", async () => {
+  const p = deferred();
+  const t = setTimeout(() => p.resolve("Hello"), 1000);
+  await assertThrowsAsync(async () => {
+    await timeout(p, 100);
+  }, TimeoutError);
+  clearTimeout(t);
+});


### PR DESCRIPTION
Loading https://deno.land/x/timeout@2.4 in denops.vim cause

```
[denops] Unexpected error occured in 'bcdice-api' (C:\home\develop\denops-bcdice-api.vim\denops\bcdice-api\main.ts): TypeError: TS2304 [ERROR]: Cannot find name 'window'.
[denops]   const promise = window.fetch(input, { signal, ...init })
[denops]                   ~~~~~~
[denops]     at https://deno.land/x/abortable@1.6/abort.ts:40:19
```

It's because `abortable` module used in `timeout` module does not support Worker environment