### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint: FORCE	## Lint code
 	@deno lint --config deno.jsonc
 
 type-check: FORCE	## Type check
-	@deno test --unstable --no-run ${TARGETS}
+	@deno test --unstable --no-run --no-check=remote ${TARGETS}
 
 test: FORCE	## Test
 	@deno test --unstable -A --no-check --jobs

--- a/denops/@denops-private/cli.ts
+++ b/denops/@denops-private/cli.ts
@@ -1,4 +1,4 @@
-import { parse } from "https://deno.land/std@0.140.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.149.0/flags/mod.ts";
 import { using } from "https://deno.land/x/disposable@v1.0.2/mod.ts#^";
 import { Service } from "./service.ts";
 import { Vim } from "./host/vim.ts";

--- a/denops/@denops-private/tee.ts
+++ b/denops/@denops-private/tee.ts
@@ -1,5 +1,5 @@
-import { Buffer } from "https://deno.land/std@0.142.0/io/mod.ts";
-import { writeAll } from "https://deno.land/std@0.142.0/streams/mod.ts";
+import { Buffer } from "https://deno.land/std@0.149.0/io/mod.ts";
+import { writeAll } from "https://deno.land/std@0.149.0/streams/mod.ts";
 
 type Reader = Deno.Reader;
 type ReadCloser = Reader & Deno.Closer;

