### PR TITLE
💥  Disable workaround implementation for Vim before 8.2.3081 in default

### DIFF
--- a/autoload/denops.vim
+++ b/autoload/denops.vim
@@ -12,10 +12,15 @@ function! denops#request_async(plugin, method, params, success, failure) abort
   return denops#server#channel#request('invoke', ['dispatchAsync', [a:plugin, a:method, a:params, success, failure]])
 endfunction
 
+function! s:define(name, default) abort
+  let g:{a:name} = get(g:, a:name, a:default)
+endfunction
+
 " Configuration
-let g:denops#deno = get(g:, 'denops#deno', 'deno')
-let g:denops#debug = get(g:, 'denops#debug', 0)
-let g:denops#trace = get(g:, 'denops#trace', 0)
+call s:define('denops#deno', 'deno')
+call s:define('denops#debug', 0)
+call s:define('denops#trace', 0)
+call s:define('denops#enable_workaround_vim_before_8_2_3081', 0)
 
 " Internal configuration
-let g:denops#_test = get(g:, 'denops#_test', 0)
+call s:define('denops#_test', 0)

--- a/autoload/denops/api/vim.vim
+++ b/autoload/denops/api/vim.vim
@@ -21,20 +21,20 @@ function! denops#api#vim#call(fn, args) abort
 endfunction
 
 " NOTE:
-" This is a workaround function to detect errors in Vim while Vim 8.2.3080 or
-" below IGNORE any errors occured in `call` channel command thus we need to
-" use `ex` command with `v:errmsg` instead.
+" This is a workaround function to detect errors in Vim before 8.2.3081 IGNORE
+" any errors occured in `call` channel command thus we need to use `ex` command
+" with `v:errmsg` instead.
 " https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
