### PR TITLE
:+1: Add `g:denops#type_check` to enable Deno's type check

### DIFF
--- a/autoload/denops.vim
+++ b/autoload/denops.vim
@@ -20,6 +20,7 @@ endfunction
 call s:define('denops#deno', 'deno')
 call s:define('denops#debug', 0)
 call s:define('denops#trace', 0)
+call s:define('denops#type_check', 0)
 call s:define('denops#enable_workaround_vim_before_8_2_3081', 0)
 
 " Internal configuration

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -193,7 +193,7 @@ endif
 let g:denops#server#deno = get(g:, 'denops#server#deno', g:denops#deno)
 let g:denops#server#deno_args = get(g:, 'denops#server#deno_args', filter([
       \ '-q',
-      \ g:denops#debug ? '' : '--no-check',
+      \ g:denops#type_check ? '' : '--no-check',
       \ '--unstable',
       \ '-A',
       \], { _, v -> !empty(v) }))

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -46,16 +46,22 @@ VARIABLE						*denops-variable*
 	features become enabled.
 
 	- Additional debug messages of denops itself
-	- Type checks of Deno modules become enabled
 
-	Note that the debug mode would affect the performance so disable it
-	unless you are debugging denops plugins.
+	Use |g:denops#type_check| to enable Deno's type check feature.
 
 	Default: 0
 
 *g:denops#trace*
 	Set 1 to enable trace mode. In trace mode, all raw RPC messages
 	between Vim/Neovim and denops are echoed.
+
+	Default: 0
+
+*g:denops#type_check*
+	Set 1 to enable Deno's type check feature.
+
+	Note that the type check would affect the performance so disable it
+	unless you are debugging denops plugins.
 
 	Default: 0
 


### PR DESCRIPTION
From this version, users need to use the following to get DEBUG and TYPE CHECK mode

```
let g:denops#debug = 1
let g:denops#type_check = 1
```