### PR TITLE
:+1: Add plugin helper functions

### DIFF
--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -1,12 +1,12 @@
 let s:loaded_plugins = {}
 let s:load_callbacks = {}
 
-function! denops#plugin#is_loaded(name) abort
-  return has_key(s:loaded_plugins, a:name)
+function! denops#plugin#is_loaded(plugin) abort
+  return has_key(s:loaded_plugins, a:plugin)
 endfunction
 
-function! denops#plugin#wait(name, ...) abort
-  if has_key(s:loaded_plugins, a:name)
+function! denops#plugin#wait(plugin, ...) abort
+  if has_key(s:loaded_plugins, a:plugin)
     return
   endif
   let options = extend({
@@ -14,27 +14,27 @@ function! denops#plugin#wait(name, ...) abort
         \}, a:0 ? a:1 : {},
         \)
   let expr = printf('sleep %dm', options.interval)
-  while !has_key(s:loaded_plugins, a:name)
+  while !has_key(s:loaded_plugins, a:plugin)
     execute expr
   endwhile
 endfunction
 
-function! denops#plugin#wait_async(name, callback) abort
-  if has_key(s:loaded_plugins, a:name)
+function! denops#plugin#wait_async(plugin, callback) abort
+  if has_key(s:loaded_plugins, a:plugin)
     " Some features behave differently in functions invoked from timer_start()
     " so use it even for immediate execution to keep consistent behavior.
     call timer_start(0, { -> a:callback() })
     return
   endif
-  let callbacks = get(s:load_callbacks, a:name, [])
+  let callbacks = get(s:load_callbacks, a:plugin, [])
   call add(callbacks, a:callback)
   let s:load_callbacks = callbacks
 endfunction
 
-function! denops#plugin#register(name, ...) abort
+function! denops#plugin#register(plugin, ...) abort
   if a:0 is# 0 || type(a:1) is# v:t_dict
     let options = a:0 > 0 ? a:1 : {}
-    let script = s:find_plugin(a:name)
+    let script = s:find_plugin(a:plugin)
   else
     let script = a:1
     let options = a:0 > 1 ? a:2 : {}
@@ -43,7 +43,7 @@ function! denops#plugin#register(name, ...) abort
   let options = s:options(options, {
         \ 'mode': 'error',
         \})
-  return s:register(a:name, script, meta, options)
+  return s:register(a:plugin, script, meta, options)
 endfunction
 
 function! denops#plugin#discover(...) abort
@@ -53,8 +53,8 @@ function! denops#plugin#discover(...) abort
         \})
   let plugins = {}
   call s:gather_plugins(plugins)
-  for [name, script] in items(plugins)
-    call s:register(name, script, meta, options)
+  for [plugin, script] in items(plugins)
+    call s:register(plugin, script, meta, options)
   endfor
 endfunction
 
@@ -62,11 +62,11 @@ function! s:gather_plugins(plugins) abort
   for runtimepath in split(&runtimepath, ',')
     let expr = denops#util#join_path(expand(runtimepath), 'denops', '*', 'main.ts')
     for script in glob(expr, 1, 1, 1)
-      let name = fnamemodify(script, ':h:t')
-      if name[:0] ==# '@' || has_key(a:plugins, name)
+      let plugin = fnamemodify(script, ':h:t')
+      if plugin[:0] ==# '@' || has_key(a:plugins, plugin)
         continue
       endif
-      call extend(a:plugins, { name : script })
+      call extend(a:plugins, { plugin : script })
     endfor
   endfor
 endfunction
@@ -83,31 +83,31 @@ function! s:options(base, default) abort
   return options
 endfunction
 
-function! s:register(name, script, meta, options) abort
-  let args = [a:name, a:script, a:meta, a:options]
+function! s:register(plugin, script, meta, options) abort
+  let args = [a:plugin, a:script, a:meta, a:options]
   call denops#util#debug(printf('register plugin: %s', args))
   return denops#server#notify('invoke', ['register', args])
 endfunction
 
-function! s:find_plugin(name) abort
+function! s:find_plugin(plugin) abort
   for runtimepath in split(&runtimepath, ',')
