### PR TITLE
:bug: Fix `denops#plugin#wait()`

### DIFF
--- a/autoload/denops/util.vim
+++ b/autoload/denops/util.vim
@@ -63,6 +63,25 @@ function! denops#util#join_path(...) abort
   return join(a:000, s:sep)
 endfunction
 
+function! denops#util#wait(timeout, condition, interval) abort
+  return s:wait(a:timeout, a:condition, a:interval)
+endfunction
+
+if exists('*wait')
+  let s:wait = function('wait')
+else
+  function! s:wait(timeout, condition, interval) abort
+    let waiter = printf('sleep %dm', a:interval)
+    let s = reltime()
+    while a:condition()
+      if reltimefloat(reltime(s)) * 1000 > a:timeout
+        return -1
+      endif
+      execute waiter
+    endwhile
+  endfunction
+endif
+
 if has('nvim')
   function! s:get_host_version() abort
     let output = execute('version')

--- a/denops/@denops-private/worker/script.ts
+++ b/denops/@denops-private/worker/script.ts
@@ -44,8 +44,9 @@ async function main(name: string, script: string, meta: Meta): Promise<void> {
             console.warn(`Failed to emit DenopsPluginPost:${name}: ${e}`)
           );
       } catch (e) {
+        console.error(`${name}: ${e}`);
         await denops.cmd(
-          `doautocmd <nomodeline> User DenopsPluginFail:${name}:${e}`,
+          `doautocmd <nomodeline> User DenopsPluginFail:${name}`,
         )
           .catch((e) =>
             console.warn(`Failed to emit DenopsPluginFail:${name}: ${e}`)

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -96,6 +96,10 @@ VARIABLE						*denops-variable*
 	Interval in milliseconds for |denops#plugin#wait()|.
 	Default: 10
 
+*g:denops#plugin#wait_timeout*
+	Timeout in milliseconds for |denops#plugin#wait()|.
+	Default: 5000
+
 -----------------------------------------------------------------------------
 FUNCTION						*denops-function*
 
@@ -160,10 +164,18 @@ denops#plugin#is_loaded({plugin})
 denops#plugin#wait({plugin}[, {options}])
 	Wait synchronously until a {plugin} plugin is loaded. It returns
 	immediately when the {plugin} plugin is already loaded.
+	It returns -1 if it timed out, -2 if the server is not yet ready, or
+	-3 if the plugin initialization failed.
+	Developers need to consider this return value to decide whether to
+	continue with the subsequent process.
 	The following attributes are available on {options}.
 
 	"interval"	Interval in milliseconds for |sleep| in internal loop.
 			Default: |g:denops#plugin#wait_interval|
+	"timeout"	Timeout in milliseconds to block.
+			Default: |g:denops#plugin#wait_timeout|
+	"silent"	1 to silence error messages.
+			Default: 0
 
 						*denops#plugin#wait_async()*
 denops#plugin#wait_async({plugin}, {callback})

--- a/plugin/denops/debug.vim
+++ b/plugin/denops/debug.vim
@@ -1,0 +1,12 @@
+if exists('g:loaded_denops_debug')
+  finish
+endif
+let g:loaded_denops_debug = 1
+
+augroup denops_debug_plugin_internal
+  autocmd!
+  autocmd User DenopsReady,DenopsStarted,DenopsStopped
+        \  call denops#util#debug(expand('<amatch>:t'))
+  autocmd User DenopsPluginPre:*,DenopsPluginPost:*
+        \  call denops#util#debug(expand('<amatch>:t'))
+augroup END


### PR DESCRIPTION
Close #174

- Add a timeout to prevent Vim from freezing forever (-1)
- If the denops server is not ready yet, it will fail immediately (-2)
- Return fail status so that developers can decide to continue (-3)

The best way to use `denops#plugin#wait()` is with early return like

```vim
if denops#plugin#wait('gin')
  return
endif
call denops#request('gin', 'status:command', [])
```