### PR TITLE
:sparkles: Support a Shared server to avoid the bottleneck of process launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,17 @@ Once you've confirmed that denops is working, you can remove
 [deno]: https://deno.land/
 [vim-plug]: https://github.com/junegunn/vim-plug
 
-### Global server
+### Shared server
 
 Normally, a Denops server is started for each Vim/Neovim instance, but there are
 cases where the process startup becomes a bottleneck and impairs usability.
 
-In such cases, launching a "global Denops server" and connecting to it will
-allow all Vim/Neovim instances to use a common Denops server, thus avoiding the
-bottleneck of process launches and possibly improving usability.
+In such cases, launching a "Shared server" and connecting to it will allow all
+Vim/Neovim instances to use a shared server, thus avoiding the bottleneck of
+process launches and possibly improving usability.
 
-To start the global Denops server, execute the following command in the
-denops.vim repository top
+To start the shared server, execute the following command in the denops.vim
+repository top
 
 ```
 deno run -A --unstable --no-check \

--- a/README.md
+++ b/README.md
@@ -57,6 +57,30 @@ Once you've confirmed that denops is working, you can remove
 [deno]: https://deno.land/
 [vim-plug]: https://github.com/junegunn/vim-plug
 
+### Global server
+
+Normally, a Denops server is started for each Vim/Neovim instance, but there are
+cases where the process startup becomes a bottleneck and impairs usability.
+
+In such cases, launching a "global Denops server" and connecting to it will
+allow all Vim/Neovim instances to use a common Denops server, thus avoiding the
+bottleneck of process launches and possibly improving usability.
+
+To start the global Denops server, execute the following command in the
+denops.vim repository top
+
+```
+deno run -A --unstable --no-check \
+	./denops/@denops-private/cli.ts \
+	--hostname 127.0.0.1 --port 32123
+```
+
+Then specify the server address in `g:denops_server_addr` as follows
+
+```vim
+let g:denops_server_addr = '127.0.0.1:32123'
+```
+
 ## Documentations
 
 To learn how to write Vim/Neovim plugins by denops, see

--- a/README.md
+++ b/README.md
@@ -70,9 +70,7 @@ To start the shared server, execute the following command in the denops.vim
 repository top
 
 ```
