### PR TITLE
:muscle: Do not use the deprecated denops#callback#remove() function

### DIFF
--- a/autoload/denops/callback.vim
+++ b/autoload/denops/callback.vim
@@ -41,7 +41,7 @@ function! denops#callback#call(id, ...) abort
   let entry = s:registry[a:id]
   let ret = call(entry.callback, a:000)
   if entry.options.once
-    call denops#callback#remove(a:id)
+    call denops#callback#unregister(a:id)
   endif
   return ret
 endfunction


### PR DESCRIPTION
This function is deprecated now.
Use denops#callback#unregister() instead.