-function! denops#api#vim#call_before_823080_pre(fn, args) abort
-  let s:call_before_823080 = {
+function! denops#api#vim#call_before_823081_pre(fn, args) abort
+  let s:call_before_823081 = {
         \ 'fn': a:fn,
         \ 'args': a:args,
         \}
 endfunction
-function! denops#api#vim#call_before_823080_call() abort
+function! denops#api#vim#call_before_823081_call() abort
   let v:errmsg = ''
-  let g:denops#api#vim#call_before_823080 = v:null
-  let g:denops#api#vim#call_before_823080 = call(s:call_before_823080.fn, s:call_before_823080.args)
+  let g:denops#api#vim#call_before_823081 = v:null
+  let g:denops#api#vim#call_before_823081 = call(s:call_before_823081.fn, s:call_before_823081.args)
   call s:debounce_redraw()
 endfunction
 
@@ -57,22 +57,22 @@ function! denops#api#vim#batch(calls) abort
 endfunction
 
 " NOTE:
-" This is a workaround function to detect errors in Vim while Vim 8.2.3080 or
-" below IGNORE any errors occured in `call` channel command thus we need to
-" use `ex` command with `v:errmsg` instead.
+" This is a workaround function to detect errors in Vim before 8.2.3081 IGNORE
+" any errors occured in `call` channel command thus we need to use `ex` command
+" with `v:errmsg` instead.
 " https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
-function! denops#api#vim#batch_before_823080_pre(calls) abort
-  let s:batch_before_823080 = a:calls
+function! denops#api#vim#batch_before_823081_pre(calls) abort
+  let s:batch_before_823081 = a:calls
 endfunction
-function! denops#api#vim#batch_before_823080_call() abort
+function! denops#api#vim#batch_before_823081_call() abort
   let v:errmsg = ''
-  let g:denops#api#vim#batch_before_823080 = []
-  for l:Call in s:batch_before_823080
+  let g:denops#api#vim#batch_before_823081 = []
+  for l:Call in s:batch_before_823081
     let result = call(Call[0], Call[1:])
     if v:errmsg !=# ''
       break
     endif
-    call add(g:denops#api#vim#batch_before_823080, result)
+    call add(g:denops#api#vim#batch_before_823081, result)
   endfor
   call s:debounce_redraw()
 endfunction

--- a/denops/@denops/denops_test.ts
+++ b/denops/@denops/denops_test.ts
@@ -26,6 +26,7 @@ test({
       "E117: Unknown function: no-such-function",
     );
   },
+  prelude: ["let g:denops#enable_workaround_vim_before_8_2_3081 = 1"],
 });
 
 test({
@@ -82,6 +83,7 @@ test({
       "E492: Not an editor command: NoSuchCommand",
     );
   },
+  prelude: ["let g:denops#enable_workaround_vim_before_8_2_3081 = 1"],
 });
 
 test({
@@ -112,6 +114,7 @@ test({
       // Neovim: "E121: Undefined variable: g:no_such_variable",
     );
   },
+  prelude: ["let g:denops#enable_workaround_vim_before_8_2_3081 = 1"],
 });
 
 test({
@@ -140,6 +143,7 @@ test({
     }, BatchError) as BatchError;
     assertEquals(err.results, [[0]]);
   },
+  prelude: ["let g:denops#enable_workaround_vim_before_8_2_3081 = 1"],
 });
 
 test({

--- a/denops/@denops/test/tester.ts
+++ b/denops/@denops/test/tester.ts
@@ -10,6 +10,7 @@ const DENOPS_PATH = Deno.env.get("DENOPS_PATH");
 type WithDenopsOptions = {
   timeout?: number;
   verbose?: boolean;
+  prelude?: string[];
 };
 
 async function withDenops(
@@ -36,6 +37,7 @@ async function withDenops(
   const pluginName = "@denops-core-test";
   const proc = run(mode, {
     commands: [
+      ...(options.prelude ?? []),
       `let g:denops#_test = 1`,
       `set runtimepath^=${DENOPS_PATH}`,
       `autocmd User DenopsReady call denops#plugin#register('${pluginName}', '${scriptPath}')`,
@@ -79,6 +81,7 @@ export type TestDefinition = Omit<Deno.TestDefinition, "fn"> & {
   fn: (denops: Denops) => Promise<void> | void;
   timeout?: number;
   verbose?: boolean;
+  prelude?: string[];
 };
 
 /**
@@ -158,6 +161,7 @@ function testInternal(t: TestDefinition): void {
         await withDenops(mode, t.fn, {
           timeout: t.timeout,
           verbose: t.verbose,
+          prelude: t.prelude,
         });
       },
     });

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -43,18 +43,26 @@ VARIABLE						*denops-variable*
 	- Type checks of Deno modules become enabled
 
 	Note that the debug mode would affect the performance so disable it
-	unless you are debugging deno plugins.
-
-	WARNING In debug mode, any interactive functions (such as |input()|)
-	does not work properly in Vim prior to 8.2.3081 due to internal
-	workaround implementations. See an issue #93 for details.
-	https://github.com/vim-denops/denops.vim/issues/93
+	unless you are debugging denops plugins.
 
 	Default: 0
 
 *g:denops#trace*
 	Set 1 to enable trace mode. In trace mode, all raw RPC messages
 	between Vim/Neovim and denops are echoed.
+
+	Default: 0
+
+*g:denops#enable_workaround_vim_before_8_2_3081*
+	Set 1 to enable workaround implementation for operations in Vim before
+	8.2.3081. Without this workaround, any errors occurred in operations
+	are ignored thus denops and denops plugins cannot detect errors.
+	However, with this workaround, interactive features (such as |input()|)
+	would always returns |v:null| so break plugins which relies on it.
+	Note that if you are using Vim 8.2.3081 or later, this option does
+	nothing.
+	https://github.com/vim/vim/pull/8477
+	https://github.com/vim-denops/denops.vim/issues/93
 
 	Default: 0
 


### PR DESCRIPTION
The workaround implementation breaks interactive features (such as `input()`) thus the implementation is disabled in default.

This is breaking changes for developers who run tests on Vim 8.2.3081 and want to detect errors. Use `prelude` option to enable the workaround implementation in `test()` like:

```typescript
test({
  mode: "vim",
  prelude: ["let g: denops#enable_workaround_vim_before_8_2_3081 = 1"],
  name: "...",
  fn: (denops) => { ... },
});
```

**Note** that this change does not affect behavior for end users. It only affects behavior when `g:denops#debug = 1` or during tests.