-    let script = denops#util#join_path(expand(runtimepath), 'denops', a:name, 'main.ts')
-    let name = fnamemodify(script, ':h:t')
-    if name[:0] ==# '@' || !filereadable(script)
+    let script = denops#util#join_path(expand(runtimepath), 'denops', a:plugin, 'main.ts')
+    let plugin = fnamemodify(script, ':h:t')
+    if plugin[:0] ==# '@' || !filereadable(script)
       continue
     endif
     return script
   endfor
-  throw printf('No denops plugin for "%s" exists', a:name)
+  throw printf('No denops plugin for "%s" exists', a:plugin)
 endfunction
 
 function! s:DenopsPluginPost() abort
-  let name = matchstr(expand('<amatch>'), 'DenopsPluginPost:\zs.*')
-  let s:loaded_plugins[name] = 1
-  if !has_key(s:load_callbacks, name)
+  let plugin = matchstr(expand('<amatch>'), 'DenopsPluginPost:\zs.*')
+  let s:loaded_plugins[plugin] = 1
+  if !has_key(s:load_callbacks, plugin)
     return
   endif
-  let callbacks = remove(s:load_callbacks, name)
+  let callbacks = remove(s:load_callbacks, plugin)
   " Vim uses FILO for a task execution registered by timer_start().
   " That's why reverse 'callbacks' in the case of Vim to keep consistent
   " behavior.

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -148,49 +148,50 @@ denops#server#status()
 	"running"	Server is running.
 
 						*denops#plugin#is_loaded()*
-denops#plugin#is_loaded({name})
-	Return 1 if a {name} plugin is already loaded. Otherwise return 0.
+denops#plugin#is_loaded({plugin})
+	Return 1 if a {plugin} plugin is already loaded. Otherwise return 0.
 
 						*denops#plugin#wait()*
-denops#plugin#wait({name}[, {options}])
-	Wait synchronously until a {name} plugin is loaded. It returns
-	immediately when the {name} plugin is already loaded.
+denops#plugin#wait({plugin}[, {options}])
+	Wait synchronously until a {plugin} plugin is loaded. It returns
+	immediately when the {plugin} plugin is already loaded.
 	The following attributes are available on {options}.
 
 	"interval"	Interval in milliseconds for |sleep| in internal loop.
 			Default: |g:denops#plugin#wait_interval|
 
 						*denops#plugin#wait_async()*
-denops#plugin#wait_async({name}, {callback})
-	Wait asynchronously until a {name} plugin is loaded and invoke a
-	{callback}. It invokes the {callback} immediately when the {name}
+denops#plugin#wait_async({plugin}, {callback})
+	Wait asynchronously until a {plugin} plugin is loaded and invoke a
+	{callback}. It invokes the {callback} immediately when the {plugin}
 	plugin is already loaded. If this function is called multiple times
-	for same {name} plugin, callbacks registered for the plugin are called
-	in order of registration. Note that the {callback} is called from
-	|timer_start()| in any cases to keep consistent behavior.
+	for same {plugin} plugin, callbacks registered for the plugin are
+	called in order of registration. Note that the {callback} is called
+	from |timer_start()| in any cases to keep consistent behavior.
 
 						*denops#plugin#register()*
-denops#plugin#register({name}[, {script}[, {options}]])
+denops#plugin#register({plugin}[, {script}[, {options}]])
 	Register denops plugin. Use this function to register denops plugins
 	which is not discovered by |denops#plugin#discover()|.
-	When a {script} is omitted, a "denops/{name}/main.ts" file is searched
-	from |runtimepath| like discover.
+	When a {script} is omitted, a "denops/{plugin}/main.ts" file is
+	searched from |runtimepath| like discover.
 	The following attributes are available on {options}.
 
-	"reload"	|v:true| to reload a {name} plugin if it is already
+	"reload"	|v:true| to reload a {plugin} plugin if it is already
 			registered.
 			DEPRECATED: Use "duplicated" option instead.
 
 	"mode"		|String| to regulate the behavior of registration when
-			a {name} plugin is already registered.
+			a {plugin} plugin is already registered.
 
 			"reload"	Reload the plugin. (Default)
 			"skip"		Skip plugin registration.
 			"error"		Throw an error.
 
