### PR TITLE
Fix the denops-helloword.vim command in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,12 @@ Plug 'vim-denops/denops.vim'
 Plug 'vim-denops/denops-helloworld.vim'
 ```
 
-Then you can confirm if denops is working properly by executing `HelloDenops`
+Then you can confirm if denops is working properly by executing `DenopsHello`
 command like:
 
 ```vim
-:HelloDenops
-Your name: John
-Hello Denops. Your name is John. This is nvim
+:DenopsHello
+Hello
 ```
 
 Once you've confirmed that denops is working, you can remove


### PR DESCRIPTION
Thank you so much for putting out this repo, It really cool.

I did follow the readme, it seems to me that he correct command is `:DenopsHello` and not `:HelloDenops`.