### PR TITLE
:+1: Add `mode` option and skip duplicated plugins in discovery

### DIFF
--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -34,10 +34,18 @@ function! s:gather_plugins(plugins) abort
 endfunction
 
 function! s:options(base) abort
-  let default = {
-        \ 'reload': v:false,
-        \}
-  return extend(default, a:base)
+  let options = extend({
+        \ 'mode': 'error',
+        \}, a:base,
+        \)
+  if has_key(options, 'reload')
+    call denops#util#warn('The "reload" option is deprecated. Use "mode" option instead.')
+    let options.mode = 'reload'
+  endif
+  if options.mode !~# '^\(reload\|error\)$'
+    throw printf('Unknown mode "%s" is specified', options.mode)
+  endif
+  return options
 endfunction
 
 function! s:register(name, script, meta, options) abort

--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -1,18 +1,23 @@
 function! denops#plugin#register(name, ...) abort
   if a:0 is# 0 || type(a:1) is# v:t_dict
-    let options = s:options(a:0 > 0 ? a:1 : {})
+    let options = a:0 > 0 ? a:1 : {}
     let script = s:find_plugin(a:name)
   else
     let script = a:1
-    let options = s:options(a:0 > 1 ? a:2 : {})
+    let options = a:0 > 1 ? a:2 : {}
   endif
   let meta = denops#util#meta()
+  let options = s:options(options, {
+        \ 'mode': 'error',
+        \})
   return s:register(a:name, script, meta, options)
 endfunction
 
 function! denops#plugin#discover(...) abort
   let meta = denops#util#meta()
-  let options = s:options(a:0 > 0 ? a:1 : {})
+  let options = s:options(a:0 > 0 ? a:1 : {}, {
+        \ 'mode': 'skip',
+        \})
   let plugins = {}
   call s:gather_plugins(plugins)
   for [name, script] in items(plugins)
@@ -33,16 +38,13 @@ function! s:gather_plugins(plugins) abort
   endfor
 endfunction
 
-function! s:options(base) abort
-  let options = extend({
-        \ 'mode': 'error',
-        \}, a:base,
-        \)
+function! s:options(base, default) abort
+  let options = extend(a:default, a:base)
   if has_key(options, 'reload')
     call denops#util#warn('The "reload" option is deprecated. Use "mode" option instead.')
     let options.mode = 'reload'
   endif
-  if options.mode !~# '^\(reload\|error\)$'
+  if options.mode !~# '^\(reload\|skip\|error\)$'
     throw printf('Unknown mode "%s" is specified', options.mode)
   endif
   return options

--- a/autoload/denops/server/channel.vim
+++ b/autoload/denops/server/channel.vim
@@ -24,6 +24,7 @@ function! denops#server#channel#start(notify) abort
         \ 'raw_options': raw_options,
         \})
   call denops#util#debug(printf('channel server started: %s', args))
+  doautocmd <nomodeline> User DenopsChannelStarted
 endfunction
 
 function! denops#server#channel#stop() abort
@@ -59,6 +60,7 @@ endfunction
 
 function! s:on_exit(status, ...) abort dict
   call denops#util#debug(printf('channel server stopped: %s', a:status))
+  doautocmd <nomodeline> User DenopsChannelStopped
   if s:stopped_by_user || v:dying || s:vim_exiting || a:status is# 143
     return
   endif
@@ -92,6 +94,8 @@ endif
 
 augroup denops_server_channel_internal
   autocmd!
+  autocmd User DenopsChannelStarted :
+  autocmd User DenopsChannelStopped :
   autocmd VimLeave * let s:vim_exiting = 1
 augroup END
 

--- a/autoload/denops/server/channel.vim
+++ b/autoload/denops/server/channel.vim
@@ -1,5 +1,6 @@
 let s:script = denops#util#script_path('@denops-private', 'channel', 'cli.ts')
 let s:vim_exiting = 0