-	It invokes |User| |DenopsPluginPre|:{name} just before denops execute
-	a "main" function of the plugin and |User| |DenopsPluginPost|:{name}
-	just after denops execute a "main" function of the plugin.
+	It invokes |User| |DenopsPluginPre|:{plugin} just before denops
+	execute a "main" function of the plugin and |User|
+	|DenopsPluginPost|:{plugin} just after denops execute a "main"
+	function of the plugin.
 
 						*denops#plugin#discover()*
 denops#plugin#discover([{options}])
@@ -248,11 +249,11 @@ DenopsReady						*DenopsReady*
 	Invoked when a denops become ready. Note that it is not mean that all
 	of denops plugins are ready.
 
-DenopsPluginPre:{name}					*DenopsPluginPre*
-	Invoked just before denops call a "main" function of a plugin {name}.
+DenopsPluginPre:{plugin}				*DenopsPluginPre*
+	Invoked just before denops call a "main" function of a plugin {plugin}.
 
-DenopsPluginPost:{name}					*DenopsPluginPost*
-	Invoked just after denops called a "main" function of a plugin {name}.
+DenopsPluginPost:{plugin}				*DenopsPluginPost*
+	Invoked just after denops called a "main" function of a plugin {plugin}.
 
 DenopsStarted						*DenopsStarted*
 	Invoked when a denops server is started.

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -179,7 +179,7 @@ denops#plugin#register({plugin}[, {script}[, {options}]])
 
 	"reload"	|v:true| to reload a {plugin} plugin if it is already
 			registered.
-			DEPRECATED: Use "duplicated" option instead.
+			DEPRECATED: Use "mode" option instead.
 
 	"mode"		|String| to regulate the behavior of registration when
 			a {plugin} plugin is already registered.

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -92,6 +92,10 @@ VARIABLE						*denops-variable*
 *g:denops#server#service#deno_args*
 	DEPRECATED: Use |g:denops#server#deno_args| instead.
 
+*g:denops#plugin#wait_interval*
+	Interval in milliseconds for |denops#plugin#wait()|.
+	Default: 10
+
 -----------------------------------------------------------------------------
 FUNCTION						*denops-function*
 
@@ -142,6 +146,28 @@ denops#server#status()
 	Status		Description~
 	"stopped"	Server is stopped.
 	"running"	Server is running.
+
+						*denops#plugin#is_loaded()*
+denops#plugin#is_loaded({name})
+	Return 1 if a {name} plugin is already loaded. Otherwise return 0.
+
+						*denops#plugin#wait()*
+denops#plugin#wait({name}[, {options}])
+	Wait synchronously until a {name} plugin is loaded. It returns
+	immediately when the {name} plugin is already loaded.
+	The following attributes are available on {options}.
+
+	"interval"	Interval in milliseconds for |sleep| in internal loop.
+			Default: |g:denops#plugin#wait_interval|
+
+						*denops#plugin#wait_async()*
+denops#plugin#wait_async({name}, {callback})
+	Wait asynchronously until a {name} plugin is loaded and invoke a
+	{callback}. It invokes the {callback} immediately when the {name}
+	plugin is already loaded. If this function is called multiple times
+	for same {name} plugin, callbacks registered for the plugin are called
+	in order of registration. Note that the {callback} is called from
+	|timer_start()| in any cases to keep consistent behavior.
 
 						*denops#plugin#register()*
 denops#plugin#register({name}[, {script}[, {options}]])


### PR DESCRIPTION
```
						*denops#plugin#is_loaded()*
denops#plugin#is_loaded({name})
	Return 1 if a {name} plugin is already loaded. Otherwise return 0.

						*denops#plugin#wait()*
denops#plugin#wait({name}[, {options}])
	Wait synchronously until a {name} plugin is loaded. It returns
	immediately when the {name} plugin is already loaded.
	The following attributes are available on {options}.

	"interval"	Interval in milliseconds for |sleep| in internal loop.
			Default: |g:denops#plugin#wait_interval|

						*denops#plugin#wait_async()*
denops#plugin#wait_async({name}, {callback})
	Wait asynchronously until a {name} plugin is loaded and invoke a
	{callback}. It invokes the {callback} immediately when the {name}
	plugin is already loaded. If this function is called multiple times
	for same {name} plugin, callbacks registered for the plugin are called
	in order of registration.
```