### PR TITLE
Accept Partial for a callback

### DIFF
--- a/autoload/denops/callback.vim
+++ b/autoload/denops/callback.vim
@@ -5,7 +5,7 @@ function! denops#callback#register(callback, ...) abort
         \ 'once': v:false,
         \}, a:0 ? a:1 : {},
         \)
-  let id = sha256(string(get(a:callback, 'func')))
+  let id = sha256(string(a:callback))
   let s:registry[id] = {
         \ 'callback': a:callback,
         \ 'options': options,


### PR DESCRIPTION
(CC: @Shougo )

`denops#callback#register()` distinguishes callbacks only by their names, so any [Partials](https://vimhelp.org/eval.txt.html#:~:text=call(Fn%2C%20mylist)-,Partial,-A%20Funcref%20optionally) made from the same function returns the same callback id, whatever their argument is.

`string()` for a funcref returns `function('funcname', [args])` formed string for a Partial, so I think it is preferable for a hash key.

I encountered this problem when I configured [ddu.vim](https://github.com/Shougo/ddu.vim) like following;

```vim
function! s:ddu_cd(command, args) abort
  for item in a:args.items
    let path = item.action.path
    execute a:command .. ' ' .. (isdirectory(path) ? path : fnamemodify(path, ':h'))
  endfor
endfunction

call ddu#custom#action('kind', 'file', 'tabnew', function('s:ddu_cd', ['tabnew | tcd']))
call ddu#custom#action('kind', 'file', 'lcd', function('s:ddu_cd', ['lcd']))
call ddu#custom#action('kind', 'file', 'tcd', function('s:ddu_cd', ['tcd']))
```

As a result of this settings, all actions (`tabnew`, `lcd`, `tcd`) performs the same behavior.

This problem can also be solved by applying next patch to ddu.vim, but I think it is better to fix this problem in denops.vim because there can be enough cases where you want to use a Partial as a callback.

```diff
diff --git a/autoload/ddu/custom.vim b/autoload/ddu/custom.vim
index dc8c56c..c751037 100644
--- a/autoload/ddu/custom.vim
+++ b/autoload/ddu/custom.vim
@@ -43,7 +43,7 @@ function! ddu#custom#action(type, source_kind_name, action_name, func) abort
     if !has_key(dict, key)
       let dict[key] = { 'actions': {} }
     endif
-    let dict[key].actions[a:action_name] = denops#callback#register(a:func)
+    let dict[key].actions[a:action_name] = denops#callback#register({ args -> a:func(args) })
   endfor
 
   call ddu#_notify('patchGlobal', [
```