### PR TITLE
:bug: Fix `denops#plugin#wait()`

### DIFF
--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -152,4 +152,4 @@ augroup denops_autoload_plugin_internal
 augroup END
 
 let g:denops#plugin#wait_interval = get(g:, 'denops#plugin#wait_interval', 10)
-let g:denops#plugin#wait_timeout = get(g:, 'denops#plugin#wait_timeout', 5000)
+let g:denops#plugin#wait_timeout = get(g:, 'denops#plugin#wait_timeout', 30000)

--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -12,10 +12,10 @@ function! denops#plugin#wait(plugin, ...) abort
         \ 'silent': 0,
         \}, a:0 ? a:1 : {},
         \)
-  if denops#server#status() !=# 'running'
+  if denops#server#status() ==# 'stopped'
     if !options.silent
       call denops#util#error(printf(
-            \ 'Failed to wait for "%s" to start. Denops server itself is not ready yet.',
+            \ 'Failed to wait for "%s" to start. Denops server itself is not started.',
             \ a:plugin,
             \))
     endif

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -164,8 +164,8 @@ denops#plugin#is_loaded({plugin})
 denops#plugin#wait({plugin}[, {options}])
 	Wait synchronously until a {plugin} plugin is loaded. It returns
 	immediately when the {plugin} plugin is already loaded.
-	It returns -1 if it timed out, -2 if the server is not yet ready, or
-	-3 if the plugin initialization failed.
+	It returns -1 if it timed out, -2 if the server is not yet ready or
+	interrupted, or -3 if the plugin initialization failed.
 	Developers need to consider this return value to decide whether to
 	continue with the subsequent process.
 	The following attributes are available on {options}.

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -98,7 +98,7 @@ VARIABLE						*denops-variable*
 
 *g:denops#plugin#wait_timeout*
 	Timeout in milliseconds for |denops#plugin#wait()|.
-	Default: 5000
+	Default: 30000
 
 -----------------------------------------------------------------------------
 FUNCTION						*denops-function*


### PR DESCRIPTION
Fails only when denops is not started yet (accept 'starting')