### PR TITLE
Upgrade supported Vim/Neovim/Deno versions for denops v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
           - "1.17.1"
           - "1.x"
         host_version:
-          - vim: "v8.2.3081"
+          - vim: "v8.2.3452"
             nvim: "v0.6.0"
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         runner:
           - ubuntu-latest
         version:
-          - "1.14.0"
+          - "1.17.1"
           - "1.x"
     runs-on: ${{ matrix.runner }}
     steps:
@@ -67,7 +67,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         version:
-          - "1.14.0"
+          - "1.17.1"
           - "1.x"
         host_version:
           - vim: "v8.2.3081"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,32 +88,31 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-deno-${{ matrix.version }}-
             ${{ runner.os }}-deno-
-      - uses: thinca/action-setup-vim@v1
+      - uses: rhysd/action-setup-vim@v1
         id: vim
         with:
-          vim_type: "Vim"
-          vim_version: "${{ matrix.host_version.vim }}"
-          download: "never"
+          neovim: false
+          version: "${{ matrix.host_version.vim }}"
       - name: Check Vim
         run: |
           echo ${DENOPS_TEST_VIM}
           ${DENOPS_TEST_VIM} --version
         env:
-          DENOPS_TEST_VIM: ${{ steps.vim.outputs.executable_path }}
-      - uses: thinca/action-setup-vim@v1
+          DENOPS_TEST_VIM: ${{ steps.vim.outputs.executable }}
+      - uses: rhysd/action-setup-vim@v1
         id: nvim
         with:
-          vim_type: "Neovim"
-          vim_version: "${{ matrix.host_version.nvim }}"
+          neovim: true
+          version: "${{ matrix.host_version.nvim }}"
       - name: Check Neovim
         run: |
           echo ${DENOPS_TEST_NVIM}
           ${DENOPS_TEST_NVIM} --version
         env:
-          DENOPS_TEST_NVIM: ${{ steps.nvim.outputs.executable_path }}
+          DENOPS_TEST_NVIM: ${{ steps.nvim.outputs.executable }}
       - name: Test
         run: make test
         env:
-          DENOPS_TEST_VIM: ${{ steps.vim.outputs.executable_path }}
-          DENOPS_TEST_NVIM: ${{ steps.nvim.outputs.executable_path }}
+          DENOPS_TEST_VIM: ${{ steps.vim.outputs.executable }}
+          DENOPS_TEST_NVIM: ${{ steps.nvim.outputs.executable }}
         timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
           - "1.x"
         host_version:
           - vim: "v8.2.3081"
