### PR TITLE
:+1: Add `denops-store` as a global store

### DIFF
--- a/denops/denops-store/deps.ts
+++ b/denops/denops-store/deps.ts
@@ -1,0 +1,1 @@
+export type { Denops } from "../@denops/mod.ts";

--- a/denops/denops-store/main.ts
+++ b/denops/denops-store/main.ts
@@ -1,0 +1,20 @@
+import type { Denops } from "./deps.ts";
+
+const store = new Map();
+
+export function main(denops: Denops): void {
+  denops.dispatcher = {
+    get(key: unknown) {
+      return Promise.resolve(store.get(key));
+    },
+
+    set(key: unknown, value: unknown) {
+      store.set(key, value);
+      return Promise.resolve();
+    },
+
+    delete(key: unknown) {
+      return Promise.resolve(store.delete(key));
+    },
+  };
+}


### PR DESCRIPTION
Please up vote (👍 ) if you need this feature on denops.vim itself.