### PR TITLE
Remove debounce redraw

### DIFF
--- a/autoload/denops/api/vim.vim
+++ b/autoload/denops/api/vim.vim
@@ -1,11 +1,3 @@
-let s:redraw_timer = -1
-let s:redraw_interval = 10
-
-function! s:debounce_redraw() abort
-  call timer_stop(s:redraw_timer)
-  let s:redraw_timer = timer_start(s:redraw_interval, { -> execute('redraw') })
-endfunction
-
 " NOTE:
 " This is a workaround function to detect errors in Vim while Vim 8.2.3081 or
 " above SILENCE any errors occured in `call` channel command.
@@ -15,8 +7,6 @@ function! denops#api#vim#call(fn, args) abort
     return [call(a:fn, a:args), '']
   catch
     return [v:null, v:exception . "\n" . v:throwpoint]
-  finally
-    call s:debounce_redraw()
   endtry
 endfunction
 
@@ -33,7 +23,5 @@ function! denops#api#vim#batch(calls) abort
     return [results, '']
   catch
     return [results, v:exception . "\n" . v:throwpoint]
-  finally
-    call s:debounce_redraw()
   endtry
 endfunction

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -17,7 +17,7 @@ INTERFACE				|denops-interface|
 INTRODUCTION					*denops-introduction*
 
 *denops.vim* (denops) is an eco-system to write plugins for Vim or Neovim in
-Deno. 
+Deno.
 
 See denops.vim Wiki for learning how to write denops plugins.
 
@@ -104,6 +104,8 @@ denops#notify({plugin}, {method}, {params})
 	Call API {method} of {plugin} with {params} and return immediately
 	without waiting a result.
 	Use |denops#request()| instead if you need a result.
+        Note: It does not redraw in Vim environment.  You need to execute
+        |:redraw| manually if it is needed.
 
 						*denops#request()*
 denops#request({plugin}, {method}, {params})


### PR DESCRIPTION
The redraw should be removed.  Because it has the side effects.

For example:  `PP ddc#custom#get_current()` does not work well.

I think the redraw is really needed, it should be solved in denops plugins side.