### PR TITLE
Improve `denops#callback` module

### DIFF
--- a/autoload/denops/callback.vim
+++ b/autoload/denops/callback.vim
@@ -17,8 +17,10 @@ function! denops#callback#call(id, ...) abort
   if !has_key(s:registry, a:id)
     throw printf('No callback function for %s exist', a:id)
   endif
-  call call(s:registry[a:id], a:000)
-  silent unlet s:registry[a:id]
+  let entry = s:registry[a:id]
+  let ret = call(entry.callback, a:000)
+  call denops#callback#remove(a:id)
+  return ret
 endfunction
 
 function! denops#callback#clear() abort

--- a/autoload/denops/callback.vim
+++ b/autoload/denops/callback.vim
@@ -6,6 +6,13 @@ function! denops#callback#add(callback) abort
   return id
 endfunction
 
+function! denops#callback#remove(id) abort
+  if !has_key(s:registry, a:id)
+    return
+  endif
+  silent unlet s:registry[a:id]
+endfunction
+
 function! denops#callback#call(id, ...) abort
   if !has_key(s:registry, a:id)
     throw printf('No callback function for %s exist', a:id)

--- a/autoload/denops/callback.vim
+++ b/autoload/denops/callback.vim
@@ -1,8 +1,15 @@
 let s:registry = {}
 
-function! denops#callback#add(callback) abort
+function! denops#callback#add(callback, ...) abort
+  let options = extend({
+        \ 'once': v:true,
+        \}, a:0 ? a:1 : {},
+        \)
   let id = sha256(string(get(a:callback, 'func')))
-  let s:registry[id] = a:callback
+  let s:registry[id] = {
+        \ 'callback': a:callback,
+        \ 'options': options,
+        \}
   return id
 endfunction
 
@@ -19,7 +26,9 @@ function! denops#callback#call(id, ...) abort
   endif
   let entry = s:registry[a:id]
   let ret = call(entry.callback, a:000)
-  call denops#callback#remove(a:id)
+  if entry.options.once
+    call denops#callback#remove(a:id)
+  endif
   return ret
 endfunction
 

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -149,11 +149,17 @@ denops#callback#add({callback})
 	Add {callback} to internal callback map as one-time anonymous
 	function and return an unique {id} to call the {callback} later.
 
+						*denops#callback#remove()*
+denops#callback#remove({id})
+	Remove a callback of {id} from internal callback map. It does nothing
+	when no {id} callback exists.
+
 						*denops#callback#call()*
 denops#callback#call({id}[, {args}...])
 	Find a callback of {id} from internal callback map and call it with
-	given {args}. Note that the callback called is automatically removed
-	from the internal callback map.
+	given {args}. It throw an error when no {id} callback exists.
+	Note that the callback called is automatically removed from the
+	internal callback map.
 
 						*denops#callback#clear()*
 denops#callback#clear()

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -145,12 +145,25 @@ denops#plugin#discover([{options}])
 	See |denops#plugin#register()| for {options}.
 
 						*denops#callback#add()*
-denops#callback#add({callback})
-	Add {callback} to internal callback map as one-time anonymous
-	function and return an unique {id} to call the {callback} later.
+denops#callback#add({callback}[, {options}])
+	Add {callback} to internal callback map as an anonymous function and
+	return an unique {id} to call the {callback} later.
+	The following attributes are available on {options}.
+
+	"once"		|v:true| to add the callback as a one-time anonymous
+			function which will be removed when the callback has
+			called. It is a default behavior due to backward
+			compatibility. Use |v:false| to make the callback
+			persistent.
 >
+	" One-time callback
 	let id = denops#call#add({ a, b -> a + b })
 	let ret = denops#callback#call(id, 1, 2)
+
+	" Persistent callback
+	let id = denops#call#add({ a, b -> a + b }, { 'once': v:false })
+	let ret1 = denops#callback#call(id, 1, 2)
+	let ret2 = denops#callback#call(id, 2, 3)
 <
 						*denops#callback#remove()*
 denops#callback#remove({id})
@@ -163,7 +176,7 @@ denops#callback#call({id}[, {args}...])
 	given {args} and return a result. It throw an error when no {id}
 	callback exists.
 	Note that the callback called is automatically removed from the
-	internal callback map.
+	internal callback map if "once" option had specified.
 
 						*denops#callback#clear()*
 denops#callback#clear()

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -148,7 +148,10 @@ denops#plugin#discover([{options}])
 denops#callback#add({callback})
 	Add {callback} to internal callback map as one-time anonymous
 	function and return an unique {id} to call the {callback} later.
