### PR TITLE
Add `context` attribute for plugins

### DIFF
--- a/denops/@denops/denops.ts
+++ b/denops/@denops/denops.ts
@@ -55,6 +55,11 @@ export interface Denops {
   readonly meta: Meta;
 
   /**
+   * Context object for plugins.
+   */
+  readonly context: Record<string | number | symbol, unknown>;
+
+  /**
    * User defined API name and method map which is used to dispatch API request
    */
   dispatcher: Dispatcher;

--- a/denops/@denops/impl.ts
+++ b/denops/@denops/impl.ts
@@ -4,6 +4,7 @@ import { BatchError, Context, Denops, Dispatcher, Meta } from "./mod.ts";
 export class DenopsImpl implements Denops {
   readonly name: string;
   readonly meta: Meta;
+  readonly context: Record<string | number | symbol, unknown>;
   #session: Session;
 
   constructor(
@@ -13,6 +14,7 @@ export class DenopsImpl implements Denops {
   ) {
     this.name = name;
     this.meta = meta;
+    this.context = {};
     this.#session = session;
   }
 


### PR DESCRIPTION
Now plugins can use `denops.context` for an instance cache or whatever.