### PR TITLE
:+1: Show the location of the exception when it occurs in the vim

### DIFF
--- a/autoload/denops/api/vim.vim
+++ b/autoload/denops/api/vim.vim
@@ -14,7 +14,7 @@ function! denops#api#vim#call(fn, args) abort
   try
     return [call(a:fn, a:args), '']
   catch
-    return [v:null, v:throwpoint . ': ' . v:exception]
+    return [v:null, v:exception . "\n" . v:throwpoint]
   finally
     call s:debounce_redraw()
   endtry
@@ -50,7 +50,7 @@ function! denops#api#vim#batch(calls) abort
     endfor
     return [results, '']
   catch
-    return [results, v:throwpoint . ': ' . v:exception]
+    return [results, v:exception . "\n" . v:throwpoint]
   finally
     call s:debounce_redraw()
   endtry

--- a/autoload/denops/api/vim.vim
+++ b/autoload/denops/api/vim.vim
@@ -14,7 +14,7 @@ function! denops#api#vim#call(fn, args) abort
   try
     return [call(a:fn, a:args), '']
   catch
-    return [v:null, v:exception]
+    return [v:null, v:throwpoint . ': ' . v:exception]
   finally
     call s:debounce_redraw()
   endtry
@@ -50,7 +50,7 @@ function! denops#api#vim#batch(calls) abort
     endfor
     return [results, '']
   catch
-    return [results, v:exception]
+    return [results, v:throwpoint . ': ' . v:exception]
   finally
     call s:debounce_redraw()
   endtry


### PR DESCRIPTION
Adding v:throwpoint.

For example:

```
[denops] Error: Failed to call 'denops#callback#call(c7311ba284c593d5311487b0f0c56ee051787e704444d1644d2a282f55b57901, [object Obje
ct])': function denops#api#vim#call[2]..denops#callback#call[5]..<SNR>89_on_success, 行 1: hoge
```

`function denops#api#vim#call[2]..denops#callback#call[5]..<SNR>89_on_success, 行 1` will be added.