-
+>
+	let id = denops#call#add({ a, b -> a + b })
+	let ret = denops#callback#call(id, 1, 2)
+<
 						*denops#callback#remove()*
 denops#callback#remove({id})
 	Remove a callback of {id} from internal callback map. It does nothing
@@ -157,7 +160,8 @@ denops#callback#remove({id})
 						*denops#callback#call()*
 denops#callback#call({id}[, {args}...])
 	Find a callback of {id} from internal callback map and call it with
-	given {args}. It throw an error when no {id} callback exists.
+	given {args} and return a result. It throw an error when no {id}
+	callback exists.
 	Note that the callback called is automatically removed from the
 	internal callback map.
 

--- a/test/denops/callback.vimspec
+++ b/test/denops/callback.vimspec
@@ -7,6 +7,14 @@ Describe denops#callback
     End
   End
 
+  Describe #remove()
+    It removes an {id} callback
+      let id = denops#callback#add({ -> 0 })
+      call denops#callback#remove(id)
+      Throws /No callback function/ denops#callback#call(id)
+    End
+  End
+
   Describe #call()
     It calls an {id} callback
       let rs = []

--- a/test/denops/callback.vimspec
+++ b/test/denops/callback.vimspec
@@ -28,6 +28,17 @@ Describe denops#callback
       Assert Equals(ret, 'Hello World')
       Throws /No callback function/ denops#callback#call(id, 'Second')
     End
+
+    It does NOT remove an {id} callback after call if 'once' option is v:false
+      let id = denops#callback#add(
+            \ { name -> printf('Hello %s', name) },
+            \ { 'once': v:false },
+            \)
+      let ret = denops#callback#call(id, 'World')
+      Assert Equals(ret, 'Hello World')
+      let ret = denops#callback#call(id, 'Second')
+      Assert Equals(ret, 'Hello Second')
+    End
   End
 
   Describe #clear()

--- a/test/denops/callback.vimspec
+++ b/test/denops/callback.vimspec
@@ -17,27 +17,24 @@ Describe denops#callback
 
   Describe #call()
     It calls an {id} callback
-      let rs = []
-      let id = denops#callback#add({ name -> add(rs, ['Hello', name]) })
-      call denops#callback#call(id, 'World')
-      Assert Equals(rs, [['Hello', 'World']])
+      let id = denops#callback#add({ name -> printf('Hello %s', name) })
+      let ret = denops#callback#call(id, 'World')
+      Assert Equals(ret, 'Hello World')
     End
 
     It removes an {id} callback after call
-      let rs = []
-      let id = denops#callback#add({ name -> add(rs, ['Hello', name]) })
-      call denops#callback#call(id, 'World')
-      Assert Equals(rs, [['Hello', 'World']])
+      let id = denops#callback#add({ name -> printf('Hello %s', name) })
+      let ret = denops#callback#call(id, 'World')
+      Assert Equals(ret, 'Hello World')
       Throws /No callback function/ denops#callback#call(id, 'Second')
     End
   End
 
   Describe #clear()
     It clears all callbacks
-      let rs = []
-      let id = denops#callback#add({ name -> add(rs, ['Hello', name]) })
+      let id = denops#callback#add({ name -> printf('Hello %s', name) })
       call denops#callback#clear()
-      Throws /No callback function/ denops#callback#call(id, 'Second')
+      Throws /No callback function/ denops#callback#call(id, 'World')
     End
   End
 End

--- a/test/denops/callback.vimspec
+++ b/test/denops/callback.vimspec
@@ -1,20 +1,21 @@
 Describe denops#callback
   Describe #add()
-    It add a specified callback and return a string ID
+    It adds a callback and return {id}
       let id = denops#callback#add({ -> 0 })
       Assert Equals(type(id), v:t_string)
+      call denops#callback#call(id)
     End
   End
 
   Describe #call()
-    It calls added callback specified by {id}
+    It calls an {id} callback
       let rs = []
       let id = denops#callback#add({ name -> add(rs, ['Hello', name]) })
       call denops#callback#call(id, 'World')
       Assert Equals(rs, [['Hello', 'World']])
     End
 
-    It can call callback only onetime
+    It removes an {id} callback after call
       let rs = []
       let id = denops#callback#add({ name -> add(rs, ['Hello', name]) })
       call denops#callback#call(id, 'World')
@@ -24,7 +25,7 @@ Describe denops#callback
   End
 
   Describe #clear()
-    It clear registered callbacks
+    It clears all callbacks
       let rs = []
       let id = denops#callback#add({ name -> add(rs, ['Hello', name]) })
       call denops#callback#clear()


### PR DESCRIPTION
Now users can use `denops#callback` module to add persistent callbacks which return results.