### PR TITLE
Add `redraw()` to `denops` for Vim

### DIFF
--- a/denops/@denops-private/host/base.ts
+++ b/denops/@denops-private/host/base.ts
@@ -6,6 +6,11 @@ import { Invoker } from "./invoker.ts";
  */
 export interface Host extends Disposable {
   /**
+   * Redraw text and cursor on Vim but Neovim.
+   */
+  redraw(force?: boolean): Promise<void>;
+
+  /**
    * Call host function and return result
    */
   call(fn: string, ...args: unknown[]): Promise<unknown>;

--- a/denops/@denops-private/host/nvim.ts
+++ b/denops/@denops-private/host/nvim.ts
@@ -19,6 +19,11 @@ export class Neovim implements Host {
     });
   }
 
+  redraw(_force?: boolean): Promise<void> {
+    // Do NOTHING on Neovim
+    return Promise.resolve();
+  }
+
   call(fn: string, ...args: unknown[]): Promise<unknown> {
     return this.#session.call("nvim_call_function", fn, args);
   }

--- a/denops/@denops-private/host/vim.ts
+++ b/denops/@denops-private/host/vim.ts
@@ -20,6 +20,10 @@ export class Vim implements Host {
     });
   }
 
+  redraw(force?: boolean): Promise<void> {
+    return this.#session.redraw(force);
+  }
+
   async call(fn: string, ...args: unknown[]): Promise<unknown> {
     const [ret, err] = await this.#session.call(
       "denops#api#vim#call",

--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -1,9 +1,11 @@
 import { compareVersions } from "https://deno.land/x/compare_versions@0.4.0/mod.ts#^";
 import {
   assertArray,
+  assertBoolean,
   assertString,
   isArray,
   isString,
+  isUndefined,
 } from "https://deno.land/x/unknownutil@v2.0.0/mod.ts#^";
 import {
   Dispatcher as SessionDispatcher,
@@ -89,6 +91,10 @@ export class Service implements ServiceApi, Disposable {
     });
   }
 
+  redraw(force?: boolean): Promise<void> {
+    return this.#host.redraw(force);
+  }
+
   async call(fn: string, ...args: unknown[]): Promise<unknown> {
     return await this.#host.call(fn, ...args);
   }
@@ -147,6 +153,13 @@ function buildServiceSession(
   options?: SessionOptions,
 ) {
   const dispatcher: SessionDispatcher = {
+    redraw: async (force) => {
+      if (!isUndefined(force)) {
+        assertBoolean(force);
+      }
+      return await service.redraw(force);
+    },
+
     call: async (fn, ...args) => {
       assertString(fn);
       assertArray(args);

--- a/denops/@denops/denops.ts
+++ b/denops/@denops/denops.ts
@@ -65,6 +65,16 @@ export interface Denops {
   dispatcher: Dispatcher;
 
   /**
+   * Redraw text and cursor on Vim.
+   *
+   * It's not equivalent to `redraw` command on Vim script and does nothing on Neovim.
+   * Use `denops.cmd('redraw')` instead if you need to execute `redraw` command.
+   *
+   * @param force: Clear screen prior to redraw.
+   */
+  redraw(force?: boolean): Promise<void>;
+
+  /**
    * Call an arbitrary function of Vim/Neovim and return the result
    *
    * @param fn: A function name of Vim/Neovim.

--- a/denops/@denops/impl.ts
+++ b/denops/@denops/impl.ts
@@ -26,6 +26,10 @@ export class DenopsImpl implements Denops {
     this.#session.dispatcher = dispatcher;
   }
 
+  async redraw(force?: boolean): Promise<void> {
+    await this.#session.call("redraw", force);
+  }
+
   async call(fn: string, ...args: unknown[]): Promise<unknown> {
     return await this.#session.call("call", fn, ...normArgs(args));
   }


### PR DESCRIPTION
It seems `redraw` channel command is NOT equivalent to `redraw` command and is required to be invoked on Vim to ensure the correct cursor position.

https://vim-jp.slack.com/archives/C01N4L5362D/p1661433257297529