### PR TITLE
👍  Extend response timeout from 10 sec to 7 days

### DIFF
--- a/denops/@denops-private/service/defs.ts
+++ b/denops/@denops-private/service/defs.ts
@@ -1,0 +1,2 @@
+// No body would leave Vim session for 7 days
+export const responseTimeout = 60 * 60 * 24 * 7;

--- a/denops/@denops-private/service/host/nvim.ts
+++ b/denops/@denops-private/service/host/nvim.ts
@@ -1,4 +1,5 @@
 import { ensureArray, ensureString, Session } from "../deps.ts";
+import { responseTimeout } from "../defs.ts";
 import { Invoker, isInvokerMethod } from "./invoker.ts";
 import { Host } from "./base.ts";
 
@@ -9,7 +10,9 @@ export class Neovim implements Host {
     reader: Deno.Reader & Deno.Closer,
     writer: Deno.Writer,
   ) {
-    this.#session = new Session(reader, writer);
+    this.#session = new Session(reader, writer, undefined, {
+      responseTimeout,
+    });
   }
 
   call(fn: string, ...args: unknown[]): Promise<unknown> {

--- a/denops/@denops-private/service/host/vim.ts
+++ b/denops/@denops-private/service/host/vim.ts
@@ -1,4 +1,5 @@
 import { VimMessage, VimSession } from "../deps.ts";
+import { responseTimeout } from "../defs.ts";
 import { Invoker, isInvokerMethod } from "./invoker.ts";
 import { Host } from "./base.ts";
 import { Meta } from "../../../@denops/denops.ts";
@@ -11,7 +12,9 @@ export class Vim implements Host {
     reader: Deno.Reader & Deno.Closer,
     writer: Deno.Writer,
   ) {
-    this.#session = new VimSession(reader, writer);
+    this.#session = new VimSession(reader, writer, undefined, {
+      responseTimeout,
+    });
   }
 
   private async callForDebugBefore823080(

--- a/denops/@denops-private/service/service.ts
+++ b/denops/@denops-private/service/service.ts
@@ -7,6 +7,7 @@ import {
   WorkerReader,
   WorkerWriter,
 } from "./deps.ts";
+import { responseTimeout } from "./defs.ts";
 import { Host } from "./host/base.ts";
 import { Invoker, RegisterOptions } from "./host/invoker.ts";
 import { Meta } from "../../@denops/denops.ts";
@@ -73,6 +74,8 @@ export class Service {
         ensureArray(args);
         return await this.dispatch(name, fn, args);
       },
+    }, {
+      responseTimeout,
     });
     this.#plugins[name] = {
       plugin,

--- a/denops/@denops-private/service/worker/script.ts
+++ b/denops/@denops-private/service/worker/script.ts
@@ -9,6 +9,7 @@ import {
   WorkerReader,
   WorkerWriter,
 } from "../deps.ts";
+import { responseTimeout } from "../defs.ts";
 import { Denops, Meta } from "../../../@denops/denops.ts";
 import { DenopsImpl } from "../../../@denops/denops.ts";
 
@@ -21,6 +22,7 @@ async function main(name: string, script: string, meta: Meta): Promise<void> {
   const mod = await import(path.toFileUrl(script).href);
   await using(
     new Session(reader, writer, {}, {
+      responseTimeout,
       errorCallback(e) {
         if (e.name === "Interrupted") {
           return;


### PR DESCRIPTION
10 sec is too short for interactive APIs and actually response timeout is not necessary for most of case.
That's why we extend it to 7 days while we think no body leave live Vim session for more than 7 days.