+let s:stopped_by_user = 0
 let s:job = v:null
 
 function! denops#server#channel#start(notify) abort
@@ -13,6 +14,7 @@ function! denops#server#channel#start(notify) abort
   let raw_options = has('nvim')
         \ ? {'rpc': v:true}
         \ : {'mode': 'json', 'err_mode': 'nl'}
+  let s:stopped_by_user = 0
   let s:job = denops#util#jobstart(args, {
         \ 'env': {
         \   'NO_COLOR': 1,
@@ -21,11 +23,12 @@ function! denops#server#channel#start(notify) abort
         \ 'on_exit': funcref('s:on_exit'),
         \ 'raw_options': raw_options,
         \})
-  call denops#util#debug(printf('channel server start: %s', args))
+  call denops#util#debug(printf('channel server started: %s', args))
 endfunction
 
 function! denops#server#channel#stop() abort
   if s:job isnot# v:null
+    let s:stopped_by_user = 1
     call denops#util#jobstop(s:job)
   endif
 endfunction
@@ -51,11 +54,12 @@ function! s:on_stderr(ctx, data, ...) abort dict
   let address = substitute(a:data, '[\s\r\n]*$', '', '')
   let a:ctx.notified = 1
   call a:ctx.notify(address)
-  call denops#util#debug(printf('channel server resolve: %s', address))
+  call denops#util#debug(printf('channel server resolved: %s', address))
 endfunction
 
 function! s:on_exit(status, ...) abort dict
-  if v:dying || s:vim_exiting || a:status is# 143
+  call denops#util#debug(printf('channel server stopped: %s', a:status))
+  if s:stopped_by_user || v:dying || s:vim_exiting || a:status is# 143
     return
   endif
   call denops#util#error(printf(

--- a/autoload/denops/server/service.vim
+++ b/autoload/denops/server/service.vim
@@ -29,6 +29,7 @@ function! denops#server#service#start(address) abort
         \ 'raw_options': raw_options,
         \})
   call denops#util#debug(printf('service server started: %s', args))
+  doautocmd <nomodeline> User DenopsServiceStarted
 endfunction
 
 function! denops#server#service#stop() abort
@@ -54,6 +55,7 @@ endfunction
 
 function! s:on_exit(status, ...) abort dict
   call denops#util#debug(printf('service server stopped: %s', a:status))
+  doautocmd <nomodeline> User DenopsServiceStopped
   if s:stopped_by_user || v:dying || s:vim_exiting || a:status is# 143
     return
   endif
@@ -65,6 +67,8 @@ endfunction
 
 augroup denops_server_service_internal
   autocmd!
+  autocmd User DenopsServiceStarted :
+  autocmd User DenopsServiceStopped :
   autocmd VimLeave * let s:vim_exiting = 1
 augroup END
 

--- a/autoload/denops/util.vim
+++ b/autoload/denops/util.vim
@@ -139,6 +139,11 @@ else
   function! s:stop(job) abort
     call job_stop(a:job)
     call timer_start(s:KILL_TIMEOUT_MS, { -> job_stop(a:job, 'kill') })
+    " Wait until the job is actually closed
+    while job_status(a:job) ==# 'run'
+      sleep 10m
+    endwhile
+    redraw
   endfunction
 
   function! s:out_cb(callback, ch, msg) abort

--- a/autoload/denops/util.vim
+++ b/autoload/denops/util.vim
@@ -37,6 +37,15 @@ function! denops#util#info(...) abort
   endfor
 endfunction
 
+function! denops#util#warn(...) abort
+  let msg = join(a:000)
+  echohl WarningMsg
+  for line in split(msg, '\n')
+    echomsg printf('[denops] %s', line)
+  endfor
+  echohl None
+endfunction
+
 function! denops#util#error(...) abort
   let msg = join(a:000)
   echohl ErrorMsg

