### PR TITLE
:+1: Show friendly error message when return value serialization failed in debug mode

### DIFF
--- a/autoload/denops/api/vim.vim
+++ b/autoload/denops/api/vim.vim
@@ -4,7 +4,12 @@
 " https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
 function! denops#api#vim#call(fn, args) abort
   try
-    return [call(a:fn, a:args), '']
+    let result = call(a:fn, a:args)
+    if g:denops#debug
+      " Check if the result is serializable
+      call json_encode(result)
+    endif
+    return [result, '']
   catch
     return [v:null, v:exception . "\n" . v:throwpoint]
   endtry
@@ -20,6 +25,10 @@ function! denops#api#vim#batch(calls) abort
     for l:Call in a:calls
       call add(results, call(Call[0], Call[1:]))
     endfor
+    if g:denops#debug
+      " Check if the result is serializable
+      call json_encode(results)
+    endif
     return [results, '']
   catch
     return [results, v:exception . "\n" . v:throwpoint]


### PR DESCRIPTION
Fixes #185 

Check the value is serializable only `g:denops#debug` is enabled.