-deno run -A --unstable --no-check \
-	./denops/@denops-private/cli.ts \
-	--hostname 127.0.0.1 --port 32123
+deno run -A --no-check ./denops/@denops-private/cli.ts
 ```
 
 Then specify the server address in `g:denops_server_addr` as follows

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -29,7 +29,12 @@ function! denops#server#start() abort
   endif
   let args = [g:denops#server#deno, 'run']
   let args += g:denops#server#deno_args
-  let args += [s:script]
+  let args += [
+        \ s:script,
+        \ '--quiet',
+        \ '--identity',
+        \ '--port', '0',
+        \]
   if g:denops#trace
     let args += ['--trace']
   endif
@@ -41,6 +46,7 @@ function! denops#server#start() abort
   let s:job = denops#job#start(args, {
         \ 'env': {
         \   'NO_COLOR': 1,
+        \   'DENO_NO_PROMPT': 1,
         \ },
         \ 'on_stdout': funcref('s:on_stdout'),
         \ 'on_stderr': funcref('s:on_stderr'),

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -17,10 +17,7 @@ function! denops#server#start() abort
   endif
   let args = [g:denops#server#deno, 'run']
   let args += g:denops#server#deno_args
-  let args += [
-        \ s:script,
-        \ '--mode=' . s:engine,
-        \]
+  let args += [s:script]
   if g:denops#trace
     let args += ['--trace']
   endif

--- a/denops/@denops-private/cli.ts
+++ b/denops/@denops-private/cli.ts
@@ -6,6 +6,14 @@ import { Neovim } from "./host/nvim.ts";
 import { TraceReader, TraceWriter } from "./tracer.ts";
 import { tee } from "./tee.ts";
 
+type Opts = {
+  hostname?: string;
+  port?: number;
+  trace?: boolean;
+  quiet?: boolean;
+  identity?: boolean;
+};
+
 type Host = typeof Vim | typeof Neovim;
 
 async function detectHost(reader: Deno.Reader): Promise<Host> {
@@ -19,20 +27,27 @@ async function detectHost(reader: Deno.Reader): Promise<Host> {
   return Neovim;
 }
 
-const opts = parse(Deno.args);
+const { hostname, port, trace, quiet, identity } = parse(Deno.args) as Opts;
 
 const listener = Deno.listen({
-  hostname: opts.hostname ?? "127.0.0.1",
-  port: opts.port ?? 0, // Automatically select free port
+  hostname: hostname ?? "127.0.0.1",
+  port: port ?? 32123,
 });
+const localAddr = listener.addr as Deno.NetAddr;
 
-// Let host know the address
-const addr = listener.addr as Deno.NetAddr;
-console.log(`${addr.hostname}:${addr.port}`);
+if (identity) {
+  console.log(`${localAddr.hostname}:${localAddr.port}`);
+}
+if (!quiet) {
+  console.log(
+    `Listen denops clients on ${localAddr.hostname}:${localAddr.port}`,
+  );
+}
 
 for await (const conn of listener) {
-  const reader = opts.trace ? new TraceReader(conn) : conn;
-  const writer = opts.trace ? new TraceWriter(conn) : conn;
+  const remoteAddr = conn.remoteAddr as Deno.NetAddr;
+  const reader = trace ? new TraceReader(conn) : conn;
+  const writer = trace ? new TraceWriter(conn) : conn;
 
   const [r1, r2] = tee(reader);
 
@@ -40,10 +55,21 @@ for await (const conn of listener) {
   const hostClass = await detectHost(r1);
   r1.close();
 
+  if (!quiet) {
+    console.log(
+      `${remoteAddr.hostname}:${remoteAddr.port} (${hostClass.name}) is connected`,
+    );
+  }
+
   // Create host and service
   using(new hostClass(r2, writer), async (host) => {
     await using(new Service(host), async (service) => {
       await service.waitClosed();
+      if (!quiet) {
+        console.log(
+          `${remoteAddr.hostname}:${remoteAddr.port} (${hostClass.name}) is closed`,
+        );
+      }
     });
   });
 }

--- a/denops/@denops-private/cli.ts
+++ b/denops/@denops-private/cli.ts
@@ -38,6 +38,7 @@ for await (const conn of listener) {
 
   // Detect host from payload
   const hostClass = await detectHost(r1);
+  r1.close();
 
   // Create host and service
   using(new hostClass(r2, writer), async (host) => {

--- a/denops/@denops-private/cli.ts
+++ b/denops/@denops-private/cli.ts
@@ -30,7 +30,6 @@ const listener = Deno.listen({
 const addr = listener.addr as Deno.NetAddr;
 console.log(`${addr.hostname}:${addr.port}`);
 
-const handlers: Promise<void>[] = [];
 for await (const conn of listener) {
   const reader = opts.trace ? new TraceReader(conn) : conn;
   const writer = opts.trace ? new TraceWriter(conn) : conn;
@@ -41,11 +40,8 @@ for await (const conn of listener) {
   const hostClass = await detectHost(r1);
 
   // Create host and service
-  const handler = using(new hostClass(r2, writer), async (host) => {
+  using(new hostClass(r2, writer), async (host) => {
     const service = new Service(host);
     await service.waitClosed();
   });
-  handlers.push(handler);
 }
-// Wait all
-await Promise.all(handlers);

--- a/denops/@denops-private/cli.ts
+++ b/denops/@denops-private/cli.ts
@@ -42,7 +42,8 @@ for await (const conn of listener) {
 
   // Create host and service
   using(new hostClass(r2, writer), async (host) => {
-    const service = new Service(host);
-    await service.waitClosed();
+    await using(new Service(host), async (service) => {
+      await service.waitClosed();
+    });
   });
 }

--- a/denops/@denops-private/cli.ts
+++ b/denops/@denops-private/cli.ts
@@ -22,8 +22,8 @@ async function detectHost(reader: Deno.Reader): Promise<Host> {
 const opts = parse(Deno.args);
 
 const listener = Deno.listen({
-  hostname: "127.0.0.1",
-  port: 0, // Automatically select free port
+  hostname: opts.hostname ?? "127.0.0.1",
+  port: opts.port ?? 0, // Automatically select free port
 });
 
 // Let host know the address

--- a/denops/@denops-private/tee.ts
+++ b/denops/@denops-private/tee.ts
@@ -1,0 +1,43 @@
+import { Buffer } from "https://deno.land/std@0.142.0/io/mod.ts";
+import { writeAll } from "https://deno.land/std@0.142.0/streams/mod.ts";
+
+type Reader = Deno.Reader;
+type ReadCloser = Reader & Deno.Closer;
+
+class Tee<R extends Reader | ReadCloser> {
+  #reader: R;
+  #inner: Buffer;
+  #outer: Buffer;
+
+  constructor(reader: R, inner: Buffer, outer: Buffer) {
+    this.#reader = reader;
+    this.#inner = inner;
+    this.#outer = outer;
+  }
+
+  async read(p: Uint8Array): Promise<number | null> {
+    let n = await this.#inner.read(p);
+    if (n) {
+      return n;
+    }
+    n = await this.#reader.read(p);
+    if (n) {
+      await writeAll(this.#outer, p.subarray(0, n));
+    }
+    return n;
+  }
+
+  close(): void {
+    if ("close" in this.#reader) {
+      this.#reader.close();
+    }
+  }
+}
+
+export function tee<R extends Reader | ReadCloser>(
+  reader: R,
+): [ReadCloser, ReadCloser] {
+  const lhs = new Buffer();
+  const rhs = new Buffer();
+  return [new Tee(reader, lhs, rhs), new Tee(reader, rhs, lhs)];
+}

--- a/denops/@denops-private/tee.ts
+++ b/denops/@denops-private/tee.ts
@@ -4,15 +4,21 @@ import { writeAll } from "https://deno.land/std@0.142.0/streams/mod.ts";
 type Reader = Deno.Reader;
 type ReadCloser = Reader & Deno.Closer;
 
+type Status = {
+  halfClosed: boolean;
+};
+
 class Tee<R extends Reader | ReadCloser> {
   #reader: R;
   #inner: Buffer;
   #outer: Buffer;
+  #status: Status;
 
-  constructor(reader: R, inner: Buffer, outer: Buffer) {
+  constructor(reader: R, inner: Buffer, outer: Buffer, status: Status) {
     this.#reader = reader;
     this.#inner = inner;
     this.#outer = outer;
+    this.#status = status;
   }
 
   async read(p: Uint8Array): Promise<number | null> {
@@ -21,16 +27,20 @@ class Tee<R extends Reader | ReadCloser> {
       return n;
     }
     n = await this.#reader.read(p);
-    if (n) {
+    if (n && !this.#status.halfClosed) {
       await writeAll(this.#outer, p.subarray(0, n));
     }
     return n;
   }
 
   close(): void {
-    if ("close" in this.#reader) {
-      this.#reader.close();
+    if (this.#status.halfClosed) {
+      if ("close" in this.#reader) {
+        this.#reader.close();
+      }
     }
+    this.#status.halfClosed = true;
+    this.#inner.reset();
   }
 }
 
@@ -39,5 +49,6 @@ export function tee<R extends Reader | ReadCloser>(
 ): [ReadCloser, ReadCloser] {
   const lhs = new Buffer();
   const rhs = new Buffer();
-  return [new Tee(reader, lhs, rhs), new Tee(reader, rhs, lhs)];
+  const status = { halfClosed: false };
+  return [new Tee(reader, lhs, rhs, status), new Tee(reader, rhs, lhs, status)];
 }

--- a/denops/@denops-private/tee_test.ts
+++ b/denops/@denops-private/tee_test.ts
@@ -1,0 +1,34 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.142.0/testing/asserts.ts";
+import {
+  readAll,
+  writeAll,
+} from "https://deno.land/std@0.142.0/streams/mod.ts";
+import { Buffer } from "https://deno.land/std@0.142.0/io/mod.ts";
+import { tee } from "./tee.ts";
+
+Deno.test("tee", async (t) => {
+  const encoder = new TextEncoder();
+
+  await t.step("returns tuple of two Deno.Reader & Deno.Closer", () => {
+    const buffer = new Buffer();
+    const [r1, r2] = tee(buffer);
+    assert("read" in r1 && typeof r1.read === "function");
+    assert("read" in r2 && typeof r2.read === "function");
+  });
+
+  await t.step(
+    "each readers are independent copy of the original reader",
+    async () => {
+      const buffer = new Buffer();
+      await writeAll(buffer, encoder.encode("Hello"));
+      await writeAll(buffer, encoder.encode("World"));
+      const [r1, r2] = tee(buffer);
+
+      assertEquals(await readAll(r1), encoder.encode("HelloWorld"));
+      assertEquals(await readAll(r2), encoder.encode("HelloWorld"));
+    },
+  );
+});

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -8,7 +8,7 @@ CONTENTS					*denops-contents*
 
 INTRODUCTION					|denops-introduction|
 USAGE					|denops-usage|
-  GLOBAL SERVER				|denops-global-server|
+  SHARED SERVER				|denops-shared-server|
 INTERFACE				|denops-interface|
   VARIABLE				|denops-variable|
   FUNCTION				|denops-function|
@@ -30,17 +30,17 @@ https://github.com/vim-denops/denops.vim/wiki
 USAGE							*denops-usage*
 
 -----------------------------------------------------------------------------
-GLOBAL SERVER					*denops-global-server*
+SHARED SERVER					*denops-shared-server*
 
 Normally, a Denops server is started for each Vim/Neovim instance, but there 
 are cases where the process startup becomes a bottleneck and impairs usability.
 
-In such cases, launching a "global Denops server" and connecting to it will
-allow all Vim/Neovim instances to use a common Denops server, thus avoiding
-the bottleneck of process launches and possibly improving usability.
+In such cases, launching a "Shared server" and connecting to it will allow all
+Vim/Neovim instances to use a shared server, thus avoiding the bottleneck of
+process launches and possibly improving usability.
 
-To start the global Denops server, execute the following command in the 
-denops.vim repository top
+To start the shared server, execute the following command in the denops.vim 
+repository top
 >
 	deno run -A --unstable --no-check \
 	      ./denops/@denops-private/cli.ts \

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -7,6 +7,8 @@ License: MIT license
 CONTENTS					*denops-contents*
 
 INTRODUCTION					|denops-introduction|
+USAGE					|denops-usage|
+  GLOBAL SERVER				|denops-global-server|
 INTERFACE				|denops-interface|
   VARIABLE				|denops-variable|
   FUNCTION				|denops-function|
@@ -25,6 +27,31 @@ https://github.com/vim-denops/denops.vim/wiki
 
 
 =============================================================================
+USAGE							*denops-usage*
+
+-----------------------------------------------------------------------------
+GLOBAL SERVER					*denops-global-server*
+
+Normally, a Denops server is started for each Vim/Neovim instance, but there 
+are cases where the process startup becomes a bottleneck and impairs usability.
+
+In such cases, launching a "global Denops server" and connecting to it will
+allow all Vim/Neovim instances to use a common Denops server, thus avoiding
+the bottleneck of process launches and possibly improving usability.
+
+To start the global Denops server, execute the following command in the 
+denops.vim repository top
+>
+	deno run -A --unstable --no-check \
+	      ./denops/@denops-private/cli.ts \
+	      --hostname 127.0.0.1 --port 32123
+<
+Then specify the server address in |g:denops_server_addr| as follows
+>
+	let g:denops_server_addr = '127.0.0.1:32123'
+<
+
+=============================================================================
 INTERFACE						*denops-interface*
 
 -----------------------------------------------------------------------------
@@ -34,6 +61,12 @@ VARIABLE						*denops-variable*
 	Disable version check on startup. Use it to forcibly enable denops on
 	non supported versions of Vim/Neovim. Do not report any errors/issues
 	occurred on non supported versions.
+	Default: 0
+
+*g:denops_server_addr*
+	Global denops server address in "{hostname}:{port}" format.
+	If the value is not specified or invalid, denops starts a local denops
+	server for each Vim/Neovim instance.
 	Default: 0
 
 *g:denops#disabled*

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -42,9 +42,7 @@ process launches and possibly improving usability.
 To start the shared server, execute the following command in the denops.vim 
 repository top
 >
-	deno run -A --unstable --no-check \
-	      ./denops/@denops-private/cli.ts \
-	      --hostname 127.0.0.1 --port 32123
+	deno run -A --no-check ./denops/@denops-private/cli.ts
 <
 Then specify the server address in |g:denops_server_addr| as follows
 >

--- a/plugin/denops.vim
+++ b/plugin/denops.vim
@@ -24,11 +24,22 @@ augroup denops_plugin_internal
   autocmd User DenopsPluginPost:* :
 augroup END
 
+function! s:init() abort
+  let addr = get(g:, 'denops_server_addr')
+  if !empty(addr)
+    if denops#server#connect(addr)
+      return
+    endif
+    " Fallback to a local denops server
+  endif
+  call denops#server#start()
+endfunction
+
 if has('vim_starting')
   augroup denops_plugin_internal_startup
     autocmd!
-    autocmd VimEnter * call denops#server#start()
+    autocmd VimEnter * call s:init()
   augroup END
 else
-  call denops#server#start()
+  call s:init()
 endif


### PR DESCRIPTION
# Usage

Start denops global server as follow

```
deno run -A --no-check ./denops/@denops-private/cli.ts
```

Then specify the address to `g:denops_server_addr` prior to Vim startup like

```vim
let g:denops_server_addr = '127.0.0.1:32123'
```

# Difference

Thanks to @ippachi at vim-jp slack.

##### Before

https://user-images.githubusercontent.com/546312/172044580-7e2419e7-48f5-419b-b098-35e22bf36208.mov

##### After

https://user-images.githubusercontent.com/546312/172044587-cdb47636-beec-41cf-a46f-4c6de81cca40.mov






