### PR TITLE
👍  Add `g:denops#trace` option to show raw RPC messages

### DIFF
--- a/autoload/denops.vim
+++ b/autoload/denops.vim
@@ -15,6 +15,7 @@ endfunction
 " Configuration
 let g:denops#deno = get(g:, 'denops#deno', 'deno')
 let g:denops#debug = get(g:, 'denops#debug', 0)
+let g:denops#trace = get(g:, 'denops#trace', 0)
 
 " Internal configuration
 let g:denops#_test = get(g:, 'denops#_test', 0)

--- a/autoload/denops/server/service.vim
+++ b/autoload/denops/server/service.vim
@@ -11,6 +11,9 @@ function! denops#server#service#start(address) abort
         \ '--mode=' . s:engine,
         \ '--address=' . a:address,
         \]
+  if g:denops#trace
+    let args += ['--trace']
+  endif
   let raw_options = has('nvim')
         \ ? {}
         \ : { 'mode': 'nl' }

--- a/denops/@denops-private/service/cli.ts
+++ b/denops/@denops-private/service/cli.ts
@@ -2,6 +2,7 @@ import { flags, using } from "./deps.ts";
 import { Service } from "./service.ts";
 import { Vim } from "./host/vim.ts";
 import { Neovim } from "./host/nvim.ts";
+import { TraceReader, TraceWriter } from "./tracer.ts";
 
 const opts = flags.parse(Deno.args);
 
