### PR TITLE
:boom: Drop support vim before 8.2.0662

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -66,7 +66,7 @@ jobs:
           - "1.11.0"
           - "1.x"
         host_version:
-          - vim: "v8.1.2424"
+          - vim: "v8.2.0662"
             nvim: "v0.4.4"
           - vim: "v8.2.3081"
             nvim: "v0.5.0"

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -70,6 +70,28 @@ jobs:
             nvim: "v0.4.4"
           - vim: "v8.2.3081"
             nvim: "v0.5.0"
+        include:
+          - runner: windows-latest
+            version: 1.11.0
+            host_version:
+              vim: v8.2.0671 # Instead of v8.2.0662
+              nvim: v0.4.4
+          - runner: windows-latest
+            version: 1.x
+            host_version:
+              vim: v8.2.0671 # Instead of v8.2.0662
+              nvim: v0.4.4
+        exclude:
+          - runner: windows-latest
+            version: 1.11.0
+            host_version:
+              vim: v8.2.0662 # Not found on vim-win32-installer
+              nvim: v0.4.4
+          - runner: windows-latest
+            version: 1.x
+            host_version:
+              vim: v8.2.0662 # Not found on vim-win32-installer
+              nvim: v0.4.4
     runs-on: ${{ matrix.runner }}
     steps:
       - run: git config --global core.autocrlf false

--- a/.github/workflows/vim.yml
+++ b/.github/workflows/vim.yml
@@ -28,7 +28,7 @@ jobs:
           - windows-latest
           - ubuntu-latest
         version:
-          - v8.1.2424
+          - v8.2.0662
           - v8.2.3081
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/vim.yml
+++ b/.github/workflows/vim.yml
@@ -30,6 +30,12 @@ jobs:
         version:
           - v8.2.0662
           - v8.2.3081
+        include:
+          - os: windows-latest
+            version: v8.2.0671 # Instead of v8.2.0662
+        exclude:
+          - os: windows-latest
+            version: v8.2.0662 # Not found on vim-win32-installer
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <sup>An ecosystem of Vim/Neovim which allows developers to write plugins in Deno.</sup>
 
 [![Deno 1.11.0 or above](https://img.shields.io/badge/Deno-Support%201.11.0-yellowgreen.svg?logo=deno)](https://github.com/denoland/deno/tree/v1.11.0)
-[![Vim 8.1.2424 or above](https://img.shields.io/badge/Vim-Support%208.1.2424-yellowgreen.svg?logo=vim)](https://github.com/vim/vim/tree/v8.1.2424)
+[![Vim 8.2.0662 or above](https://img.shields.io/badge/Vim-Support%208.2.0662-yellowgreen.svg?logo=vim)](https://github.com/vim/vim/tree/v8.2.0662)
 [![Neovim 0.4.4 or above](https://img.shields.io/badge/Neovim-Support%200.4.4-yellowgreen.svg?logo=neovim&logoColor=white)](https://github.com/neovim/neovim/tree/v0.4.4)
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)

--- a/autoload/health/denops.vim
+++ b/autoload/health/denops.vim
@@ -1,5 +1,5 @@
 let s:deno_version = '1.11.0'
-let s:vim_version = '8.1.2424'
+let s:vim_version = '8.2.0662'
 let s:neovim_version = '0.4.4'
 
 function! s:compare_version(v1, v2) abort

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -30,6 +30,12 @@ INTERFACE						*denops-interface*
 -----------------------------------------------------------------------------
 VARIABLE						*denops-variable*
 
+*g:denops_disable_version_check*
+	Disable version check on startup. Use it to forcibly enable denops on
+	non supported versions of Vim/Neovim. Do not report any errors/issues
+	occurred on non supported versions.
+	Default: 0
+
 *g:denops#deno*
 	Executable program of Deno. Use it to specify executable program of
 	Deno if 'deno' is not in PATH.

--- a/plugin/denops.vim
+++ b/plugin/denops.vim
@@ -3,6 +3,13 @@ if exists('g:loaded_denops')
 endif
 let g:loaded_denops = 1
 
+if !get(g:, 'denops_disable_version_check') && !has('nvim-0.4.4') && !has('patch-8.2.0662')
+  echohl WarningMsg
+  echo '[denops] Denops requires Vim 8.2.0662 or Neovim 0.4.4. See ":h g:denops_disable_version_check" to disable this check.'
+  echohl None
+  finish
+endif
+
 if !executable(g:denops#deno)
   echohl WarningMsg
   echo printf("[denops] A '%s' (g:denops#deno) is not executable. Denops requires executable Deno.", g:denops#deno)


### PR DESCRIPTION
It seems Vim before 8.2.0662 does not support `input()` function in the channel command, thus we cannot support.

https://github.com/vim/vim/commit/dfc33a665d3b12689aa971575b8e7de4e5202d83

**Note** that denops check Vim/Neovim version on startup from this PR. Disable the feature by the following code if you'd love to use denops on non supported versions.

```vim
let g:denops_disable_version_check = 1
```