### PR TITLE
👍  Drop arguments after `undefined` for convenience

### DIFF
--- a/autoload/denops/api.vim
+++ b/autoload/denops/api.vim
@@ -1,3 +1,7 @@
+function! denops#api#id(...) abort
+  return a:000
+endfunction
+
 function! denops#api#cmd(cmd, context) abort
   call extend(l:, a:context)
   call execute(a:cmd, '')

--- a/denops/@denops/denops_test.ts
+++ b/denops/@denops/denops_test.ts
@@ -29,6 +29,34 @@ test({
 
 test({
   mode: "all",
+  name:
+    "denops.call() drop arguments after `undefined` (but `null`) for convenience",
+  fn: async (denops) => {
+    assertEquals(
+      await denops.call("denops#api#id", 0, 1, 2),
+      [0, 1, 2],
+    );
+    assertEquals(
+      await denops.call("denops#api#id", 0, 1, undefined, 2),
+      [0, 1],
+    );
+    assertEquals(
+      await denops.call("denops#api#id", 0, undefined, 1, 2),
+      [0],
+    );
+    assertEquals(
+      await denops.call("denops#api#id", 0, 1, null, 2),
+      [0, 1, null, 2],
+    );
+    assertEquals(
+      await denops.call("denops#api#id", 0, null, 1, 2),
+      [0, null, 1, 2],
+    );
+  },
+});
+
+test({
+  mode: "all",
   name: "denops.cmd() invoke a Vim/Neovim command",
   fn: async (denops) => {
     await denops.cmd("execute 'let g:denops_test = value'", {
@@ -110,5 +138,26 @@ test({
       );
     }, BatchError) as BatchError;
     assertEquals(err.results, [[0]]);
+  },
+});
+
+test({
+  mode: "all",
+  name:
+    "denops.batch() drop arguments after `undefined` (but `null`) for convenience",
+  fn: async (denops) => {
+    const results = await denops.batch(
+      ["denops#api#id", 0, 1, 2],
+      ["denops#api#id", 0, 1, undefined, 2],
+      ["denops#api#id", 0, undefined, 1, 2],
+      ["denops#api#id", 0, 1, null, 2],
+      ["denops#api#id", 0, null, 1, 2],
+    );
+    assertEquals(results, [[0, 1, 2], [0, 1], [0], [0, 1, null, 2], [
+      0,
+      null,
+      1,
+      2,
+    ]]);
   },
 });


### PR DESCRIPTION
Now arguments after `undefined` in `call` or `batch` are dropped for convenience like:

```typescript
test({
  mode: "all",
  name:
    "denops.call() drop arguments after `undefined` (but `null`) for convenience",
  fn: async (denops) => {
    assertEquals(
      await denops.call("denops#api#id", 0, 1, 2),
      [0, 1, 2],
    );
    assertEquals(
      await denops.call("denops#api#id", 0, 1, undefined, 2),
      [0, 1],
    );
    assertEquals(
      await denops.call("denops#api#id", 0, undefined, 1, 2),
      [0],
    );
    assertEquals(
      await denops.call("denops#api#id", 0, 1, null, 2),
      [0, 1, null, 2],
    );
    assertEquals(
      await denops.call("denops#api#id", 0, null, 1, 2),
      [0, null, 1, 2],
    );
  },
});
```

```typescript
test({
  mode: "all",
  name:
    "denops.batch() drop arguments after `undefined` (but `null`) for convenience",
  fn: async (denops) => {
    const results = await denops.batch(
      ["denops#api#id", 0, 1, 2],
      ["denops#api#id", 0, 1, undefined, 2],
      ["denops#api#id", 0, undefined, 1, 2],
      ["denops#api#id", 0, 1, null, 2],
      ["denops#api#id", 0, null, 1, 2],
    );
    assertEquals(results, [[0, 1, 2], [0, 1], [0], [0, 1, null, 2], [
      0,
      null,
      1,
      2,
    ]]);
  },
});
```