### PR TITLE
:coffee: Upgrade `actions/cache` to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: "${{ matrix.version }}"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ env.DENO_DIR }}
           key: ${{ runner.os }}-deno-${{ matrix.version }}-${{ hashFiles('**/*.ts') }}
@@ -80,7 +80,7 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: "${{ matrix.version }}"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache
         with:
           path: ${{ env.DENO_DIR }}


### PR DESCRIPTION
To avoid Node.js 12 actions are deprecated warning