--- a/denops/@denops-private/service/host/invoker.ts
+++ b/denops/@denops-private/service/host/invoker.ts
@@ -2,7 +2,13 @@ import { Service } from "../service.ts";
 import { Meta } from "../../../@denops/denops.ts";
 
 export type RegisterOptions = {
-  reload?: boolean;
+  /**
+   * The behavior of register when the plugin is already registered.
+   *
+   * reload:  Reload the plugin
+   * error:   Throw an error
+   */
+  mode?: "reload" | "error";
 };
 
 export class Invoker {

--- a/denops/@denops-private/service/host/invoker.ts
+++ b/denops/@denops-private/service/host/invoker.ts
@@ -6,9 +6,10 @@ export type RegisterOptions = {
    * The behavior of register when the plugin is already registered.
    *
    * reload:  Reload the plugin
+   * skip:    Skip registration
    * error:   Throw an error
    */
-  mode?: "reload" | "error";
+  mode?: "reload" | "skip" | "error";
 };
 
 export class Invoker {

--- a/denops/@denops-private/service/service.ts
+++ b/denops/@denops-private/service/service.ts
@@ -42,6 +42,11 @@ export class Service {
         }
         const { worker } = this.#plugins[name];
         worker.terminate();
+      } else if (options.mode === "skip") {
+        if (meta.mode === "debug") {
+          console.log(`A denops plugin '${name}' is already registered. Skip`);
+        }
+        return;
       } else {
         throw new Error(`A denops plugin '${name}' is already registered`);
       }

--- a/denops/@denops-private/service/service.ts
+++ b/denops/@denops-private/service/service.ts
@@ -18,11 +18,11 @@ const workerScript = "./worker/script.ts";
  * Service manage plugins and is visible from the host (Vim/Neovim) through `invoke()` function.
  */
 export class Service {
-  #plugins: Record<string, { worker: Worker; plugin: Session }>;
+  #plugins: Map<string, { worker: Worker; session: Session }>;
   #host: Host;
 
   constructor(host: Host) {
-    this.#plugins = {};
+    this.#plugins = new Map();
     this.#host = host;
     this.#host.register(new Invoker(this));
   }
@@ -33,15 +33,15 @@ export class Service {
     meta: Meta,
     options: RegisterOptions,
   ): void {
-    if (name in this.#plugins) {
+    const plugin = this.#plugins.get(name);
+    if (plugin) {
       if (options.mode === "reload") {
         if (meta.mode === "debug") {
           console.log(
             `A denops plugin '${name}' is already registered. Reload`,
           );
         }
-        const { worker } = this.#plugins[name];
-        worker.terminate();
+        plugin.worker.terminate();
       } else if (options.mode === "skip") {
         if (meta.mode === "debug") {
           console.log(`A denops plugin '${name}' is already registered. Skip`);
@@ -64,7 +64,7 @@ export class Service {
     worker.postMessage({ name, script, meta });
     const reader = new WorkerReader(worker);
     const writer = new WorkerWriter(worker);
-    const plugin = new Session(reader, writer, {
+    const session = new Session(reader, writer, {
       call: async (fn, ...args) => {
         ensureString(fn);
         ensureArray(args);
@@ -87,10 +87,10 @@ export class Service {
     }, {
       responseTimeout,
     });
-    this.#plugins[name] = {
-      plugin,
+    this.#plugins.set(name, {
+      session,
       worker,
-    };
+    });
   }
 
   async call(fn: string, ...args: unknown[]): Promise<unknown> {
@@ -105,11 +105,11 @@ export class Service {
 
   async dispatch(name: string, fn: string, args: unknown[]): Promise<unknown> {
     try {
-      const { plugin } = this.#plugins[name];
+      const plugin = this.#plugins.get(name);
       if (!plugin) {
         throw new Error(`No plugin '${name}' is registered`);
       }
-      return await plugin.call(fn, ...args);
+      return await plugin.session.call(fn, ...args);
     } catch (e) {
       // NOTE:
       // Vim/Neovim does not handle JavaScript Error instance thus use string instead

--- a/denops/@denops-private/service/service.ts
+++ b/denops/@denops-private/service/service.ts
@@ -34,11 +34,16 @@ export class Service {
     options: RegisterOptions,
   ): void {
     if (name in this.#plugins) {
-      if (options.reload) {
+      if (options.mode === "reload") {
+        if (meta.mode === "debug") {
+          console.log(
+            `A denops plugin '${name}' is already registered. Reload`,
+          );
+        }
         const { worker } = this.#plugins[name];
         worker.terminate();
       } else {
-        throw new Error(`A denops plugin '${name}' has already registered`);
+        throw new Error(`A denops plugin '${name}' is already registered`);
       }
     }
     const worker = new Worker(

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -147,15 +147,16 @@ denops#plugin#register({name}[, {script}[, {options}]])
 	from |runtimepath| like discover.
 	The following attributes are available on {options}.
 
-	"reload"	|v:true| to reload a {name} plugin if it has already
+	"reload"	|v:true| to reload a {name} plugin if it is already
 			registered.
+			DEPRECATED: Use "duplicated" option instead.
 
-	It throws an error when a {name} plugin has already registered unless
-	"reload" {options} is specified. So use a "reload" option to reload
-	registered plugin like:
->
-	call denops#plugin#register('helloworld', { 'reload': v:true })
-<
+	"mode"		|String| to regulate the behavior of registration when
+			a {name} plugin is already registered.
+
+			"reload"	Reload the plugin. (Default)
+			"error"		Throw an error.
+
 	It invokes |User| |DenopsPluginPre|:{name} just before denops execute
 	a "main" function of the plugin and |User| |DenopsPluginPost|:{name}
 	just after denops execute a "main" function of the plugin.

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -155,6 +155,7 @@ denops#plugin#register({name}[, {script}[, {options}]])
 			a {name} plugin is already registered.
 
 			"reload"	Reload the plugin. (Default)
+			"skip"		Skip plugin registration.
 			"error"		Throw an error.
 
 	It invokes |User| |DenopsPluginPre|:{name} just before denops execute
@@ -168,7 +169,8 @@ denops#plugin#discover([{options}])
 	if the middle directory does not starts from "@".
 	This is automatically called on |User| |DenopsReady| autocmd invoked by
 	|denops#server#start()|.
-	See |denops#plugin#register()| for {options}.
+	It uses same {options} as |denops#plugin#register()| except that the
+	default value of "mode" is "skip".
 
 						*denops#callback#add()*
 denops#callback#add({callback}[, {options}])

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -215,14 +215,26 @@ denops#callback#clear()
 AUTOCMD						*denops-autocmd*
 
 DenopsReady						*DenopsReady*
-	Invoked when a denops "service" service become ready. Note that it is
-	not mean that all of denops plugins are ready.
+	Invoked when a denops become ready. Note that it is not mean that all
+	of denops plugins are ready.
 
 DenopsPluginPre:{name}					*DenopsPluginPre*
 	Invoked just before denops call a "main" function of a plugin {name}.
 
 DenopsPluginPost:{name}					*DenopsPluginPost*
 	Invoked just after denops called a "main" function of a plugin {name}.
+
+DenopsChannelStarted					*DenopsChannelStarted*
+	Invoked when a denops "channel" server is started.
+
+DenopsChannelStopped					*DenopsChannelStopped*
+	Invoked when a denops "channel" server is stopped.
+
+DenopsServiceStarted					*DenopsServiceStarted*
+	Invoked when a denops "service" server is started.
+
+DenopsServiceStopped					*DenopsServiceStopped*
+	Invoked when a denops "service" server is stopped.
 
 =============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl


### PR DESCRIPTION
SSIA

Now `reload` option is deprecated. Developers should use `"mode": "reload"` for that.