--- a/denops/@denops-private/tee_test.ts
+++ b/denops/@denops-private/tee_test.ts
@@ -1,12 +1,12 @@
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.142.0/testing/asserts.ts";
+} from "https://deno.land/std@0.149.0/testing/asserts.ts";
 import {
   readAll,
   writeAll,
-} from "https://deno.land/std@0.142.0/streams/mod.ts";
-import { Buffer } from "https://deno.land/std@0.142.0/io/mod.ts";
+} from "https://deno.land/std@0.149.0/streams/mod.ts";
+import { Buffer } from "https://deno.land/std@0.149.0/io/mod.ts";
 import { tee } from "./tee.ts";
 
 Deno.test("tee", async (t) => {

--- a/denops/@denops-private/worker/script.ts
+++ b/denops/@denops-private/worker/script.ts
@@ -1,4 +1,4 @@
-import { toFileUrl } from "https://deno.land/std@0.140.0/path/mod.ts";
+import { toFileUrl } from "https://deno.land/std@0.149.0/path/mod.ts";
 import {
   assertObject,
   assertString,

--- a/denops/@denops/test.ts
+++ b/denops/@denops/test.ts
@@ -25,7 +25,6 @@ test({
       async () => {
         await denops.call("no-such-function");
       },
-      undefined,
       "E117: Unknown function: no-such-function",
     );
   },
@@ -81,7 +80,6 @@ test({
       async () => {
         await denops.cmd("NoSuchCommand");
       },
-      undefined,
       "E492: Not an editor command: NoSuchCommand",
     );
   },
@@ -109,7 +107,6 @@ test({
       async () => {
         await denops.eval("g:no_such_variable");
       },
-      undefined,
       "g:no_such_variable",
       // Vim:    "E15: Invalid expression: g:no_such_variable",
       // Neovim: "E121: Undefined variable: g:no_such_variable",

--- a/denops/@denops/test.ts
+++ b/denops/@denops/test.ts
@@ -1,8 +1,8 @@
-import * as path from "https://deno.land/std@0.140.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.149.0/path/mod.ts";
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.140.0/testing/asserts.ts";
+} from "https://deno.land/std@0.149.0/testing/asserts.ts";
 import { test } from "./test/tester.ts";
 import { BatchError } from "./mod.ts";
 

--- a/denops/@denops/test/bypass/cli.ts
+++ b/denops/@denops/test/bypass/cli.ts
@@ -1,4 +1,4 @@
-import { copy } from "https://deno.land/std@0.140.0/streams/conversion.ts";
+import { copy } from "https://deno.land/std@0.149.0/streams/conversion.ts";
 import {
   WorkerReader,
   WorkerWriter,

--- a/denops/@denops/test/tester.ts
+++ b/denops/@denops/test/tester.ts
@@ -1,7 +1,7 @@
-import * as path from "https://deno.land/std@0.140.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.149.0/path/mod.ts";
 import { Session } from "https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^";
 import { using } from "https://deno.land/x/disposable@v1.0.2/mod.ts#^";
-import { deadline } from "https://deno.land/std@0.140.0/async/mod.ts";
+import { deadline } from "https://deno.land/std@0.149.0/async/mod.ts";
 import type { Denops, Meta } from "../mod.ts";
 import { DenopsImpl } from "../impl.ts";
 import { DENOPS_TEST_NVIM, DENOPS_TEST_VIM, run } from "./runner.ts";

--- a/denops/@denops/test/tester_test.ts
+++ b/denops/@denops/test/tester_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.140.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.149.0/testing/asserts.ts";
 import { test } from "./tester.ts";
 
 test(


### PR DESCRIPTION
The output of `make update` is

```
/home/runner/work/denops.vim/denops.vim/denops/@denops-private/tracer.ts

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/tee_test.ts
[1/3] Looking for releases: https://deno.land/std@0.142.0/testing/asserts.ts
[1/3] Attempting update: https://deno.land/std@0.142.0/testing/asserts.ts -> 0.149.0
[1/3] Update successful: https://deno.land/std@0.142.0/testing/asserts.ts -> 0.149.0
[2/3] Looking for releases: https://deno.land/std@0.142.0/streams/mod.ts
[2/3] Attempting update: https://deno.land/std@0.142.0/streams/mod.ts -> 0.149.0
[2/3] Update successful: https://deno.land/std@0.142.0/streams/mod.ts -> 0.149.0
[3/3] Looking for releases: https://deno.land/std@0.142.0/io/mod.ts
[3/3] Attempting update: https://deno.land/std@0.142.0/io/mod.ts -> 0.149.0
[3/3] Update successful: https://deno.land/std@0.142.0/io/mod.ts -> 0.149.0

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/service.ts
[1/5] Looking for releases: https://deno.land/x/compare_versions@0.4.0/mod.ts#^
[1/5] Using latest: https://deno.land/x/compare_versions@0.4.0/mod.ts#^
[2/5] Looking for releases: https://deno.land/x/unknownutil@v2.0.0/mod.ts#^
[2/5] Using latest: https://deno.land/x/unknownutil@v2.0.0/mod.ts#^
[3/5] Looking for releases: https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^
[3/5] Using latest: https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^
[4/5] Looking for releases: https://deno.land/x/workerio@v1.4.4/mod.ts#^
[4/5] Using latest: https://deno.land/x/workerio@v1.4.4/mod.ts#^
[5/5] Looking for releases: https://deno.land/x/disposable@v1.0.2/mod.ts#^
[5/5] Using latest: https://deno.land/x/disposable@v1.0.2/mod.ts#^

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/cli.ts
[1/2] Looking for releases: https://deno.land/std@0.140.0/flags/mod.ts
[1/2] Attempting update: https://deno.land/std@0.140.0/flags/mod.ts -> 0.149.0
[1/2] Update successful: https://deno.land/std@0.140.0/flags/mod.ts -> 0.149.0
[2/2] Looking for releases: https://deno.land/x/disposable@v1.0.2/mod.ts#^
[2/2] Using latest: https://deno.land/x/disposable@v1.0.2/mod.ts#^

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/defs.ts

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/worker/script.ts
[1/5] Looking for releases: https://deno.land/std@0.140.0/path/mod.ts
[1/5] Attempting update: https://deno.land/std@0.140.0/path/mod.ts -> 0.149.0
[1/5] Update successful: https://deno.land/std@0.140.0/path/mod.ts -> 0.149.0
[2/5] Looking for releases: https://deno.land/x/unknownutil@v2.0.0/mod.ts#^
[2/5] Using latest: https://deno.land/x/unknownutil@v2.0.0/mod.ts#^
[3/5] Looking for releases: https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^
[3/5] Using latest: https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^
[4/5] Looking for releases: https://deno.land/x/disposable@v1.0.2/mod.ts#^
[4/5] Using latest: https://deno.land/x/disposable@v1.0.2/mod.ts#^
[5/5] Looking for releases: https://deno.land/x/workerio@v1.4.4/mod.ts#^
[5/5] Using latest: https://deno.land/x/workerio@v1.4.4/mod.ts#^

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/tee.ts
[1/2] Looking for releases: https://deno.land/std@0.142.0/io/mod.ts
[1/2] Attempting update: https://deno.land/std@0.142.0/io/mod.ts -> 0.149.0
[1/2] Update successful: https://deno.land/std@0.142.0/io/mod.ts -> 0.149.0
[2/2] Looking for releases: https://deno.land/std@0.142.0/streams/mod.ts
[2/2] Attempting update: https://deno.land/std@0.142.0/streams/mod.ts -> 0.149.0
[2/2] Update successful: https://deno.land/std@0.142.0/streams/mod.ts -> 0.149.0

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/host/nvim.ts
[1/2] Looking for releases: https://deno.land/x/unknownutil@v2.0.0/mod.ts#^
[1/2] Using latest: https://deno.land/x/unknownutil@v2.0.0/mod.ts#^
[2/2] Looking for releases: https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^
[2/2] Using latest: https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/host/vim.ts
[1/2] Looking for releases: https://deno.land/x/vim_channel_command@v0.7.1/mod.ts#^
[1/2] Using latest: https://deno.land/x/vim_channel_command@v0.7.1/mod.ts#^
[2/2] Looking for releases: https://deno.land/x/vim_channel_command@v0.7.1/mod.ts#^
[2/2] Using latest: https://deno.land/x/vim_channel_command@v0.7.1/mod.ts#^

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/host/invoker.ts

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/host/base.ts
[1/1] Looking for releases: https://deno.land/x/disposable@v1.0.2/mod.ts#^
[1/1] Using latest: https://deno.land/x/disposable@v1.0.2/mod.ts#^

/home/runner/work/denops.vim/denops.vim/denops/@denops/mod.ts

/home/runner/work/denops.vim/denops.vim/denops/@denops/impl.ts
[1/1] Looking for releases: https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^
[1/1] Using latest: https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^

/home/runner/work/denops.vim/denops.vim/denops/@denops/test.ts
[1/2] Looking for releases: https://deno.land/std@0.140.0/path/mod.ts
[1/2] Attempting update: https://deno.land/std@0.140.0/path/mod.ts -> 0.149.0
[1/2] Update successful: https://deno.land/std@0.140.0/path/mod.ts -> 0.149.0
[2/2] Looking for releases: https://deno.land/std@0.140.0/testing/asserts.ts
[2/2] Attempting update: https://deno.land/std@0.140.0/testing/asserts.ts -> 0.149.0
[2/2] Update successful: https://deno.land/std@0.140.0/testing/asserts.ts -> 0.149.0

/home/runner/work/denops.vim/denops.vim/denops/@denops/denops.ts

/home/runner/work/denops.vim/denops.vim/denops/@denops/test/mod.ts

/home/runner/work/denops.vim/denops.vim/denops/@denops/test/tester_test.ts
[1/1] Looking for releases: https://deno.land/std@0.140.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.140.0/testing/asserts.ts -> 0.149.0
[1/1] Update successful: https://deno.land/std@0.140.0/testing/asserts.ts -> 0.149.0

/home/runner/work/denops.vim/denops.vim/denops/@denops/test/runner.ts

/home/runner/work/denops.vim/denops.vim/denops/@denops/test/bypass/cli.ts
[1/2] Looking for releases: https://deno.land/std@0.140.0/streams/conversion.ts
[1/2] Attempting update: https://deno.land/std@0.140.0/streams/conversion.ts -> 0.149.0
[1/2] Update successful: https://deno.land/std@0.140.0/streams/conversion.ts -> 0.149.0
[2/2] Looking for releases: https://deno.land/x/workerio@v1.4.4/mod.ts#^
[2/2] Using latest: https://deno.land/x/workerio@v1.4.4/mod.ts#^

/home/runner/work/denops.vim/denops.vim/denops/@denops/test/tester.ts
[1/4] Looking for releases: https://deno.land/std@0.140.0/path/mod.ts
[1/4] Attempting update: https://deno.land/std@0.140.0/path/mod.ts -> 0.149.0
[1/4] Update successful: https://deno.land/std@0.140.0/path/mod.ts -> 0.149.0
[2/4] Looking for releases: https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^
[2/4] Using latest: https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^
[3/4] Looking for releases: https://deno.land/x/disposable@v1.0.2/mod.ts#^
[3/4] Using latest: https://deno.land/x/disposable@v1.0.2/mod.ts#^
[4/4] Looking for releases: https://deno.land/std@0.140.0/async/mod.ts
[4/4] Attempting update: https://deno.land/std@0.140.0/async/mod.ts -> 0.149.0
[4/4] Update successful: https://deno.land/std@0.140.0/async/mod.ts -> 0.149.0

/home/runner/work/denops.vim/denops.vim/denops/@denops/README.md

/home/runner/work/denops.vim/denops.vim/README.md

Already latest version:
https://deno.land/x/compare_versions@0.4.0/mod.ts#^ == 0.4.0
https://deno.land/x/unknownutil@v2.0.0/mod.ts#^ == v2.0.0
https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^ == v3.1.6
https://deno.land/x/workerio@v1.4.4/mod.ts#^ == v1.4.4
https://deno.land/x/disposable@v1.0.2/mod.ts#^ == v1.0.2
https://deno.land/x/disposable@v1.0.2/mod.ts#^ == v1.0.2
https://deno.land/x/unknownutil@v2.0.0/mod.ts#^ == v2.0.0
https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^ == v3.1.6
https://deno.land/x/disposable@v1.0.2/mod.ts#^ == v1.0.2
https://deno.land/x/workerio@v1.4.4/mod.ts#^ == v1.4.4
https://deno.land/x/unknownutil@v2.0.0/mod.ts#^ == v2.0.0
https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^ == v3.1.6
https://deno.land/x/vim_channel_command@v0.7.1/mod.ts#^ == v0.7.1
https://deno.land/x/vim_channel_command@v0.7.1/mod.ts#^ == v0.7.1
https://deno.land/x/disposable@v1.0.2/mod.ts#^ == v1.0.2
https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^ == v3.1.6
https://deno.land/x/workerio@v1.4.4/mod.ts#^ == v1.4.4
https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^ == v3.1.6
https://deno.land/x/disposable@v1.0.2/mod.ts#^ == v1.0.2

Successfully updated:
https://deno.land/std@0.142.0/testing/asserts.ts 0.142.0 -> 0.149.0
https://deno.land/std@0.142.0/streams/mod.ts 0.142.0 -> 0.149.0
https://deno.land/std@0.142.0/io/mod.ts 0.142.0 -> 0.149.0
https://deno.land/std@0.140.0/flags/mod.ts 0.140.0 -> 0.149.0
https://deno.land/std@0.140.0/path/mod.ts 0.140.0 -> 0.149.0
https://deno.land/std@0.142.0/io/mod.ts 0.142.0 -> 0.149.0
https://deno.land/std@0.142.0/streams/mod.ts 0.142.0 -> 0.149.0
https://deno.land/std@0.140.0/path/mod.ts 0.140.0 -> 0.149.0
https://deno.land/std@0.140.0/testing/asserts.ts 0.140.0 -> 0.149.0
https://deno.land/std@0.140.0/testing/asserts.ts 0.140.0 -> 0.149.0
https://deno.land/std@0.140.0/streams/conversion.ts 0.140.0 -> 0.149.0
https://deno.land/std@0.140.0/path/mod.ts 0.140.0 -> 0.149.0
https://deno.land/std@0.140.0/async/mod.ts 0.140.0 -> 0.149.0
make[1]: Entering directory '/home/runner/work/denops.vim/denops.vim'
make[1]: Leaving directory '/home/runner/work/denops.vim/denops.vim'

```