### PR TITLE
:+1: Don't load health#denops#check() when there is no checkhealth feature

### DIFF
--- a/autoload/health/denops.vim
+++ b/autoload/health/denops.vim
@@ -1,3 +1,7 @@
+if !exists('*health#report_info')
+  finish
+endif
+
 let s:deno_version = '1.11.0'
 let s:vim_version = '8.2.0662'
 let s:neovim_version = '0.4.4'


### PR DESCRIPTION
In vim, `health#.*()` functions don't exist by default.
So if `health#report_info()` doesn't exist, it will stop loading the file.
In the case of vim, if the `health#.*()` functions are defined by the
plugin, it will be load.