### PR TITLE
:+1: Refine `denops#callback` module

### DIFF
--- a/autoload/denops.vim
+++ b/autoload/denops.vim
@@ -7,8 +7,12 @@ function! denops#request(plugin, method, params) abort
 endfunction
 
 function! denops#request_async(plugin, method, params, success, failure) abort
-  let success = denops#callback#add(a:success)
-  let failure = denops#callback#add(a:failure)
+  let success = denops#callback#register(a:success, {
+        \ 'once': v:true,
+        \})
+  let failure = denops#callback#register(a:failure, {
+        \ 'once': v:true,
+        \})
   return denops#server#request('invoke', ['dispatchAsync', [a:plugin, a:method, a:params, success, failure]])
 endfunction
 

--- a/autoload/denops/callback.vim
+++ b/autoload/denops/callback.vim
@@ -1,8 +1,22 @@
 let s:registry = {}
 
 function! denops#callback#add(callback, ...) abort
+  call denops#util#warn('denops#callback#add is deprecated. Use denops#callback#register instead.')
   let options = extend({
         \ 'once': v:true,
+        \}, a:0 ? a:1 : {},
+        \)
+  return denops#callback#register(a:callback, options)
+endfunction
+
+function! denops#callback#remove(id) abort
+  call denops#util#warn('denops#callback#remove is deprecated. Use denops#callback#unregister instead.')
+  call denops#callback#unregister(a:id)
+endfunction
+
+function! denops#callback#register(callback, ...) abort
+  let options = extend({
+        \ 'once': v:false,
         \}, a:0 ? a:1 : {},
         \)
   let id = sha256(string(get(a:callback, 'func')))
@@ -13,7 +27,7 @@ function! denops#callback#add(callback, ...) abort
   return id
 endfunction
 
-function! denops#callback#remove(id) abort
+function! denops#callback#unregister(id) abort
   if !has_key(s:registry, a:id)
     return
   endif

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -212,8 +212,30 @@ denops#plugin#discover([{options}])
 	It uses same {options} as |denops#plugin#register()| except that the
 	default value of "mode" is "skip".
 
+						*denops#callback#register()*
+denops#callback#register({callback}[, {options}])
+	Register {callback} to internal callback map as an anonymous function
+	and return an unique {id} to call the {callback} later.
+	The following attributes are available on {options}.
+
+	"once"		|v:true| to register the callback as a one-time
+			anonymous function which will be removed when the 
+			callback has called. 
+			Default: |v:false|
+>
+	" Persistent callback
+	let id = denops#call#register({ a, b -> a + b })
+	let ret1 = denops#callback#call(id, 1, 2)
+	let ret2 = denops#callback#call(id, 2, 3)
+
+	" One-time callback
+	let id = denops#call#register({ a, b -> a + b }, { 'once': v:true })
+	let ret1 = denops#callback#call(id, 1, 2)
+<
 						*denops#callback#add()*
 denops#callback#add({callback}[, {options}])
+	DEPRECATED: Use |denops#callback#register()| instead.
+
 	Add {callback} to internal callback map as an anonymous function and
 	return an unique {id} to call the {callback} later.
 	The following attributes are available on {options}.
@@ -233,10 +255,17 @@ denops#callback#add({callback}[, {options}])
 	let ret1 = denops#callback#call(id, 1, 2)
 	let ret2 = denops#callback#call(id, 2, 3)
 <
+						*denops#callback#unregister()*
+denops#callback#unregister({id})
+	Unregister a callback of {id} from internal callback map. It does
+	nothing when no {id} callback exists.
 						*denops#callback#remove()*
 denops#callback#remove({id})
+	DEPRECATED: Use |denops#callback#unregister()| instead.
+
 	Remove a callback of {id} from internal callback map. It does nothing
 	when no {id} callback exists.
+
 
 						*denops#callback#call()*
 denops#callback#call({id}[, {args}...])


### PR DESCRIPTION
- Add `denops#callback#register()` and deprecate `denops#callback#add()`
  - The default value of `once` option is reversed
- Add `denops#callback#unregister()` and deprecate `denops#callback#remove()`