### PR TITLE
:+1: Debounce `redraw` after `call` and `batch` on Vim

### DIFF
--- a/autoload/denops/api/vim.vim
+++ b/autoload/denops/api/vim.vim
@@ -1,3 +1,11 @@
+let s:redraw_timer = -1
+let s:redraw_interval = 10
+
+function! s:debounce_redraw() abort
+  call timer_stop(s:redraw_timer)
+  let s:redraw_timer = timer_start(s:redraw_interval, { -> execute('redraw') })
+endfunction
+
 " NOTE:
 " This is a workaround function to detect errors in Vim while Vim 8.2.3081 or
 " above SILENCE any errors occured in `call` channel command.
@@ -7,6 +15,8 @@ function! denops#api#vim#call(fn, args) abort
     return [call(a:fn, a:args), '']
   catch
     return [v:null, v:exception]
+  finally
+    call s:debounce_redraw()
   endtry
 endfunction
 
@@ -25,6 +35,7 @@ function! denops#api#vim#call_before_823080_call() abort
   let v:errmsg = ''
   let g:denops#api#vim#call_before_823080 = v:null
   let g:denops#api#vim#call_before_823080 = call(s:call_before_823080.fn, s:call_before_823080.args)
+  call s:debounce_redraw()
 endfunction
 
 " NOTE:
@@ -40,6 +51,8 @@ function! denops#api#vim#batch(calls) abort
     return [results, '']
   catch
     return [results, v:exception]
+  finally
+    call s:debounce_redraw()
   endtry
 endfunction
 
@@ -61,4 +74,5 @@ function! denops#api#vim#batch_before_823080_call() abort
     endif
     call add(g:denops#api#vim#batch_before_823080, result)
   endfor
+  call s:debounce_redraw()
 endfunction

--- a/denops/@denops-private/service/host/vim.ts
+++ b/denops/@denops-private/service/host/vim.ts
@@ -64,14 +64,10 @@ export class Vim implements Host {
     // Vim after 8.2.2081 SILENCE errors so we can detect errors by try/catch tech. The cost
     // of the tech is quite small (determined by vim-denops/denops-benchmark) thus we alreays
     // enable this workaround.
-    try {
-      if (this.#meta.mode !== "release" && isBefore823080(this.#meta.version)) {
-        return await this.callForDebugBefore823080(fn, ...args);
-      }
-      return await this.callForDebug(fn, ...args);
-    } finally {
-      await this.#session.redraw();
+    if (this.#meta.mode !== "release" && isBefore823080(this.#meta.version)) {
+      return await this.callForDebugBefore823080(fn, ...args);
     }
+    return await this.callForDebug(fn, ...args);
   }
 
   private async batchForDebugBefore823080(
@@ -111,14 +107,10 @@ export class Vim implements Host {
     // However, such workaround would impact the performance thus we only
     // enable such workaround when 'g:denops#debug' or 'g:denops#_test' is
     // enabled.
-    try {
-      if (this.#meta.mode !== "release" && isBefore823080(this.#meta.version)) {
-        return this.batchForDebugBefore823080(...calls);
-      }
-      return this.batchForDebug(...calls);
-    } finally {
-      await this.#session.redraw();
+    if (this.#meta.mode !== "release" && isBefore823080(this.#meta.version)) {
+      return this.batchForDebugBefore823080(...calls);
     }
+    return this.batchForDebug(...calls);
   }
 
   register(invoker: Invoker): void {


### PR DESCRIPTION
SSIA