### PR TITLE
Fix behavior of `denops.call()` when called concurrently on Vim prior to v8.2.3080

### DIFF
--- a/denops/@denops-private/service/deps.ts
+++ b/denops/@denops-private/service/deps.ts
@@ -19,3 +19,5 @@ export type {
 
 export { using } from "https://deno.land/x/disposable@v0.2.0/mod.ts#^";
 export type { Disposable } from "https://deno.land/x/disposable@v0.2.0/mod.ts#^";
+
+export { Lock } from "https://deno.land/x/async@v1.1.2/mod.ts#^";

--- a/denops/@denops/denops_test.ts
+++ b/denops/@denops/denops_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertThrowsAsync } from "./deps_test.ts";
 import { test } from "./test/tester.ts";
 import { BatchError } from "./denops.ts";
+import { path } from "./deps.ts";
 
 test({
   mode: "all",
@@ -159,5 +160,31 @@ test({
       1,
       2,
     ]]);
+  },
+});
+
+test({
+  mode: "all",
+  name: "denops.call() works properly even when called concurrently",
+  fn: async (denops) => {
+    const cwd = await denops.call("getcwd") as string;
+    await denops.cmd("edit dummy1");
+    await denops.cmd("file dummy2");
+    const results = await Promise.all([
+      denops.call("expand", "%"),
+      denops.call("expand", "%:p"),
+      denops.call("expand", "%hello"),
+      denops.call("expand", "#"),
+      denops.call("expand", "#:p"),
+      denops.call("expand", "#hello"),
+    ]);
+    assertEquals(results, [
+      "dummy2",
+      path.join(cwd, "dummy2"),
+      "dummy2",
+      "dummy1",
+      path.join(cwd, "dummy1"),
+      "dummy1",
+    ]);
   },
 });


### PR DESCRIPTION
SSIA