### PR TITLE
Change error mode to reload mode for plugin#register

### DIFF
--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -41,7 +41,7 @@ function! denops#plugin#register(plugin, ...) abort
   endif
   let meta = denops#util#meta()
   let options = s:options(options, {
-        \ 'mode': 'error',
+        \ 'mode': 'reload',
         \})
   return s:register(a:plugin, script, meta, options)
 endfunction


### PR DESCRIPTION
The current default value is different from the value described at
https://github.com/tani/denops.vim/blob/396abba65d56c9058f833f310a5f0e707a124c12/doc/denops.txt#L162-L179