### PR TITLE
Improve behavior and performance on Vim

### DIFF
--- a/autoload/denops/api.vim
+++ b/autoload/denops/api.vim
@@ -7,26 +7,3 @@ function! denops#api#eval(expr, context) abort
   call extend(l:, a:context)
   return eval(a:expr)
 endfunction
-
-" NOTE: This function is useless for Vim 8.2.3080 or below
-" https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
-function! denops#api#call(fn, args) abort
-  try
-    return [call(a:fn, a:args), '']
-  catch
-    return [v:null, v:exception]
-  endtry
-endfunction
-
-function! denops#api#call_before_823080_pre(fn, args) abort
-  let s:call_before_823080 = {
-        \ 'fn': a:fn,
-        \ 'args': a:args,
-        \}
-endfunction
-
-function! denops#api#call_before_823080_call() abort
-  let v:errmsg = ''
-  let g:denops#api#call_before_823080 = v:null
-  let g:denops#api#call_before_823080 = call(s:call_before_823080.fn, s:call_before_823080.args)
-endfunction

--- a/autoload/denops/api/vim.vim
+++ b/autoload/denops/api/vim.vim
@@ -26,3 +26,39 @@ function! denops#api#vim#call_before_823080_call() abort
   let g:denops#api#vim#call_before_823080 = v:null
   let g:denops#api#vim#call_before_823080 = call(s:call_before_823080.fn, s:call_before_823080.args)
 endfunction
+
+" NOTE:
+" This is a workaround function to detect errors in Vim while Vim 8.2.3081 or
+" above SILENCE any errors occured in `call` channel command.
+" https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
+function! denops#api#vim#batch(calls) abort
+  let results = []
+  try
+    for l:Call in a:calls
+      call add(results, call(Call[0], Call[1:]))
+    endfor
+    return [results, '']
+  catch
+    return [results, v:exception]
+  endtry
+endfunction
+
+" NOTE:
+" This is a workaround function to detect errors in Vim while Vim 8.2.3080 or
+" below IGNORE any errors occured in `call` channel command thus we need to
+" use `ex` command with `v:errmsg` instead.
+" https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
+function! denops#api#vim#batch_before_823080_pre(calls) abort
+  let s:batch_before_823080 = a:calls
+endfunction
+function! denops#api#vim#batch_before_823080_call() abort
+  let v:errmsg = ''
+  let g:denops#api#vim#batch_before_823080 = []
+  for l:Call in s:batch_before_823080
+    let result = call(Call[0], Call[1:])
+    if v:errmsg !=# ''
+      break
+    endif
+    call add(g:denops#api#vim#batch_before_823080, result)
+  endfor
+endfunction

--- a/autoload/denops/api/vim.vim
+++ b/autoload/denops/api/vim.vim
@@ -1,0 +1,28 @@
+" NOTE:
+" This is a workaround function to detect errors in Vim while Vim 8.2.3081 or
+" above SILENCE any errors occured in `call` channel command.
+" https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
+function! denops#api#vim#call(fn, args) abort
+  try
+    return [call(a:fn, a:args), '']
+  catch
+    return [v:null, v:exception]
+  endtry
+endfunction
+
+" NOTE:
+" This is a workaround function to detect errors in Vim while Vim 8.2.3080 or
+" below IGNORE any errors occured in `call` channel command thus we need to
+" use `ex` command with `v:errmsg` instead.
+" https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
+function! denops#api#vim#call_before_823080_pre(fn, args) abort
+  let s:call_before_823080 = {
+        \ 'fn': a:fn,
+        \ 'args': a:args,
+        \}
+endfunction
+function! denops#api#vim#call_before_823080_call() abort
+  let v:errmsg = ''
+  let g:denops#api#vim#call_before_823080 = v:null
+  let g:denops#api#vim#call_before_823080 = call(s:call_before_823080.fn, s:call_before_823080.args)
+endfunction

--- a/denops/@denops-private/service/host/vim.ts
+++ b/denops/@denops-private/service/host/vim.ts
@@ -19,13 +19,13 @@ export class Vim implements Host {
     ...args: unknown[]
   ): Promise<unknown> {
     await this.#session.call(
-      "denops#api#call_before_823080_pre",
+      "denops#api#vim#call_before_823080_pre",
       fn,
       args,
     ) as string;
-    await this.#session.ex("call denops#api#call_before_823080_call()");
+    await this.#session.ex("call denops#api#vim#call_before_823080_call()");
     const [ret, err] = await this.#session.expr(
-      "[g:denops#api#call_before_823080, v:errmsg]",
+      "[g:denops#api#vim#call_before_823080, v:errmsg]",
     ) as [unknown, string];
     if (err !== "") {
       throw new Error(`Failed to call '${fn}(${args.join(", ")})': ${err}`);
@@ -35,7 +35,7 @@ export class Vim implements Host {
 
   private async callForDebug(fn: string, ...args: unknown[]): Promise<unknown> {
     const [ret, err] = await this.#session.call(
-      "denops#api#call",
+      "denops#api#vim#call",
       fn,
       args,
     ) as [

--- a/denops/@denops-private/service/host/vim.ts
+++ b/denops/@denops-private/service/host/vim.ts
@@ -64,12 +64,7 @@ export class Vim implements Host {
     // enabled.
     try {
       if (this.#meta.mode !== "release") {
-        if (
-          this.#meta.version.localeCompare("8.2.3080", undefined, {
-            numeric: true,
-            sensitivity: "base",
-          }) === -1
-        ) {
+        if (isBefore823080(this.#meta.version)) {
           return await this.callForDebugBefore823080(fn, ...args);
         } else {
           return await this.callForDebug(fn, ...args);
@@ -95,12 +90,7 @@ export class Vim implements Host {
     // enabled.
     let call;
     if (this.#meta.mode !== "release") {
-      if (
-        this.#meta.version.localeCompare("8.2.3080", undefined, {
-          numeric: true,
-          sensitivity: "base",
-        }) === -1
-      ) {
+      if (isBefore823080(this.#meta.version)) {
         call = this.callForDebugBefore823080;
       } else {
         call = this.callForDebug;
@@ -146,6 +136,13 @@ export class Vim implements Host {
   dispose(): void {
     this.#session.dispose();
   }
+}
+
+function isBefore823080(version: string): boolean {
+  return version.localeCompare("8.2.3080", undefined, {
+    numeric: true,
+    sensitivity: "base",
+  }) === -1;
 }
 
 async function dispatch(invoker: Invoker, expr: unknown): Promise<unknown> {

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -40,7 +40,6 @@ VARIABLE						*denops-variable*
 	features become enabled.
 
 	- Additional debug messages of denops itself
-	- Error checks become enabled on Vim (always enabled on Neovim)
 	- Type checks of Deno modules become enabled
 
 	Note that the debug mode would affect the performance so disable it


### PR DESCRIPTION
1. Always use a workaround version in Vim so that errors that occurred in Vim become detectable (without `g:denops#debug = 1`)
2. Improve performance of `batch` approx 5 times