### PR TITLE
🐛Stop swapfile creation on test

### DIFF
--- a/denops/@denops/test/runner.ts
+++ b/denops/@denops/test/runner.ts
@@ -40,6 +40,7 @@ function buildVimArgs(): string[] {
     "NONE",
     "-i",
     "NONE",
+    "-n",
     "-N",
     "-X",
     "-e",
@@ -56,5 +57,6 @@ function buildNvimArgs(): string[] {
     "--clean",
     "--embed",
     "--headless",
+    "-n",
   ];
 }


### PR DESCRIPTION
Stop .swp, etc. from being created in the current directory when buffer changed in testing.