@@ -17,9 +18,12 @@ if (!opts.mode) {
 const address = JSON.parse(opts.address);
 const conn = await Deno.connect(address);
 
+const reader = opts.trace ? new TraceReader(conn) : conn;
+const writer = opts.trace ? new TraceWriter(conn) : conn;
+
 // Create host and service
 const hostClass = opts.mode === "vim" ? Vim : Neovim;
-await using(new hostClass(conn, conn), async (host) => {
+await using(new hostClass(reader, writer), async (host) => {
   const service = new Service(host);
   await service.waitClosed();
 });

--- a/denops/@denops-private/service/tracer.ts
+++ b/denops/@denops-private/service/tracer.ts
@@ -1,0 +1,45 @@
+const textDecoder = new TextDecoder();
+
+export class TraceReader implements Deno.Reader, Deno.Closer {
+  #reader: Deno.Reader & Deno.Closer;
+
+  constructor(reader: Deno.Reader & Deno.Closer) {
+    this.#reader = reader;
+  }
+
+  close(): void {
+    this.#reader.close();
+  }
+
+  async read(p: Uint8Array): Promise<number | null> {
+    const n = await this.#reader.read(p);
+    if (n) {
+      const value = p.subarray(0, n);
+      try {
+        console.log("r:", textDecoder.decode(value));
+      } catch {
+        console.log("r:", value);
+      }
+    }
+    return n;
+  }
+}
+
+export class TraceWriter implements Deno.Writer {
+  #writer: Deno.Writer;
+
+  constructor(writer: Deno.Writer) {
+    this.#writer = writer;
+  }
+
+  async write(p: Uint8Array): Promise<number> {
+    const n = await this.#writer.write(p);
+    const value = p.subarray(0, n);
+    try {
+      console.log("w:", textDecoder.decode(value));
+    } catch {
+      console.log("w:", value);
+    }
+    return n;
+  }
+}

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -47,6 +47,12 @@ VARIABLE						*denops-variable*
 
 	Default: 0
 
+*g:denops#trace*
+	Set 1 to enable trace mode. In trace mode, all raw RPC messages
+	between Vim/Neovim and denops are echoed.
+
+	Default: 0
+
 *g:denops#server#channel#deno*
 	Executable program of Deno for starting a "channel" server.
 	Default: |g:denops#deno|


### PR DESCRIPTION
To check raw RPC messages


### Vim (channel command JSON)

```
[denops] r: [0,["invoke","register",["ghosttext","/Users/alisue/.vim/pack/minpac/start/dps-ghosttext.vim/denops/ghosttext/main.ts",{"platform":"mac","host":"vim","mode":"release","version":"8.2.2681"},{"reload":false}]]]
[denops] [0,["invoke","register",["gin","/Users/alisue/.vim/pack/minpac/start/gin.vim/denops/gin/main.ts",{"platform":"mac","host":"vim","mode":"release","version":"8.2.2681"},{"reload":false}]]]
[denops] [0,["invoke","register",["helloworld","/Users/alisue/.vim/pack/minpac/start/denops-helloworld.vim/denops/helloworld/main.ts",{"platform":"mac","host":"vim","mode":"release","version":"8.2.2681"},{"reload":false}]]]
[denops] [0,["invoke","register",["benchmark","/Users/alisue/.vim/pack/minpac/start/denops-benchmark/denops/benchmark/main.ts",{"platform":"mac","host":"vim","mode":"release","version":"8.2.2681"},{"reload":false}]]]
[denops] w: ["call","denops#util#meta",[],0]
[denops] r: [0,{"platform":"mac","host":"vim","mode":"release","version":"8.2.2681"}]
[denops] w: ["call","denops#api#vim#call",["execute",["doautocmd <nomodeline> User DenopsPluginPre:benchmark",""]],-1]
[denops] w: ["call","denops#api#vim#call",["execute",["doautocmd <nomodeline> User DenopsPluginPre:helloworld",""]],-2]
[denops] r: [-1,["",""]]
[denops] r: [-2,["",""]]
[denops] w: ["call","denops#api#vim#call",["denops#api#cmd",["call execute(l:__denops_internal_command, '')",{"__denops_internal_command":["function! DenopsBenchmark(s, n) abort","call denops#notify('benchmark', 'benchmark', [a:s, a:n])","endfunction","function! DenopsBenchmarkBatch(s, n) abort","call denops#notify('benchmark', 'benchmarkBatch', [a:s, a:n])","endfunction"]}]],-3]
[denops] w: ["call","denops#api#vim#call",["denops#api#cmd",["call execute(l:__denops_internal_command, '')",{"__denops_internal_command":["command! HelloWorld call denops#notify(\"helloworld\", \"say\", [\"World\"])","command! HelloDenops call denops#notify(\"helloworld\", \"say\", [\"Denops\"])"]}]],-4]
[denops] r: [-3,[0,""]]
[denops] r: [-4,[0,""]]
[denops] w: ["call","denops#api#vim#call",["execute",["doautocmd <nomodeline> User DenopsPluginPost:benchmark",""]],-5]
[denops] w: ["call","denops#api#vim#call",["execute",["doautocmd <nomodeline> User DenopsPluginPost:helloworld",""]],-6]
[denops] r: [-5,["",""]]
[denops] r: [-6,["",""]]
[denops] w: ["call","denops#api#vim#call",["execute",["doautocmd <nomodeline> User DenopsPluginPre:ghosttext",""]],-7]
[denops] w: ["call","denops#api#vim#call",["execute",["doautocmd <nomodeline> User DenopsPluginPre:gin",""]],-8]
[denops] r: [-7,["",""]]
[denops] r: [-8,["",""]]
[denops] w: ["call","denops#api#vim#call",["execute",["doautocmd <nomodeline> User DenopsPluginPost:ghosttext",""]],-9]
[denops] w: ["call","denops#api#vim#call",["denops#api#cmd",["call execute(l:__denops_internal_command, '')",{"__denops_internal_command":["command! -nargs=* Gin call denops#notify('gin', 'native:command', [<f-args>])"]}]],-10]
[denops] r: [-9,["",""]]
[denops] r: [-10,[0,""]]
[denops] w: ["call","denops#api#vim#call",["denops#api#cmd",["call execute(l:__denops_internal_command, '')",{"__denops_internal_command":["aug ginstatus_internal","au! *","au BufReadCmd ginstatus://* call denops#notify('gin', \"status:read\", [expand('<abuf>') + 0])","aug END"]}]],-11]
[denops] r: [-11,[0,""]]
[denops] w: ["call","denops#api#vim#call",["denops#api#cmd",["call execute(l:__denops_internal_command, '')",{"__denops_internal_command":["command! -nargs=* GinStatus call denops#notify('gin', 'status:command', [<f-args>])"]}]],-12]
[denops] r: [-12,[0,""]]
[denops] w: ["call","denops#api#vim#call",["execute",["doautocmd <nomodeline> User DenopsPluginPost:gin",""]],-13]
[denops] r: [-13,["",""]]
```

### Neovim (msgpack-rpc)

```
[denops] r: �^B�invoke��register��ghosttext�W/Users/alisue/.config/nvim/pack/minpac/start/dps-ghosttext.vim/denops/ghosttext/main.ts��platform�mac�host�nvim�mode�release�version�0.5.0��reload<93>^B�invoke��register��gin�G/Users/alisue/.config/nvim/pack/minpac/start/gin.vim/denops/gin/main.ts��platform�mac�host�nvim�mode�release�version�0.5.0��reload<93>^B�invoke��register��helloworld�\/Users/alisue/.config/nvim/pack/minpac/start/denops-helloworld.vim/denops/helloworld/main.ts��platform�mac�host�nvim�mode�release�version�0.5.0��reload<93>^B�invoke��register��benchmark�V/Users/alisue/.config/nvim/pack/minpac/start/denops-benchmark/denops/benchmark/main.ts��platform�mac�host�nvim�mode�release�version�0.5.0��reload�
[denops] w: �
[denops] 
[denops] �nvim_call_function��execute��6doautocmd <nomodeline> User DenopsPluginPre:helloworld�
[denops] r: �^A
[denops] ��
[denops] w: �
[denops] ^A�nvim_call_function��denops#api#cmd��-call execute(l:__denops_internal_command, '')��__denops_internal_command��Fcommand! HelloWorld call denops#notify("helloworld", "say", ["World"])�Hcommand! HelloDenops call denops#notify("helloworld", "say", ["Denops"])
[denops] r: �^A^A�
[denops] 
[denops] w: �
[denops] ^B�nvim_call_function��execute��7doautocmd <nomodeline> User DenopsPluginPost:helloworld�
[denops] r: �^A^B��
[denops] w: �
[denops] ^C�nvim_call_function��execute��5doautocmd <nomodeline> User DenopsPluginPre:benchmark�
[denops] r: �^A^C��
[denops] w: �
[denops] ^D�nvim_call_function��denops#api#cmd��-call execute(l:__denops_internal_command, '')��__denops_internal_command��%function! DenopsBenchmark(s, n) abort�8call denops#notify('benchmark', 'benchmark', [a:s, a:n])�endfunction�*function! DenopsBenchmarkBatch(s, n) abort�=call denops#notify('benchmark', 'benchmarkBatch', [a:s, a:n])�endfunction
[denops] r: �^A^D�
[denops] 
[denops] w: �
[denops] ^E�nvim_call_function��execute��6doautocmd <nomodeline> User DenopsPluginPost:benchmark�
[denops] r: �^A^E��
[denops] w: �
[denops] ^F�nvim_call_function��execute��5doautocmd <nomodeline> User DenopsPluginPre:ghosttext�
[denops] r: �^A^F��
[denops] w: �
[denops] ^G�nvim_call_function��execute��6doautocmd <nomodeline> User DenopsPluginPost:ghosttext�
[denops] r: �^A^G��
[denops] w: �
[denops] ^H�nvim_call_function��execute��/doautocmd <nomodeline> User DenopsPluginPre:gin�
[denops] r: �^A^H��
[denops] w: �
[denops] ^I�nvim_call_function��denops#api#cmd��-call execute(l:__denops_internal_command, '')��__denops_internal_command��Mcommand! -nargs=* Gin call denops#notify('gin', 'native:command', [<f-args>])
[denops] r: �^A^I�
[denops] 
[denops] w: �
[denops] 
[denops] �nvim_call_function��denops#api#cmd��-call execute(l:__denops_internal_command, '')��__denops_internal_command��aug ginstatus_internal�au! *�\au BufReadCmd ginstatus://* call denops#notify('gin', "status:read", [expand('<abuf>') + 0])�aug END
[denops] r: �^A
[denops] �
[denops] 
[denops] w: �
[denops] ^K�nvim_call_function��denops#api#cmd��-call execute(l:__denops_internal_command, '')��__denops_internal_command��Scommand! -nargs=* GinStatus call denops#notify('gin', 'status:command', [<f-args>])
[denops] r: �^A^K�
[denops] 
[denops] w: �
[denops] ^L�nvim_call_function��execute��0doautocmd <nomodeline> User DenopsPluginPost:gin�
[denops] r: �^A^L��
```