### PR TITLE
Use `deno_std` instead of `Deno.copy` for fix lint

### DIFF
--- a/denops/@denops-private/channel/cli.ts
+++ b/denops/@denops-private/channel/cli.ts
@@ -1,3 +1,5 @@
+import { copy } from "./deps.ts";
+
 const listener = Deno.listen({
   hostname: "127.0.0.1",
   port: 0, // Automatically select free port
@@ -9,7 +11,7 @@ console.warn(JSON.stringify(listener.addr));
 for await (const conn of listener) {
   // Allow only single client
   await Promise.all([
-    Deno.copy(conn, Deno.stdout).finally(() => conn.close()),
-    Deno.copy(Deno.stdin, conn),
+    copy(conn, Deno.stdout).finally(() => conn.close()),
+    copy(Deno.stdin, conn),
   ]);
 }

--- a/denops/@denops-private/channel/deps.ts
+++ b/denops/@denops-private/channel/deps.ts
@@ -1,0 +1,1 @@
+export { copy } from "https://deno.land/std@0.101.0/io/util.ts";

--- a/denops/@denops-private/service/deps.ts
+++ b/denops/@denops-private/service/deps.ts
@@ -1,5 +1,5 @@
-export * as flags from "https://deno.land/std@0.100.0/flags/mod.ts#^";
-export * as path from "https://deno.land/std@0.100.0/path/mod.ts#^";
+export * as flags from "https://deno.land/std@0.101.0/flags/mod.ts#^";
+export * as path from "https://deno.land/std@0.101.0/path/mod.ts#^";
 
 export * from "https://deno.land/x/unknownutil@v0.1.1/mod.ts#^";
 

--- a/denops/@denops/deps.ts
+++ b/denops/@denops/deps.ts
@@ -1,4 +1,5 @@
 export * as path from "https://deno.land/std@0.101.0/path/mod.ts#^";
+export { copy } from "https://deno.land/std@0.101.0/io/util.ts";
 
 export type { Dispatcher } from "https://deno.land/x/msgpack_rpc@v3.1.0/mod.ts#^";
 export { Session } from "https://deno.land/x/msgpack_rpc@v3.1.0/mod.ts#^";

--- a/denops/@denops/deps.ts
+++ b/denops/@denops/deps.ts
@@ -1,4 +1,4 @@
-export * as path from "https://deno.land/std@0.100.0/path/mod.ts#^";
+export * as path from "https://deno.land/std@0.101.0/path/mod.ts#^";
 
 export type { Dispatcher } from "https://deno.land/x/msgpack_rpc@v3.1.0/mod.ts#^";
 export { Session } from "https://deno.land/x/msgpack_rpc@v3.1.0/mod.ts#^";

--- a/denops/@denops/deps_test.ts
+++ b/denops/@denops/deps_test.ts
@@ -1,2 +1,2 @@
-export * from "https://deno.land/std@0.100.0/testing/asserts.ts#^";
-export { deferred } from "https://deno.land/std@0.100.0/async/mod.ts#^";
+export * from "https://deno.land/std@0.101.0/testing/asserts.ts#^";
+export { deferred } from "https://deno.land/std@0.101.0/async/mod.ts#^";

--- a/denops/@denops/test/bypass/cli.ts
+++ b/denops/@denops/test/bypass/cli.ts
@@ -1,4 +1,4 @@
-import { WorkerReader, WorkerWriter } from "../../deps.ts";
+import { copy, WorkerReader, WorkerWriter } from "../../deps.ts";
 
 // deno-lint-ignore no-explicit-any
 const worker = self as any;
@@ -9,6 +9,6 @@ const addr = JSON.parse(Deno.env.get("DENOPS_TEST_ADDRESS") || "");
 const conn = await Deno.connect(addr);
 
 await Promise.race([
-  Deno.copy(conn, writer).finally(() => conn.close()),
-  Deno.copy(reader, conn),
+  copy(conn, writer).finally(() => conn.close()),
+  copy(reader, conn),
 ]);


### PR DESCRIPTION
Use `deno_std` instead of `Deno.copy`.
Because `Deno.copy` has been deprecated on `Deno 1.12.0`.
https://deno.com/blog/v1.12#deprecation-of-deno.copy