### PR TITLE
Fixed DenopsStopped event firing and reconnect to shared servers

### DIFF
--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -228,11 +228,18 @@ else
           \ 'drop': 'auto',
           \ 'noblock': 1,
           \ 'timeout': 1000 * 60 * 60 * 24 * 7,
+          \ 'close_cb': funcref('s:on_channel_close'),
           \})
     if ch_status(chan) !=# 'open'
       throw printf('Failed to connect `%s`', a:address)
     endif
     return chan
+  endfunction
+
+  function! s:on_channel_close(chan) abort
+    if s:chan is# a:chan
+      call s:on_exit(0)
+    endif
   endfunction
 
   function! s:notify(chan, method, params) abort

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -131,6 +131,7 @@ function! s:on_exit(status, ...) abort
   if s:job is# v:null && s:chan is# v:null
     return
   endif
+  let is_local_server = s:job isnot# v:null
   let s:job = v:null
   let s:chan = v:null
   call denops#util#debug(printf('Server stopped: %s', a:status))
@@ -139,7 +140,7 @@ function! s:on_exit(status, ...) abort
     return
   endif
   let addr = get(g:, 'denops_server_addr')
-  if empty(addr)
+  if is_local_server || empty(addr)
     " Restart asynchronously to avoid #136
     call timer_start(g:denops#server#restart_delay, { -> s:restart(a:status) })
   else " reconnect

--- a/denops/@denops-private/cli.ts
+++ b/denops/@denops-private/cli.ts
@@ -1,6 +1,8 @@
+import { deadline } from "https://deno.land/std@0.149.0/async/mod.ts";
 import { parse } from "https://deno.land/std@0.149.0/flags/mod.ts";
 import { using } from "https://deno.land/x/disposable@v1.0.2/mod.ts#^";
 import { Service } from "./service.ts";
+import { HostContainer } from "./host/host_container.ts";
 import { Vim } from "./host/vim.ts";
 import { Neovim } from "./host/nvim.ts";
 import { TraceReader, TraceWriter } from "./tracer.ts";
@@ -27,6 +29,57 @@ async function detectHost(reader: Deno.Reader): Promise<Host> {
   return Neovim;
 }
 
+/**
+ * Register signals for graceful termination
+ */
+function registerSignals(
+  listener: Deno.Listener,
+  hosts: HostContainer,
+) {
+  const signals: ReadonlyArray<readonly [Deno.Signal, number]> = [
+    ["SIGINT", 2],
+    ...(
+      Deno.build.os === "windows"
+        ? [
+          // SIGBREAK was added from Deno version 1.23
+          ["SIGBREAK" as Deno.Signal, 21],
+        ] as const
+        : [
+          ["SIGTERM", 15],
+        ] as const
+    ),
+  ];
+
+  const terminate_timeout = 2000;
+
+  const unregister = signals.map(([sigid, signum]) => {
+    const handler = () => signalHandler(signum);
+    try {
+      Deno.addSignalListener(sigid, handler);
+    } catch (_) {
+      return () => {}; // not implemented, so do nothing
+    }
+    return () => Deno.removeSignalListener(sigid, handler);
+  });
+
+  function signalHandler(signum: number) {
+    if (!quiet) {
+      console.error(`Terminate by signal ${signum}`);
+    }
+
+    // Unregister all signals, so a second signal kills the server immediately
+    unregister.forEach((u) => u());
+
+    // Disable new connection
+    listener.close();
+
+    const reason = 128 + signum;
+    deadline(hosts.terminate(reason), terminate_timeout).finally(() =>
+      Deno.exit(reason)
+    );
+  }
+}
+
 const { hostname, port, trace, quiet, identity } = parse(Deno.args) as Opts;
 
 const listener = Deno.listen({
@@ -43,6 +96,10 @@ if (!quiet) {
     `Listen denops clients on ${localAddr.hostname}:${localAddr.port}`,
   );
 }
+
+const hosts = new HostContainer();
+
+registerSignals(listener, hosts);
 
 for await (const conn of listener) {
   const remoteAddr = conn.remoteAddr as Deno.NetAddr;
@@ -63,13 +120,18 @@ for await (const conn of listener) {
 
   // Create host and service
   using(new hostClass(r2, writer), async (host) => {
-    await using(new Service(host), async (service) => {
-      await service.waitClosed();
+    hosts.add(host);
+    try {
+      await using(new Service(host), async (service) => {
+        await service.waitClosed();
+      });
+    } finally {
+      hosts.delete(host);
       if (!quiet) {
         console.log(
           `${remoteAddr.hostname}:${remoteAddr.port} (${hostClass.name}) is closed`,
         );
       }
-    });
+    }
   });
 }

--- a/denops/@denops-private/host/host_container.ts
+++ b/denops/@denops-private/host/host_container.ts
@@ -1,0 +1,36 @@
+import { deferred } from "https://deno.land/x/msgpack_rpc@v3.1.6/deps.ts";
+import { Host } from "./base.ts";
+
+export class HostContainer {
+  readonly #container: Set<Host> = new Set();
+  #cleared = deferred<void>();
+
+  get size() {
+    return this.#container.size;
+  }
+
+  add(host: Host): void {
+    this.#container.add(host);
+  }
+
+  delete(host: Host): void {
+    this.#container.delete(host);
+    if (this.#container.size === 0) {
+      this.#cleared.resolve();
+    }
+  }
+
+  async terminate(reason: number): Promise<void> {
+    if (this.#container.size > 0) {
+      this.#cleared = deferred<void>();
+      await Promise.allSettled(
+        Array.from(this.#container).map((host) =>
+          host.call("denops#server#_on_exit", reason).finally(() =>
+            host.dispose()
+          )
+        ),
+      );
+      await this.#cleared;
+    }
+  }
+}

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -351,7 +351,8 @@ DenopsStarted						*DenopsStarted*
 	Invoked when a denops server is started.
 
 DenopsStopped						*DenopsStopped*
-	Invoked when a denops server is stopped.
+	Invoked when a denops server is stopped or disconnected from a
+	|denops-shared-server|.
 
 =============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -131,6 +131,11 @@ VARIABLE						*denops-variable*
 	The number of restart count within |g:denops#server#restart_interval|.
 	Default: 3
 
+*g:denops#server#reconnect_delay*
+	Reconnect delay in milliseconds. This is the time to wait for the
+	shared server to restart.
+	Default: 1000
+
 *g:denops#server#reconnect_interval*
 	Interval in milliseconds before retry connection to the server.
 	Default: 100


### PR DESCRIPTION
Fixed `DenopsStopped` event not firing correctly.

Before PR:
- When internal server is stopped, `DenopsStopped` event is fired and restart server.
- When internal server connection is closed (but process is running), no event is fired. 
- When shared server is stopped or connection is closed, no event is fired.

This PR:
- When internal server is stopped or connection is closed, `DenopsStopped` event is fired and restart server.
- When shared server is stopped or connection is closed, `DenopsStopped` event is fired and reconnect to server.

## Limitation

Event firing and reconnecting (or restarting) will not work if all of the following conditions are met:

- Using shared server.
- Using Windows (Not a WSL).
- Using NeoVim.
- Using Deno version less than 1.23.0, or using Deno version less than 1.27.2.20221109 installed with Chocolatey.

<del>
On Windows, This feature requires deno v1.23.0 or later.<br>
Can we update the deno minimum version?
</del>

[Keep the minimum version.](#issuecomment-1302842013)