### PR TITLE
Release denops v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
           - "1.17.1"
           - "1.x"
         host_version:
-          - vim: "v8.2.3081"
+          - vim: "v8.2.3452"
             nvim: "v0.6.0"
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         runner:
           - ubuntu-latest
         version:
-          - "1.14.0"
+          - "1.17.1"
           - "1.x"
     runs-on: ${{ matrix.runner }}
     steps:
@@ -67,7 +67,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         version:
-          - "1.14.0"
+          - "1.17.1"
           - "1.x"
         host_version:
           - vim: "v8.2.3081"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
           - "1.x"
         host_version:
           - vim: "v8.2.3081"
-            nvim: "v0.5.0"
+            nvim: "v0.6.0"
     runs-on: ${{ matrix.runner }}
     steps:
       - run: git config --global core.autocrlf false

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help:
 
 tools: FORCE	## Install development tools
 	@mkdir -p ${TOOLS}
-	@deno install -A -f -n udd --root ${TOOLS} https://deno.land/x/udd@0.5.0/main.ts
+	@deno install -A -f -n udd --root ${TOOLS} https://deno.land/x/udd@0.7.2/main.ts
 
 fmt: FORCE	## Format code
 	@deno fmt --config deno.jsonc

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Deno 1.17.1 or above](https://img.shields.io/badge/Deno-Support%201.17.1-yellowgreen.svg?logo=deno)](https://github.com/denoland/deno/tree/v1.17.1)
 [![Vim 8.2.3081 or above](https://img.shields.io/badge/Vim-Support%208.2.3081-yellowgreen.svg?logo=vim)](https://github.com/vim/vim/tree/v8.2.3081)
-[![Neovim 0.5.0 or above](https://img.shields.io/badge/Neovim-Support%200.5.0-yellowgreen.svg?logo=neovim&logoColor=white)](https://github.com/neovim/neovim/tree/v0.5.0)
+[![Neovim 0.6.0 or above](https://img.shields.io/badge/Neovim-Support%200.6.0-yellowgreen.svg?logo=neovim&logoColor=white)](https://github.com/neovim/neovim/tree/v0.6.0)
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![deno land](http://img.shields.io/badge/available%20on-deno.land/x/denops__core-lightgrey.svg?logo=deno)](https://deno.land/x/denops_core)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <sup>An ecosystem of Vim/Neovim which allows developers to write plugins in Deno.</sup>
 
 [![Deno 1.17.1 or above](https://img.shields.io/badge/Deno-Support%201.17.1-yellowgreen.svg?logo=deno)](https://github.com/denoland/deno/tree/v1.17.1)
-[![Vim 8.2.3081 or above](https://img.shields.io/badge/Vim-Support%208.2.3081-yellowgreen.svg?logo=vim)](https://github.com/vim/vim/tree/v8.2.3081)
+[![Vim 8.2.3452 or above](https://img.shields.io/badge/Vim-Support%208.2.3452-yellowgreen.svg?logo=vim)](https://github.com/vim/vim/tree/v8.2.3452)
 [![Neovim 0.6.0 or above](https://img.shields.io/badge/Neovim-Support%200.6.0-yellowgreen.svg?logo=neovim&logoColor=white)](https://github.com/neovim/neovim/tree/v0.6.0)
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <strong>Denops</strong><br>
 <sup>An ecosystem of Vim/Neovim which allows developers to write plugins in Deno.</sup>
 
-[![Deno 1.14.0 or above](https://img.shields.io/badge/Deno-Support%201.14.0-yellowgreen.svg?logo=deno)](https://github.com/denoland/deno/tree/v1.14.0)
+[![Deno 1.17.1 or above](https://img.shields.io/badge/Deno-Support%201.17.1-yellowgreen.svg?logo=deno)](https://github.com/denoland/deno/tree/v1.17.1)
 [![Vim 8.2.3081 or above](https://img.shields.io/badge/Vim-Support%208.2.3081-yellowgreen.svg?logo=vim)](https://github.com/vim/vim/tree/v8.2.3081)
 [![Neovim 0.5.0 or above](https://img.shields.io/badge/Neovim-Support%200.5.0-yellowgreen.svg?logo=neovim&logoColor=white)](https://github.com/neovim/neovim/tree/v0.5.0)
 

--- a/autoload/denops/api/vim.vim
+++ b/autoload/denops/api/vim.vim
@@ -1,11 +1,3 @@
-let s:redraw_timer = -1
-let s:redraw_interval = 10
-
-function! s:debounce_redraw() abort
-  call timer_stop(s:redraw_timer)
-  let s:redraw_timer = timer_start(s:redraw_interval, { -> execute('redraw') })
-endfunction
-
 " NOTE:
 " This is a workaround function to detect errors in Vim while Vim 8.2.3081 or
 " above SILENCE any errors occured in `call` channel command.
@@ -15,8 +7,6 @@ function! denops#api#vim#call(fn, args) abort
     return [call(a:fn, a:args), '']
   catch
     return [v:null, v:exception . "\n" . v:throwpoint]
-  finally
-    call s:debounce_redraw()
   endtry
 endfunction
 
@@ -33,7 +23,5 @@ function! denops#api#vim#batch(calls) abort
     return [results, '']
   catch
     return [results, v:exception . "\n" . v:throwpoint]
-  finally
-    call s:debounce_redraw()
   endtry
 endfunction

--- a/autoload/health/denops.vim
+++ b/autoload/health/denops.vim
@@ -1,6 +1,6 @@
 let s:deno_version = '1.17.1'
 let s:vim_version = '8.2.3081'
-let s:neovim_version = '0.5.0'
+let s:neovim_version = '0.6.0'
 
 function! s:compare_version(v1, v2) abort
   let v1 = map(split(a:v1, '\.'), { _, v -> v + 0 })

--- a/autoload/health/denops.vim
+++ b/autoload/health/denops.vim
@@ -1,5 +1,5 @@
 let s:deno_version = '1.17.1'
-let s:vim_version = '8.2.3081'
+let s:vim_version = '8.2.3452'
 let s:neovim_version = '0.6.0'
 
 function! s:compare_version(v1, v2) abort

--- a/autoload/health/denops.vim
+++ b/autoload/health/denops.vim
@@ -1,4 +1,4 @@
-let s:deno_version = '1.14.0'
+let s:deno_version = '1.17.1'
 let s:vim_version = '8.2.3081'
 let s:neovim_version = '0.5.0'
 

--- a/denops/@denops-private/cli.ts
+++ b/denops/@denops-private/cli.ts
@@ -1,4 +1,4 @@
-import { parse } from "https://deno.land/std@0.119.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.123.0/flags/mod.ts";
 import { using } from "https://deno.land/x/disposable@v1.0.2/mod.ts#^";
 import { Service } from "./service.ts";
 import { Vim } from "./host/vim.ts";

--- a/denops/@denops-private/worker/script.ts
+++ b/denops/@denops-private/worker/script.ts
@@ -1,4 +1,4 @@
-import { toFileUrl } from "https://deno.land/std@0.119.0/path/mod.ts";
+import { toFileUrl } from "https://deno.land/std@0.123.0/path/mod.ts";
 import {
   ensureObject,
   ensureString,

--- a/denops/@denops/test.ts
+++ b/denops/@denops/test.ts
@@ -1,8 +1,8 @@
-import * as path from "https://deno.land/std@0.119.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.123.0/path/mod.ts";
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.119.0/testing/asserts.ts";
+} from "https://deno.land/std@0.123.0/testing/asserts.ts";
 import { test } from "./test/tester.ts";
 import { BatchError } from "./mod.ts";
 

--- a/denops/@denops/test.ts
+++ b/denops/@denops/test.ts
@@ -29,7 +29,6 @@ test({
       "E117: Unknown function: no-such-function",
     );
   },
-  prelude: ["let g:denops#enable_workaround_vim_before_8_2_3081 = 1"],
 });
 
 test({
@@ -86,7 +85,6 @@ test({
       "E492: Not an editor command: NoSuchCommand",
     );
   },
-  prelude: ["let g:denops#enable_workaround_vim_before_8_2_3081 = 1"],
 });
 
 test({
@@ -117,7 +115,6 @@ test({
       // Neovim: "E121: Undefined variable: g:no_such_variable",
     );
   },
-  prelude: ["let g:denops#enable_workaround_vim_before_8_2_3081 = 1"],
 });
 
 test({
@@ -145,7 +142,6 @@ test({
       );
     }, BatchError);
   },
-  prelude: ["let g:denops#enable_workaround_vim_before_8_2_3081 = 1"],
 });
 
 test({

--- a/denops/@denops/test/bypass/cli.ts
+++ b/denops/@denops/test/bypass/cli.ts
@@ -1,4 +1,4 @@
-import { copy } from "https://deno.land/std@0.119.0/streams/conversion.ts";
+import { copy } from "https://deno.land/std@0.123.0/streams/conversion.ts";
 import {
   WorkerReader,
   WorkerWriter,

--- a/denops/@denops/test/tester.ts
+++ b/denops/@denops/test/tester.ts
@@ -1,7 +1,7 @@
-import * as path from "https://deno.land/std@0.119.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.123.0/path/mod.ts";
 import { Session } from "https://deno.land/x/msgpack_rpc@v3.1.4/mod.ts#^";
 import { using } from "https://deno.land/x/disposable@v1.0.2/mod.ts#^";
-import { deadline } from "https://deno.land/std@0.119.0/async/mod.ts";
+import { deadline } from "https://deno.land/std@0.123.0/async/mod.ts";
 import type { Denops, Meta } from "../mod.ts";
 import { DenopsImpl } from "../impl.ts";
 import { DENOPS_TEST_NVIM, DENOPS_TEST_VIM, run } from "./runner.ts";

--- a/denops/@denops/test/tester_test.ts
+++ b/denops/@denops/test/tester_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.119.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.123.0/testing/asserts.ts";
 import { test } from "./tester.ts";
 
 test(

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -17,7 +17,7 @@ INTERFACE				|denops-interface|
 INTRODUCTION					*denops-introduction*
 
 *denops.vim* (denops) is an eco-system to write plugins for Vim or Neovim in
-Deno. 
+Deno.
 
 See denops.vim Wiki for learning how to write denops plugins.
 
@@ -104,6 +104,8 @@ denops#notify({plugin}, {method}, {params})
 	Call API {method} of {plugin} with {params} and return immediately
 	without waiting a result.
 	Use |denops#request()| instead if you need a result.
+        Note: It does not redraw in Vim environment.  You need to execute
+        |:redraw| manually if it is needed.
 
 						*denops#request()*
 denops#request({plugin}, {method}, {params})

--- a/plugin/denops.vim
+++ b/plugin/denops.vim
@@ -3,9 +3,9 @@ if exists('g:loaded_denops')
 endif
 let g:loaded_denops = 1
 
-if !get(g:, 'denops_disable_version_check') && !has('nvim-0.5.0') && !has('patch-8.2.3081')
+if !get(g:, 'denops_disable_version_check') && !has('nvim-0.6.0') && !has('patch-8.2.3081')
   echohl WarningMsg
-  echo '[denops] Denops requires Vim 8.2.3081 or Neovim 0.5.0. See ":h g:denops_disable_version_check" to disable this check.'
+  echo '[denops] Denops requires Vim 8.2.3081 or Neovim 0.6.0. See ":h g:denops_disable_version_check" to disable this check.'
   echohl None
   finish
 endif

--- a/plugin/denops.vim
+++ b/plugin/denops.vim
@@ -3,9 +3,9 @@ if exists('g:loaded_denops')
 endif
 let g:loaded_denops = 1
 
-if !get(g:, 'denops_disable_version_check') && !has('nvim-0.6.0') && !has('patch-8.2.3081')
+if !get(g:, 'denops_disable_version_check') && !has('nvim-0.6.0') && !has('patch-8.2.3452')
   echohl WarningMsg
-  echo '[denops] Denops requires Vim 8.2.3081 or Neovim 0.6.0. See ":h g:denops_disable_version_check" to disable this check.'
+  echo '[denops] Denops requires Vim 8.2.3452 or Neovim 0.6.0. See ":h g:denops_disable_version_check" to disable this check.'
   echohl None
   finish
 endif


### PR DESCRIPTION
### Breaking change

- Developers must call `redraw` manually when `denops#notify()` is used.
- Minimum supported Deno version becomes 1.17.1
- Minimum supported Vim version becomes 8.2.3452
- Minimum supported Neovim version becomes 0.6.0