-            nvim: "v0.5.0"
+            nvim: "v0.6.0"
     runs-on: ${{ matrix.runner }}
     steps:
       - run: git config --global core.autocrlf false

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Deno 1.17.1 or above](https://img.shields.io/badge/Deno-Support%201.17.1-yellowgreen.svg?logo=deno)](https://github.com/denoland/deno/tree/v1.17.1)
 [![Vim 8.2.3081 or above](https://img.shields.io/badge/Vim-Support%208.2.3081-yellowgreen.svg?logo=vim)](https://github.com/vim/vim/tree/v8.2.3081)
-[![Neovim 0.5.0 or above](https://img.shields.io/badge/Neovim-Support%200.5.0-yellowgreen.svg?logo=neovim&logoColor=white)](https://github.com/neovim/neovim/tree/v0.5.0)
+[![Neovim 0.6.0 or above](https://img.shields.io/badge/Neovim-Support%200.6.0-yellowgreen.svg?logo=neovim&logoColor=white)](https://github.com/neovim/neovim/tree/v0.6.0)
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![deno land](http://img.shields.io/badge/available%20on-deno.land/x/denops__core-lightgrey.svg?logo=deno)](https://deno.land/x/denops_core)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <sup>An ecosystem of Vim/Neovim which allows developers to write plugins in Deno.</sup>
 
 [![Deno 1.17.1 or above](https://img.shields.io/badge/Deno-Support%201.17.1-yellowgreen.svg?logo=deno)](https://github.com/denoland/deno/tree/v1.17.1)
-[![Vim 8.2.3081 or above](https://img.shields.io/badge/Vim-Support%208.2.3081-yellowgreen.svg?logo=vim)](https://github.com/vim/vim/tree/v8.2.3081)
+[![Vim 8.2.3452 or above](https://img.shields.io/badge/Vim-Support%208.2.3452-yellowgreen.svg?logo=vim)](https://github.com/vim/vim/tree/v8.2.3452)
 [![Neovim 0.6.0 or above](https://img.shields.io/badge/Neovim-Support%200.6.0-yellowgreen.svg?logo=neovim&logoColor=white)](https://github.com/neovim/neovim/tree/v0.6.0)
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <strong>Denops</strong><br>
 <sup>An ecosystem of Vim/Neovim which allows developers to write plugins in Deno.</sup>
 
-[![Deno 1.14.0 or above](https://img.shields.io/badge/Deno-Support%201.14.0-yellowgreen.svg?logo=deno)](https://github.com/denoland/deno/tree/v1.14.0)
+[![Deno 1.17.1 or above](https://img.shields.io/badge/Deno-Support%201.17.1-yellowgreen.svg?logo=deno)](https://github.com/denoland/deno/tree/v1.17.1)
 [![Vim 8.2.3081 or above](https://img.shields.io/badge/Vim-Support%208.2.3081-yellowgreen.svg?logo=vim)](https://github.com/vim/vim/tree/v8.2.3081)
 [![Neovim 0.5.0 or above](https://img.shields.io/badge/Neovim-Support%200.5.0-yellowgreen.svg?logo=neovim&logoColor=white)](https://github.com/neovim/neovim/tree/v0.5.0)
 

--- a/autoload/health/denops.vim
+++ b/autoload/health/denops.vim
@@ -1,6 +1,6 @@
 let s:deno_version = '1.17.1'
 let s:vim_version = '8.2.3081'
-let s:neovim_version = '0.5.0'
+let s:neovim_version = '0.6.0'
 
 function! s:compare_version(v1, v2) abort
   let v1 = map(split(a:v1, '\.'), { _, v -> v + 0 })

--- a/autoload/health/denops.vim
+++ b/autoload/health/denops.vim
@@ -1,5 +1,5 @@
 let s:deno_version = '1.17.1'
-let s:vim_version = '8.2.3081'
+let s:vim_version = '8.2.3452'
 let s:neovim_version = '0.6.0'
 
 function! s:compare_version(v1, v2) abort

--- a/autoload/health/denops.vim
+++ b/autoload/health/denops.vim
@@ -1,4 +1,4 @@
-let s:deno_version = '1.14.0'
+let s:deno_version = '1.17.1'
 let s:vim_version = '8.2.3081'
 let s:neovim_version = '0.5.0'
 

--- a/denops/@denops/test.ts
+++ b/denops/@denops/test.ts
@@ -29,7 +29,6 @@ test({
       "E117: Unknown function: no-such-function",
     );
   },
-  prelude: ["let g:denops#enable_workaround_vim_before_8_2_3081 = 1"],
 });
 
 test({
@@ -86,7 +85,6 @@ test({
       "E492: Not an editor command: NoSuchCommand",
     );
   },
-  prelude: ["let g:denops#enable_workaround_vim_before_8_2_3081 = 1"],
 });
 
 test({
@@ -117,7 +115,6 @@ test({
       // Neovim: "E121: Undefined variable: g:no_such_variable",
     );
   },
-  prelude: ["let g:denops#enable_workaround_vim_before_8_2_3081 = 1"],
 });
 
 test({
@@ -145,7 +142,6 @@ test({
       );
     }, BatchError);
   },
-  prelude: ["let g:denops#enable_workaround_vim_before_8_2_3081 = 1"],
 });
 
 test({

--- a/plugin/denops.vim
+++ b/plugin/denops.vim
@@ -3,9 +3,9 @@ if exists('g:loaded_denops')
 endif
 let g:loaded_denops = 1
 
-if !get(g:, 'denops_disable_version_check') && !has('nvim-0.5.0') && !has('patch-8.2.3081')
+if !get(g:, 'denops_disable_version_check') && !has('nvim-0.6.0') && !has('patch-8.2.3081')
   echohl WarningMsg
-  echo '[denops] Denops requires Vim 8.2.3081 or Neovim 0.5.0. See ":h g:denops_disable_version_check" to disable this check.'
+  echo '[denops] Denops requires Vim 8.2.3081 or Neovim 0.6.0. See ":h g:denops_disable_version_check" to disable this check.'
   echohl None
   finish
 endif

--- a/plugin/denops.vim
+++ b/plugin/denops.vim
@@ -3,9 +3,9 @@ if exists('g:loaded_denops')
 endif
 let g:loaded_denops = 1
 
-if !get(g:, 'denops_disable_version_check') && !has('nvim-0.6.0') && !has('patch-8.2.3081')
+if !get(g:, 'denops_disable_version_check') && !has('nvim-0.6.0') && !has('patch-8.2.3452')
   echohl WarningMsg
-  echo '[denops] Denops requires Vim 8.2.3081 or Neovim 0.6.0. See ":h g:denops_disable_version_check" to disable this check.'
+  echo '[denops] Denops requires Vim 8.2.3452 or Neovim 0.6.0. See ":h g:denops_disable_version_check" to disable this check.'
   echohl None
   finish
 endif


### PR DESCRIPTION
### Deno

The latest version

### Vim

**Which version should we use?**

- 8.2.2434
    - is the version for Ubuntu 20.10
    - [for Windows exist](https://github.com/vim/vim-win32-installer/releases/tag/v8.2.2434)
    - A years ago... ([2021/01](https://github.com/vim/vim/commit/f2b26bcf8f498fed72759af4aa768fb2aab3118c))
- 8.2.3455
    - is the version for MacVim
    - for Windows does not exist ([8.2.3452](https://github.com/vim/vim-win32-installer/releases/tag/v8.2.3452) is closest)
    - Four month ago ([2021/09](https://github.com/vim/vim/commit/690c524ce6629f9ff67728541ba211f831caf0ee))

### Neovim

The latest version