### PR TITLE
:muscle: Refine features in `util` as internal modules and make them deprecated

### DIFF
--- a/autoload/denops.vim
+++ b/autoload/denops.vim
@@ -7,13 +7,13 @@ function! denops#request(plugin, method, params) abort
 endfunction
 
 function! denops#request_async(plugin, method, params, success, failure) abort
-  let success = denops#callback#register(a:success, {
+  let l:success = denops#callback#register(a:success, {
         \ 'once': v:true,
         \})
-  let failure = denops#callback#register(a:failure, {
+  let l:failure = denops#callback#register(a:failure, {
         \ 'once': v:true,
         \})
-  return denops#server#request('invoke', ['dispatchAsync', [a:plugin, a:method, a:params, success, failure]])
+  return denops#server#request('invoke', ['dispatchAsync', [a:plugin, a:method, a:params, l:success, l:failure]])
 endfunction
 
 function! s:define(name, default) abort

--- a/autoload/denops.vim
+++ b/autoload/denops.vim
@@ -26,6 +26,7 @@ call s:define('denops#deno', 'deno')
 call s:define('denops#debug', 0)
 call s:define('denops#trace', 0)
 call s:define('denops#type_check', 0)
+call s:define('denops#disable_deprecation_warning_message', 0)
 
 " Internal configuration
 call s:define('denops#_test', 0)

--- a/autoload/denops/_internal/echo.vim
+++ b/autoload/denops/_internal/echo.vim
@@ -1,0 +1,14 @@
+function! denops#_internal#echo#deprecate(...) abort
+  if g:denops#disable_deprecation_warning_message
+    return
+  endif
+  call s:echomsg('WarningMsg', a:000)
+endfunction
+
+function! s:echomsg(hl, msg) abort
+  execute printf('echohl %s', a:hl)
+  for l:line in split(a:msg, '\n')
+    echomsg printf('[denops] %s', l:line)
+  endfor
+  echohl None
+endfunction

--- a/autoload/denops/_internal/echo.vim
+++ b/autoload/denops/_internal/echo.vim
@@ -5,9 +5,28 @@ function! denops#_internal#echo#deprecate(...) abort
   call s:echomsg('WarningMsg', a:000)
 endfunction
 
+function! denops#_internal#echo#debug(...) abort
+  if !g:denops#debug
+    return
+  endif
+  call s:echomsg('Comment', a:000)
+endfunction
+
+function! denops#_internal#echo#info(...) abort
+  call s:echomsg('None', a:000)
+endfunction
+
+function! denops#_internal#echo#warn(...) abort
+  call s:echomsg('WarningMsg', a:000)
+endfunction
+
+function! denops#_internal#echo#error(...) abort
+  call s:echomsg('ErrorMsg', a:000)
+endfunction
+
 function! s:echomsg(hl, msg) abort
   execute printf('echohl %s', a:hl)
-  for l:line in split(a:msg, '\n')
+  for l:line in split(join(a:msg), '\n')
     echomsg printf('[denops] %s', l:line)
   endfor
   echohl None

--- a/autoload/denops/_internal/job.vim
+++ b/autoload/denops/_internal/job.vim
@@ -1,4 +1,4 @@
-function! denops#job#start(args, ...) abort
+function! denops#_internal#job#start(args, ...) abort
   let l:options = extend({
         \ 'pty': 0,
         \ 'env': {},
@@ -11,7 +11,7 @@ function! denops#job#start(args, ...) abort
   return s:start(a:args, l:options)
 endfunction
 
-function! denops#job#stop(job) abort
+function! denops#_internal#job#stop(job) abort
   call s:stop(a:job)
 endfunction
 
@@ -78,4 +78,3 @@ else
     call a:callback(a:status)
   endfunction
 endif
-

--- a/autoload/denops/_internal/meta.vim
+++ b/autoload/denops/_internal/meta.vim
@@ -1,0 +1,30 @@
+function! denops#_internal#meta#get() abort
+  let l:mode = g:denops#_test ? 'test' : g:denops#debug ? 'debug' : 'release'
+  let s:meta = exists('s:meta') ? s:meta : s:get()
+  return extend({'mode': l:mode}, s:meta, 'keep')
+endfunction
+
+function! s:get() abort
+  let l:host = has('nvim') ? 'nvim' : 'vim'
+  let l:version = s:get_host_version()
+  let l:platform = has('win32') ? 'windows' : has('mac') ? 'mac' : 'linux'
+  return {
+        \ 'host': l:host,
+        \ 'version': l:version,
+        \ 'platform': l:platform,
+        \}
+endfunction
+
+if has('nvim')
+  function! s:get_host_version() abort
+    let l:output = execute('version')
+    return matchstr(l:output, 'NVIM v\zs[0-9.]\+')
+  endfunction
+else
+  function! s:get_host_version() abort
+    let l:output = execute('version')
+    let l:major = matchstr(l:output, 'Vi IMproved \zs[0-9.]\+')
+    let l:patch = matchstr(l:output, 'Included patches: [0-9]\+-\zs[0-9]\+')
+    return printf('%s.%s', l:major, l:patch)
+  endfunction
+endif

--- a/autoload/denops/_internal/path.vim
+++ b/autoload/denops/_internal/path.vim
@@ -1,0 +1,32 @@
+let s:sep = has('win32') ? '\' : '/'
+let s:root = expand('<sfile>:h:h:h:h')
+
+function! denops#_internal#path#join(paths) abort
+  return join(a:paths, s:sep)
+endfunction
+
+function! denops#_internal#path#norm(path) abort
+  return s:norm(a:path)
+endfunction
+
+function! denops#_internal#path#script(paths) abort
+  return s:script(a:paths)
+endfunction
+
+if has('win32unix')
+  function! s:norm(path) abort
+    return trim(system(printf("cygpath -m '%s'", a:path)))
+  endfunction
+
+  function! s:script(paths) abort
+    return s:norm(denops#_internal#path#join([s:root, 'denops'] + a:paths))
+  endfunction
+else
+  function! s:norm(path) abort
+    return a:path
+  endfunction
+
+  function! s:script(paths) abort
+    return denops#_internal#path#join([s:root, 'denops'] + a:paths)
+  endfunction
+endif

--- a/autoload/denops/_internal/wait.vim
+++ b/autoload/denops/_internal/wait.vim
@@ -1,0 +1,38 @@
+function! denops#_internal#wait#for(timeout, condition, interval) abort
+  let l:timeout = g:denops#_internal#wait#timeout
+  let l:timer = timer_start(l:timeout, { -> s:warn_wait(l:timeout) })
+  try
+    return s:wait(a:timeout, a:condition, a:interval)
+  finally
+    silent! call timer_stop(l:timer)
+  endtry
+endfunction
+
+function! s:warn_wait(timeout) abort
+  let l:m = printf(
+        \ 'It tooks more than %d ms. Use Ctrl-C to cancel.',
+        \ a:timeout,
+        \)
+  call denops#_internal#echo#warn(l:m)
+endfunction
+
+if exists('*wait')
+  let s:wait = function('wait')
+else
+  function! s:wait(timeout, condition, interval) abort
+    let l:waiter = printf('sleep %dm', a:interval)
+    let l:s = reltime()
+    try
+      while !a:condition()
+        if reltimefloat(reltime(l:s)) * 1000 > a:timeout
+          return -1
+        endif
+        execute l:waiter
+      endwhile
+    catch /^Vim:Interrupt$/
+      return -2
+    endtry
+  endfunction
+endif
+
+let g:denops#_internal#wait#timeout = get(g:, 'denops#_internal#wait#timeout', 5000)

--- a/autoload/denops/api/vim.vim
+++ b/autoload/denops/api/vim.vim
@@ -4,12 +4,12 @@
 " https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
 function! denops#api#vim#call(fn, args) abort
   try
-    let result = call(a:fn, a:args)
+    let l:result = call(a:fn, a:args)
     if g:denops#debug
       " Check if the result is serializable
-      call json_encode(result)
+      call json_encode(l:result)
     endif
-    return [result, '']
+    return [l:result, '']
   catch
     return [v:null, v:exception . "\n" . v:throwpoint]
   endtry
@@ -20,17 +20,17 @@ endfunction
 " above SILENCE any errors occurred in `call` channel command.
 " https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
 function! denops#api#vim#batch(calls) abort
-  let results = []
+  let l:results = []
   try
     for l:Call in a:calls
-      call add(results, call(Call[0], Call[1:]))
+      call add(l:results, call(l:Call[0], l:Call[1:]))
     endfor
     if g:denops#debug
       " Check if the result is serializable
-      call json_encode(results)
+      call json_encode(l:results)
     endif
-    return [results, '']
+    return [l:results, '']
   catch
-    return [results, v:exception . "\n" . v:throwpoint]
+    return [l:results, v:exception . "\n" . v:throwpoint]
   endtry
 endfunction

--- a/autoload/denops/callback.vim
+++ b/autoload/denops/callback.vim
@@ -1,16 +1,16 @@
 let s:registry = {}
 
 function! denops#callback#register(callback, ...) abort
-  let options = extend({
+  let l:options = extend({
         \ 'once': v:false,
         \}, a:0 ? a:1 : {},
         \)
-  let id = sha256(string(a:callback))
-  let s:registry[id] = {
+  let l:id = sha256(string(a:callback))
+  let s:registry[l:id] = {
         \ 'callback': a:callback,
-        \ 'options': options,
+        \ 'options': l:options,
         \}
-  return id
+  return l:id
 endfunction
 
 function! denops#callback#unregister(id) abort
@@ -24,12 +24,12 @@ function! denops#callback#call(id, ...) abort
   if !has_key(s:registry, a:id)
     throw printf('No callback function for %s exist', a:id)
   endif
-  let entry = s:registry[a:id]
-  let ret = call(entry.callback, a:000)
-  if entry.options.once
+  let l:entry = s:registry[a:id]
+  let l:ret = call(l:entry.callback, a:000)
+  if l:entry.options.once
     call denops#callback#unregister(a:id)
   endif
-  return ret
+  return l:ret
 endfunction
 
 function! denops#callback#clear() abort

--- a/autoload/denops/job.vim
+++ b/autoload/denops/job.vim
@@ -1,5 +1,5 @@
 function! denops#job#start(args, ...) abort
-  let options = extend({
+  let l:options = extend({
         \ 'pty': 0,
         \ 'env': {},
         \ 'on_stdout': { -> 0 },
@@ -8,7 +8,7 @@ function! denops#job#start(args, ...) abort
         \ 'raw_options': {},
         \}, a:0 ? a:1 : {},
         \)
-  return s:start(a:args, options)
+  return s:start(a:args, l:options)
 endfunction
 
 function! denops#job#stop(job) abort
@@ -17,14 +17,14 @@ endfunction
 
 if has('nvim')
   function! s:start(args, options) abort
-    let options = extend({
+    let l:options = extend({
           \ 'pty': a:options.pty,
           \ 'env': a:options.env,
           \ 'on_stdout': funcref('s:on_recv', [a:options.on_stdout]),
           \ 'on_stderr': funcref('s:on_recv', [a:options.on_stderr]),
           \ 'on_exit': funcref('s:on_exit', [a:options.on_exit]),
           \}, a:options.raw_options)
-    return jobstart(a:args, options)
+    return jobstart(a:args, l:options)
   endfunction
 
   function! s:stop(job) abort
@@ -49,7 +49,7 @@ else
   let s:KILL_TIMEOUT_MS = 2000
 
   function! s:start(args, options) abort
-    let options = extend({
+    let l:options = extend({
           \ 'noblock': 1,
           \ 'pty': a:options.pty,
           \ 'env': a:options.env,
@@ -57,7 +57,7 @@ else
           \ 'err_cb': funcref('s:out_cb', [a:options.on_stderr]),
           \ 'exit_cb': funcref('s:exit_cb', [a:options.on_exit]),
           \}, a:options.raw_options)
-    return job_start(a:args, options)
+    return job_start(a:args, l:options)
   endfunction
 
   function! s:stop(job) abort

--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -24,7 +24,7 @@ function! denops#plugin#wait(plugin, ...) abort
   if has_key(s:loaded_plugins, a:plugin)
     return s:loaded_plugins[a:plugin]
   endif
-  let l:ret = denops#util#wait(
+  let l:ret = denops#_internal#wait#for(
         \ l:options.timeout,
         \ { -> has_key(s:loaded_plugins, a:plugin) },
         \ l:options.interval,

--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -14,7 +14,7 @@ function! denops#plugin#wait(plugin, ...) abort
         \)
   if denops#server#status() ==# 'stopped'
     if !l:options.silent
-      call denops#util#error(printf(
+      call denops#_internal#echo#error(printf(
             \ 'Failed to wait for "%s" to start. Denops server itself is not started.',
             \ a:plugin,
             \))
@@ -31,7 +31,7 @@ function! denops#plugin#wait(plugin, ...) abort
         \)
   if l:ret is# -1
     if !l:options.silent
-      call denops#util#error(printf(
+      call denops#_internal#echo#error(printf(
             \ 'Failed to wait for "%s" to start. It took more than %d milliseconds and timed out.',
             \ a:plugin,
             \ l:options.timeout,
@@ -78,7 +78,7 @@ function! denops#plugin#discover(...) abort
         \})
   let l:plugins = {}
   call s:gather_plugins(l:plugins)
-  call denops#util#debug(printf('%d plugins are discovered', len(l:plugins)))
+  call denops#_internal#echo#debug(printf('%d plugins are discovered', len(l:plugins)))
   for [l:plugin, l:script] in items(l:plugins)
     call s:register(l:plugin, l:script, l:meta, l:options)
   endfor
@@ -105,7 +105,7 @@ endfunction
 function! s:register(plugin, script, meta, options) abort
   let l:script = denops#util#normalize_path(a:script)
   let l:args = [a:plugin, l:script, a:meta, a:options]
-  call denops#util#debug(printf('register plugin: %s', l:args))
+  call denops#_internal#echo#debug(printf('register plugin: %s', l:args))
   return denops#server#request('invoke', ['register', l:args])
 endfunction
 

--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -85,7 +85,7 @@ function! denops#plugin#discover(...) abort
 endfunction
 
 function! s:gather_plugins(plugins) abort
-  for l:script in globpath(&runtimepath, denops#util#join_path('denops', '*', 'main.ts'), 1, 1, 1)
+  for l:script in globpath(&runtimepath, denops#_internal#path#join(['denops', '*', 'main.ts']), 1, 1, 1)
     let l:plugin = fnamemodify(l:script, ':h:t')
     if l:plugin[:0] ==# '@' || has_key(a:plugins, l:plugin)
       continue
@@ -103,14 +103,14 @@ function! s:options(base, default) abort
 endfunction
 
 function! s:register(plugin, script, meta, options) abort
-  let l:script = denops#util#normalize_path(a:script)
+  let l:script = denops#_internal#path#norm(a:script)
   let l:args = [a:plugin, l:script, a:meta, a:options]
   call denops#_internal#echo#debug(printf('register plugin: %s', l:args))
   return denops#server#request('invoke', ['register', l:args])
 endfunction
 
 function! s:find_plugin(plugin) abort
-  for l:script in globpath(&runtimepath, denops#util#join_path('denops', a:plugin, 'main.ts'), 1, 1, 1)
+  for l:script in globpath(&runtimepath, denops#_internal#path#join(['denops', a:plugin, 'main.ts']), 1, 1, 1)
     let l:plugin = fnamemodify(l:script, ':h:t')
     if l:plugin[:0] ==# '@' || !filereadable(l:script)
       continue

--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -64,7 +64,7 @@ function! denops#plugin#register(plugin, ...) abort
     let l:script = a:1
     let l:options = a:0 > 1 ? a:2 : {}
   endif
-  let l:meta = denops#util#meta()
+  let l:meta = denops#_internal#meta#get()
   let l:options = s:options(l:options, {
         \ 'mode': 'error',
         \})
@@ -72,7 +72,7 @@ function! denops#plugin#register(plugin, ...) abort
 endfunction
 
 function! denops#plugin#discover(...) abort
-  let l:meta = denops#util#meta()
+  let l:meta = denops#_internal#meta#get()
   let l:options = s:options(a:0 > 0 ? a:1 : {}, {
         \ 'mode': 'skip',
         \})

--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -6,14 +6,14 @@ function! denops#plugin#is_loaded(plugin) abort
 endfunction
 
 function! denops#plugin#wait(plugin, ...) abort
-  let options = extend({
+  let l:options = extend({
         \ 'interval': g:denops#plugin#wait_interval,
         \ 'timeout': g:denops#plugin#wait_timeout,
         \ 'silent': 0,
         \}, a:0 ? a:1 : {},
         \)
   if denops#server#status() ==# 'stopped'
-    if !options.silent
+    if !l:options.silent
       call denops#util#error(printf(
             \ 'Failed to wait for "%s" to start. Denops server itself is not started.',
             \ a:plugin,
@@ -24,17 +24,17 @@ function! denops#plugin#wait(plugin, ...) abort
   if has_key(s:loaded_plugins, a:plugin)
     return s:loaded_plugins[a:plugin]
   endif
-  let ret = denops#util#wait(
-        \ options.timeout,
+  let l:ret = denops#util#wait(
+        \ l:options.timeout,
         \ { -> has_key(s:loaded_plugins, a:plugin) },
-        \ options.interval,
+        \ l:options.interval,
         \)
-  if ret is# -1
-    if !options.silent
+  if l:ret is# -1
+    if !l:options.silent
       call denops#util#error(printf(
             \ 'Failed to wait for "%s" to start. It took more than %d milliseconds and timed out.',
             \ a:plugin,
-            \ options.timeout,
+            \ l:options.timeout,
             \))
     endif
     return -1
@@ -51,98 +51,98 @@ function! denops#plugin#wait_async(plugin, callback) abort
     call timer_start(0, { -> a:callback() })
     return
   endif
-  let callbacks = get(s:load_callbacks, a:plugin, [])
-  call add(callbacks, a:callback)
-  let s:load_callbacks[a:plugin] = callbacks
+  let l:callbacks = get(s:load_callbacks, a:plugin, [])
+  call add(l:callbacks, a:callback)
+  let s:load_callbacks[a:plugin] = l:callbacks
 endfunction
 
 function! denops#plugin#register(plugin, ...) abort
   if a:0 is# 0 || type(a:1) is# v:t_dict
-    let options = a:0 > 0 ? a:1 : {}
-    let script = s:find_plugin(a:plugin)
+    let l:options = a:0 > 0 ? a:1 : {}
+    let l:script = s:find_plugin(a:plugin)
   else
-    let script = a:1
-    let options = a:0 > 1 ? a:2 : {}
+    let l:script = a:1
+    let l:options = a:0 > 1 ? a:2 : {}
   endif
-  let meta = denops#util#meta()
-  let options = s:options(options, {
+  let l:meta = denops#util#meta()
+  let l:options = s:options(l:options, {
         \ 'mode': 'error',
         \})
-  return s:register(a:plugin, script, meta, options)
+  return s:register(a:plugin, l:script, l:meta, l:options)
 endfunction
 
 function! denops#plugin#discover(...) abort
-  let meta = denops#util#meta()
-  let options = s:options(a:0 > 0 ? a:1 : {}, {
+  let l:meta = denops#util#meta()
+  let l:options = s:options(a:0 > 0 ? a:1 : {}, {
         \ 'mode': 'skip',
         \})
-  let plugins = {}
-  call s:gather_plugins(plugins)
-  call denops#util#debug(printf('%d plugins are discovered', len(plugins)))
-  for [plugin, script] in items(plugins)
-    call s:register(plugin, script, meta, options)
+  let l:plugins = {}
+  call s:gather_plugins(l:plugins)
+  call denops#util#debug(printf('%d plugins are discovered', len(l:plugins)))
+  for [l:plugin, l:script] in items(l:plugins)
+    call s:register(l:plugin, l:script, l:meta, l:options)
   endfor
 endfunction
 
 function! s:gather_plugins(plugins) abort
-  for script in globpath(&runtimepath, denops#util#join_path('denops', '*', 'main.ts'), 1, 1, 1)
-    let plugin = fnamemodify(script, ':h:t')
-    if plugin[:0] ==# '@' || has_key(a:plugins, plugin)
+  for l:script in globpath(&runtimepath, denops#util#join_path('denops', '*', 'main.ts'), 1, 1, 1)
+    let l:plugin = fnamemodify(l:script, ':h:t')
+    if l:plugin[:0] ==# '@' || has_key(a:plugins, l:plugin)
       continue
     endif
-    call extend(a:plugins, { plugin : script })
+    call extend(a:plugins, { l:plugin : l:script })
   endfor
 endfunction
 
 function! s:options(base, default) abort
-  let options = extend(a:default, a:base)
-  if options.mode !~# '^\(reload\|skip\|error\)$'
-    throw printf('Unknown mode "%s" is specified', options.mode)
+  let l:options = extend(a:default, a:base)
+  if l:options.mode !~# '^\(reload\|skip\|error\)$'
+    throw printf('Unknown mode "%s" is specified', l:options.mode)
   endif
-  return options
+  return l:options
 endfunction
 
 function! s:register(plugin, script, meta, options) abort
-  let script = denops#util#normalize_path(a:script)
-  let args = [a:plugin, script, a:meta, a:options]
-  call denops#util#debug(printf('register plugin: %s', args))
-  return denops#server#request('invoke', ['register', args])
+  let l:script = denops#util#normalize_path(a:script)
+  let l:args = [a:plugin, l:script, a:meta, a:options]
+  call denops#util#debug(printf('register plugin: %s', l:args))
+  return denops#server#request('invoke', ['register', l:args])
 endfunction
 
 function! s:find_plugin(plugin) abort
-  for script in globpath(&runtimepath, denops#util#join_path('denops', a:plugin, 'main.ts'), 1, 1, 1)
-    let plugin = fnamemodify(script, ':h:t')
-    if plugin[:0] ==# '@' || !filereadable(script)
+  for l:script in globpath(&runtimepath, denops#util#join_path('denops', a:plugin, 'main.ts'), 1, 1, 1)
+    let l:plugin = fnamemodify(l:script, ':h:t')
+    if l:plugin[:0] ==# '@' || !filereadable(l:script)
       continue
     endif
-    return script
+    return l:script
   endfor
   throw printf('No denops plugin for "%s" exists', a:plugin)
 endfunction
 
 function! s:DenopsPluginPost() abort
-  let plugin = matchstr(expand('<amatch>'), 'DenopsPluginPost:\zs.*')
-  let s:loaded_plugins[plugin] = 0
-  if !has_key(s:load_callbacks, plugin)
+  let l:plugin = matchstr(expand('<amatch>'), 'DenopsPluginPost:\zs.*')
+  let s:loaded_plugins[l:plugin] = 0
+  if !has_key(s:load_callbacks, l:plugin)
     return
   endif
-  let callbacks = remove(s:load_callbacks, plugin)
+  let l:callbacks = remove(s:load_callbacks, l:plugin)
   " Vim uses FILO for a task execution registered by timer_start().
   " That's why reverse 'callbacks' in the case of Vim to keep consistent
   " behavior.
-  let callbacks = has('nvim') ? callbacks : reverse(callbacks)
-  for l:Callback in callbacks
+  let l:callbacks = has('nvim') ? l:callbacks : reverse(l:callbacks)
+  for l:Callback in l:callbacks
     call timer_start(0, { -> l:Callback() })
   endfor
 endfunction
 
 function! s:DenopsPluginFail() abort
-  let plugin = matchstr(expand('<amatch>'), 'DenopsPluginFail:\zs.*')
-  let s:loaded_plugins[plugin] = -3
-  if !has_key(s:load_callbacks, plugin)
+  let l:plugin = matchstr(expand('<amatch>'), 'DenopsPluginFail:\zs.*')
+  let s:loaded_plugins[l:plugin] = -3
+  if !has_key(s:load_callbacks, l:plugin)
     return
   endif
-  call remove(s:load_callbacks, plugin)
+  call remove(s:load_callbacks, l:plugin)
 endfunction
 
 augroup denops_autoload_plugin_internal

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -14,7 +14,7 @@ function! denops#server#connect() abort
   endif
   let l:addr = get(g:, 'denops_server_addr')
   if empty(l:addr)
-    call denops#util#error('denops shared server address (g:denops_server_addr) is not given')
+    call denops#_internal#echo#error('denops shared server address (g:denops_server_addr) is not given')
     return
   endif
   return s:connect(l:addr)
@@ -24,7 +24,7 @@ function! denops#server#start() abort
   if g:denops#disabled
     return
   elseif denops#server#status() isnot# s:STATUS_STOPPED
-    call denops#util#debug('Server is already starting or running. Skip')
+    call denops#_internal#echo#debug('Server is already starting or running. Skip')
     return
   endif
   let l:args = [g:denops#server#deno, 'run']
@@ -53,7 +53,7 @@ function! denops#server#start() abort
         \ 'on_exit': funcref('s:on_exit'),
         \ 'raw_options': l:raw_options,
         \})
-  call denops#util#debug(printf('Server spawned: %s', l:args))
+  call denops#_internal#echo#debug(printf('Server spawned: %s', l:args))
   doautocmd <nomodeline> User DenopsStarted
 endfunction
 
@@ -125,7 +125,7 @@ endfunction
 function! s:on_exit(status, ...) abort dict
   let s:job = v:null
   let s:chan = v:null
-  call denops#util#debug(printf('Server stopped: %s', a:status))
+  call denops#_internal#echo#debug(printf('Server stopped: %s', a:status))
   doautocmd <nomodeline> User DenopsStopped
   if s:stopped_on_purpose || v:dying || v:exiting || s:vim_exiting
     return
@@ -139,17 +139,17 @@ function! s:connect(addr) abort
   let l:threshold = g:denops#server#reconnect_threshold
   let l:previous_exception = ''
   for l:i in range(l:threshold)
-    call denops#util#debug(printf('Connecting to `%s`', a:addr))
+    call denops#_internal#echo#debug(printf('Connecting to `%s`', a:addr))
     try
       let s:chan = s:raw_connect(a:addr)
       doautocmd <nomodeline> User DenopsReady
       return v:true
     catch
-      call denops#util#debug(printf('Failed to connect `%s`: %s', a:addr, v:exception))
+      call denops#_internal#echo#debug(printf('Failed to connect `%s`: %s', a:addr, v:exception))
       let l:previous_exception = v:exception
     endtry
   endfor
-  call denops#util#error(printf('Failed to connect `%s`: %s', a:addr, l:previous_exception))
+  call denops#_internal#echo#error(printf('Failed to connect `%s`: %s', a:addr, l:previous_exception))
 endfunction
 
 function! s:stop(restart) abort
@@ -161,18 +161,18 @@ function! s:restart(status) abort
   if s:restart_guard()
     return
   endif
-  call denops#util#warn(printf(
+  call denops#_internal#echo#warn(printf(
         \ 'Server stopped (%d). Restarting...',
         \ a:status,
         \))
   call denops#server#start()
-  call denops#util#info('Server is restarted.')
+  call denops#_internal#echo#info('Server is restarted.')
 endfunction
 
 function! s:restart_guard() abort
   let s:restart_count = get(s:, 'restart_count', 0) + 1
   if s:restart_count >= g:denops#server#restart_threshold
-    call denops#util#warn(printf(
+    call denops#_internal#echo#warn(printf(
           \ 'Server stopped %d times within %d millisec. Denops become disabled to avoid infinity restart loop.',
           \ g:denops#server#restart_threshold,
           \ g:denops#server#restart_interval,

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -12,14 +12,13 @@ function! denops#server#connect() abort
   if g:denops#disabled
     return
   endif
-  let addr = get(g:, 'denops_server_addr')
-  if empty(addr)
+  let l:addr = get(g:, 'denops_server_addr')
+  if empty(l:addr)
     call denops#util#error('denops shared server address (g:denops_server_addr) is not given')
     return
   endif
-  return s:connect(addr)
+  return s:connect(l:addr)
 endfunction
-
 
 function! denops#server#start() abort
   if g:denops#disabled
@@ -28,23 +27,23 @@ function! denops#server#start() abort
     call denops#util#debug('Server is already starting or running. Skip')
     return
   endif
-  let args = [g:denops#server#deno, 'run']
-  let args += g:denops#server#deno_args
-  let args += [
+  let l:args = [g:denops#server#deno, 'run']
+  let l:args += g:denops#server#deno_args
+  let l:args += [
         \ s:script,
         \ '--quiet',
         \ '--identity',
         \ '--port', '0',
         \]
   if g:denops#trace
-    let args += ['--trace']
+    let l:args += ['--trace']
   endif
-  let raw_options = has('nvim')
+  let l:raw_options = has('nvim')
         \ ? {}
         \ : { 'mode': 'nl' }
   let s:stopped_on_purpose = 0
   let s:chan = v:null
-  let s:job = denops#job#start(args, {
+  let s:job = denops#job#start(l:args, {
         \ 'env': {
         \   'NO_COLOR': 1,
         \   'DENO_NO_PROMPT': 1,
@@ -52,9 +51,9 @@ function! denops#server#start() abort
         \ 'on_stdout': funcref('s:on_stdout'),
         \ 'on_stderr': funcref('s:on_stderr'),
         \ 'on_exit': funcref('s:on_exit'),
-        \ 'raw_options': raw_options,
+        \ 'raw_options': l:raw_options,
         \})
-  call denops#util#debug(printf('Server spawned: %s', args))
+  call denops#util#debug(printf('Server spawned: %s', l:args))
   doautocmd <nomodeline> User DenopsStarted
 endfunction
 
@@ -102,13 +101,13 @@ endfunction
 
 function! s:on_stdout(data) abort
   if s:chan isnot# v:null
-    for line in split(a:data, '\n')
-      echomsg printf('[denops] %s', substitute(line, '\t', '    ', 'g'))
+    for l:line in split(a:data, '\n')
+      echomsg printf('[denops] %s', substitute(l:line, '\t', '    ', 'g'))
     endfor
     return
   endif
-  let addr = substitute(a:data, '\r\?\n$', '', 'g')
-  if !s:connect(addr)
+  let l:addr = substitute(a:data, '\r\?\n$', '', 'g')
+  if !s:connect(l:addr)
     call denops#server#stop()
     call s:on_stderr(a:data)
     return
@@ -117,8 +116,8 @@ endfunction
 
 function! s:on_stderr(data) abort
   echohl ErrorMsg
-  for line in split(a:data, '\n')
-    echomsg printf('[denops] %s', substitute(line, '\t', '    ', 'g'))
+  for l:line in split(a:data, '\n')
+    echomsg printf('[denops] %s', substitute(l:line, '\t', '    ', 'g'))
   endfor
   echohl None
 endfunction
@@ -136,10 +135,10 @@ function! s:on_exit(status, ...) abort dict
 endfunction
 
 function! s:connect(addr) abort
-  let interval = g:denops#server#reconnect_interval
-  let threshold = g:denops#server#reconnect_threshold
-  let previous_exception = ''
-  for i in range(threshold)
+  let l:interval = g:denops#server#reconnect_interval
+  let l:threshold = g:denops#server#reconnect_threshold
+  let l:previous_exception = ''
+  for l:i in range(l:threshold)
     call denops#util#debug(printf('Connecting to `%s`', a:addr))
     try
       let s:chan = s:raw_connect(a:addr)
@@ -147,10 +146,10 @@ function! s:connect(addr) abort
       return v:true
     catch
       call denops#util#debug(printf('Failed to connect `%s`: %s', a:addr, v:exception))
-      let previous_exception = v:exception
+      let l:previous_exception = v:exception
     endtry
   endfor
-  call denops#util#error(printf('Failed to connect `%s`: %s', a:addr, previous_exception))
+  call denops#util#error(printf('Failed to connect `%s`: %s', a:addr, l:previous_exception))
 endfunction
 
 function! s:stop(restart) abort
@@ -192,13 +191,13 @@ endfunction
 
 if has('nvim')
   function! s:raw_connect(address) abort
-    let chan = sockconnect('tcp', a:address, {
+    let l:chan = sockconnect('tcp', a:address, {
           \ 'rpc': v:true,
           \})
-    if chan is# 0
+    if l:chan is# 0
       throw printf('Failed to connect `%s`', a:address)
     endif
-    return chan
+    return l:chan
   endfunction
 
   function! s:notify(chan, method, params) abort
@@ -210,16 +209,16 @@ if has('nvim')
   endfunction
 else
   function! s:raw_connect(address) abort
-    let chan = ch_open(a:address, {
+    let l:chan = ch_open(a:address, {
           \ 'mode': 'json',
           \ 'drop': 'auto',
           \ 'noblock': 1,
           \ 'timeout': 1000 * 60 * 60 * 24 * 7,
           \})
-    if ch_status(chan) !=# 'open'
+    if ch_status(l:chan) !=# 'open'
       throw printf('Failed to connect `%s`', a:address)
     endif
-    return chan
+    return l:chan
   endfunction
 
   function! s:notify(chan, method, params) abort
@@ -227,11 +226,11 @@ else
   endfunction
 
   function! s:request(chan, method, params) abort
-    let [ok, err] = ch_evalexpr(a:chan, [a:method] + a:params)
-    if err isnot# v:null
-      throw err
+    let [l:ok, l:err] = ch_evalexpr(a:chan, [a:method] + a:params)
+    if l:err isnot# v:null
+      throw l:err
     endif
-    return ok
+    return l:ok
   endfunction
 endif
 

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -1,4 +1,4 @@
-let s:script = denops#util#script_path('@denops-private', 'cli.ts')
+let s:script = denops#_internal#path#script(['@denops-private', 'cli.ts'])
 let s:engine = has('nvim') ? 'nvim' : 'vim'
 let s:vim_exiting = 0
 let s:stopped_on_purpose = 0

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -43,7 +43,7 @@ function! denops#server#start() abort
         \ : { 'mode': 'nl' }
   let s:stopped_on_purpose = 0
   let s:chan = v:null
-  let s:job = denops#job#start(l:args, {
+  let s:job = denops#_internal#job#start(l:args, {
         \ 'env': {
         \   'NO_COLOR': 1,
         \   'DENO_NO_PROMPT': 1,
@@ -154,7 +154,7 @@ endfunction
 
 function! s:stop(restart) abort
   let s:stopped_on_purpose = a:restart ? 0 : 1
-  call denops#job#stop(s:job)
+  call denops#_internal#job#stop(s:job)
 endfunction
 
 function! s:restart(status) abort

--- a/autoload/denops/util.vim
+++ b/autoload/denops/util.vim
@@ -19,41 +19,40 @@ function! denops#util#meta() abort
   return s:meta
 endfunction
 
+" DEPRECATED:
 function! denops#util#debug(...) abort
-  if !g:denops#debug
-    return
-  endif
-  let l:msg = join(a:000)
-  echohl Comment
-  for l:line in split(l:msg, '\n')
-    echomsg printf('[denops] %s', l:line)
-  endfor
-  echohl None
+  call denops#_internal#echo#deprecate(
+        \ 'The function `denops#util#debug` is deprecated and will be removed.',
+        \ 'Denops does not provide a public alternative so plugins must define it by themselves.',
+        \)
+  call call('denops#_internal#echo#debug', a:000)
 endfunction
 
+" DEPRECATED:
 function! denops#util#info(...) abort
-  let l:msg = join(a:000)
-  for l:line in split(l:msg, '\n')
-    echomsg printf('[denops] %s', l:line)
-  endfor
+  call denops#_internal#echo#deprecate(
+        \ 'The function `denops#util#info` is deprecated and will be removed.',
+        \ 'Denops does not provide a public alternative so plugins must define it by themselves.',
+        \)
+  call call('denops#_internal#echo#info', a:000)
 endfunction
 
+" DEPRECATED:
 function! denops#util#warn(...) abort
-  let l:msg = join(a:000)
-  echohl WarningMsg
-  for l:line in split(l:msg, '\n')
-    echomsg printf('[denops] %s', l:line)
-  endfor
-  echohl None
+  call denops#_internal#echo#deprecate(
+        \ 'The function `denops#util#warn` is deprecated and will be removed.',
+        \ 'Denops does not provide a public alternative so plugins must define it by themselves.',
+        \)
+  call call('denops#_internal#echo#warn', a:000)
 endfunction
 
+" DEPRECATED:
 function! denops#util#error(...) abort
-  let l:msg = join(a:000)
-  echohl ErrorMsg
-  for l:line in split(l:msg, '\n')
-    echomsg printf('[denops] %s', l:line)
-  endfor
-  echohl None
+  call denops#_internal#echo#deprecate(
+        \ 'The function `denops#util#error` is deprecated and will be removed.',
+        \ 'Denops does not provide a public alternative so plugins must define it by themselves.',
+        \)
+  call call('denops#_internal#echo#error', a:000)
 endfunction
 
 if has('win32unix')

--- a/autoload/denops/util.vim
+++ b/autoload/denops/util.vim
@@ -1,6 +1,5 @@
 let s:sep = has('win32') ? '\' : '/'
 let s:root = expand('<sfile>:h:h:h')
-let s:wait_warning_time = 5000
 
 " DEPRECATED:
 function! denops#util#meta() abort
@@ -69,49 +68,11 @@ function! denops#util#join_path(...) abort
   return join(a:000, s:sep)
 endfunction
 
-function! denops#util#wait(timeout, condition, interval) abort
-  return s:wait(a:timeout, a:condition, a:interval)
-endfunction
-
-function! s:warn_wait() abort
-  let l:m = printf(
-        \ 'It tooks more than %d ms. Use Ctrl-C to cancel.',
-        \ s:wait_warning_time,
+" DEPRECATED
+function! denops#util#wait(...) abort
+  call denops#_internal#echo#deprecate(
+        \ 'The function `denops#util#wait` is deprecated and will be removed.',
+        \ 'Denops does not provide a public alternative so plugins must define it by themselves.',
         \)
-  call denops#util#warn(l:m)
+  call call('denops#_internal#wait#for', a:000)
 endfunction
-
-if exists('*wait')
-  function! s:wait(timeout, condition, interval) abort
-    let l:t = timer_start(
-          \ s:wait_warning_time,
-          \ { -> s:warn_wait() },
-          \)
-    try
-      return wait(a:timeout, a:condition, a:interval)
-    finally
-      silent! call timer_stop(l:t)
-    endtry
-  endfunction
-else
-  function! s:wait(timeout, condition, interval) abort
-    let l:t = timer_start(
-          \ s:wait_warning_time,
-          \ { -> s:warn_wait() },
-          \)
-    let l:waiter = printf('sleep %dm', a:interval)
-    let l:s = reltime()
-    try
-      while !a:condition()
-        if reltimefloat(reltime(l:s)) * 1000 > a:timeout
-          return -1
-        endif
-        execute l:waiter
-      endwhile
-    catch /^Vim:Interrupt$/
-      return -2
-    finally
-      silent! call timer_stop(l:t)
-    endtry
-  endfunction
-endif

--- a/autoload/denops/util.vim
+++ b/autoload/denops/util.vim
@@ -1,6 +1,3 @@
-let s:sep = has('win32') ? '\' : '/'
-let s:root = expand('<sfile>:h:h:h')
-
 " DEPRECATED:
 function! denops#util#meta() abort
   call denops#_internal#echo#deprecate(
@@ -46,26 +43,31 @@ function! denops#util#error(...) abort
   call call('denops#_internal#echo#error', a:000)
 endfunction
 
-if has('win32unix')
-  function! denops#util#normalize_path(path) abort
-    return trim(system(printf("cygpath -m '%s'", a:path)))
-  endfunction
-
-  function! denops#util#script_path(...) abort
-    return denops#util#normalize_path(call('denops#util#join_path', [s:root, 'denops'] + a:000))
-  endfunction
-else
-  function! denops#util#normalize_path(path) abort
-    return a:path
-  endfunction
-
-  function! denops#util#script_path(...) abort
-    return call('denops#util#join_path', [s:root, 'denops'] + a:000)
-  endfunction
-endif
-
+" DEPRECATED:
 function! denops#util#join_path(...) abort
-  return join(a:000, s:sep)
+  call denops#_internal#echo#deprecate(
+        \ 'The function `denops#util#join_path` is deprecated and will be removed.',
+        \ 'Denops does not provide a public alternative so plugins must define it by themselves.',
+        \)
+  return denops#_internal#path#join(a:000)
+endfunction
+
+" DEPRECATED:
+function! denops#util#normalize_path(path) abort
+  call denops#_internal#echo#deprecate(
+        \ 'The function `denops#util#normalize_path` is deprecated and will be removed.',
+        \ 'Denops does not provide a public alternative so plugins must define it by themselves.',
+        \)
+  return denops#_internal#path#norm(a:path)
+endfunction
+
+" DEPRECATED:
+function! denops#util#script_path(...) abort
+  call denops#_internal#echo#deprecate(
+        \ 'The function `denops#util#script_path` is deprecated and will be removed.',
+        \ 'Denops does not provide a public alternative so plugins must define it by themselves.',
+        \)
+  return denops#_internal#path#script(a:000)
 endfunction
 
 " DEPRECATED

--- a/autoload/denops/util.vim
+++ b/autoload/denops/util.vim
@@ -3,15 +3,15 @@ let s:root = expand('<sfile>:h:h:h')
 let s:wait_warning_time = 5000
 
 function! denops#util#meta() abort
-  let mode = g:denops#_test ? 'test' : g:denops#debug ? 'debug' : 'release'
+  let l:mode = g:denops#_test ? 'test' : g:denops#debug ? 'debug' : 'release'
   if exists('s:meta')
-    return extend({'mode': mode}, s:meta, 'keep')
+    return extend({'mode': l:mode}, s:meta, 'keep')
   endif
   let l:host = has('nvim') ? 'nvim' : 'vim'
   let l:version = s:get_host_version()
   let l:platform = has('win32') ? 'windows' : has('mac') ? 'mac' : 'linux'
   let s:meta = {
-        \ 'mode': mode,
+        \ 'mode': l:mode,
         \ 'host': l:host,
         \ 'version': l:version,
         \ 'platform': l:platform,
@@ -23,35 +23,35 @@ function! denops#util#debug(...) abort
   if !g:denops#debug
     return
   endif
-  let msg = join(a:000)
+  let l:msg = join(a:000)
   echohl Comment
-  for line in split(msg, '\n')
-    echomsg printf('[denops] %s', line)
+  for l:line in split(l:msg, '\n')
+    echomsg printf('[denops] %s', l:line)
   endfor
   echohl None
 endfunction
 
 function! denops#util#info(...) abort
-  let msg = join(a:000)
-  for line in split(msg, '\n')
-    echomsg printf('[denops] %s', line)
+  let l:msg = join(a:000)
+  for l:line in split(l:msg, '\n')
+    echomsg printf('[denops] %s', l:line)
   endfor
 endfunction
 
 function! denops#util#warn(...) abort
-  let msg = join(a:000)
+  let l:msg = join(a:000)
   echohl WarningMsg
-  for line in split(msg, '\n')
-    echomsg printf('[denops] %s', line)
+  for l:line in split(l:msg, '\n')
+    echomsg printf('[denops] %s', l:line)
   endfor
   echohl None
 endfunction
 
 function! denops#util#error(...) abort
-  let msg = join(a:000)
+  let l:msg = join(a:000)
   echohl ErrorMsg
-  for line in split(msg, '\n')
-    echomsg printf('[denops] %s', line)
+  for l:line in split(l:msg, '\n')
+    echomsg printf('[denops] %s', l:line)
   endfor
   echohl None
 endfunction
@@ -83,58 +83,58 @@ function! denops#util#wait(timeout, condition, interval) abort
 endfunction
 
 function! s:warn_wait() abort
-  let m = printf(
+  let l:m = printf(
         \ 'It tooks more than %d ms. Use Ctrl-C to cancel.',
         \ s:wait_warning_time,
         \)
-  call denops#util#warn(m)
+  call denops#util#warn(l:m)
 endfunction
 
 if exists('*wait')
   function! s:wait(timeout, condition, interval) abort
-    let t = timer_start(
+    let l:t = timer_start(
           \ s:wait_warning_time,
           \ { -> s:warn_wait() },
           \)
     try
       return wait(a:timeout, a:condition, a:interval)
     finally
-      silent! call timer_stop(t)
+      silent! call timer_stop(l:t)
     endtry
   endfunction
 else
   function! s:wait(timeout, condition, interval) abort
-    let t = timer_start(
+    let l:t = timer_start(
           \ s:wait_warning_time,
           \ { -> s:warn_wait() },
           \)
-    let waiter = printf('sleep %dm', a:interval)
-    let s = reltime()
+    let l:waiter = printf('sleep %dm', a:interval)
+    let l:s = reltime()
     try
       while !a:condition()
-        if reltimefloat(reltime(s)) * 1000 > a:timeout
+        if reltimefloat(reltime(l:s)) * 1000 > a:timeout
           return -1
         endif
-        execute waiter
+        execute l:waiter
       endwhile
     catch /^Vim:Interrupt$/
       return -2
     finally
-      silent! call timer_stop(t)
+      silent! call timer_stop(l:t)
     endtry
   endfunction
 endif
 
 if has('nvim')
   function! s:get_host_version() abort
-    let output = execute('version')
-    return matchstr(output, 'NVIM v\zs[0-9.]\+')
+    let l:output = execute('version')
+    return matchstr(l:output, 'NVIM v\zs[0-9.]\+')
   endfunction
 else
   function! s:get_host_version() abort
-    let output = execute('version')
-    let major = matchstr(output, 'Vi IMproved \zs[0-9.]\+')
-    let patch = matchstr(output, 'Included patches: [0-9]\+-\zs[0-9]\+')
-    return printf('%s.%s', major, patch)
+    let l:output = execute('version')
+    let l:major = matchstr(l:output, 'Vi IMproved \zs[0-9.]\+')
+    let l:patch = matchstr(l:output, 'Included patches: [0-9]\+-\zs[0-9]\+')
+    return printf('%s.%s', l:major, l:patch)
   endfunction
 endif

--- a/autoload/denops/util.vim
+++ b/autoload/denops/util.vim
@@ -2,21 +2,13 @@ let s:sep = has('win32') ? '\' : '/'
 let s:root = expand('<sfile>:h:h:h')
 let s:wait_warning_time = 5000
 
+" DEPRECATED:
 function! denops#util#meta() abort
-  let l:mode = g:denops#_test ? 'test' : g:denops#debug ? 'debug' : 'release'
-  if exists('s:meta')
-    return extend({'mode': l:mode}, s:meta, 'keep')
-  endif
-  let l:host = has('nvim') ? 'nvim' : 'vim'
-  let l:version = s:get_host_version()
-  let l:platform = has('win32') ? 'windows' : has('mac') ? 'mac' : 'linux'
-  let s:meta = {
-        \ 'mode': l:mode,
-        \ 'host': l:host,
-        \ 'version': l:version,
-        \ 'platform': l:platform,
-        \}
-  return s:meta
+  call denops#_internal#echo#deprecate(
+        \ 'The function `denops#util#meta` is deprecated and will be removed.',
+        \ 'Denops does not provide a public alternative so plugins must define it by themselves.',
+        \)
+  return denops#_internal#meta#get()
 endfunction
 
 " DEPRECATED:
@@ -121,19 +113,5 @@ else
     finally
       silent! call timer_stop(l:t)
     endtry
-  endfunction
-endif
-
-if has('nvim')
-  function! s:get_host_version() abort
-    let l:output = execute('version')
-    return matchstr(l:output, 'NVIM v\zs[0-9.]\+')
-  endfunction
-else
-  function! s:get_host_version() abort
-    let l:output = execute('version')
-    let l:major = matchstr(l:output, 'Vi IMproved \zs[0-9.]\+')
-    let l:patch = matchstr(l:output, 'Included patches: [0-9]\+-\zs[0-9]\+')
-    return printf('%s.%s', l:major, l:patch)
   endfunction
 endif

--- a/autoload/health/denops.vim
+++ b/autoload/health/denops.vim
@@ -72,7 +72,7 @@ function! s:check_vim_version() abort
         \))
   call health#report_info(printf(
         \ 'Detected Vim version: `%s`',
-        \ denops#util#meta().version,
+        \ denops#_internal#meta#get().version,
         \))
   if !has(printf('patch-%s', s:vim_version))
     call health#report_error(printf(
@@ -91,7 +91,7 @@ function! s:check_neovim_version() abort
         \))
   call health#report_info(printf(
         \ 'Detected Neovim version: `%s`',
-        \ denops#util#meta().version,
+        \ denops#_internal#meta#get().version,
         \))
   if !has(printf('nvim-%s', s:neovim_version))
     call health#report_error(printf(

--- a/autoload/health/denops.vim
+++ b/autoload/health/denops.vim
@@ -3,21 +3,21 @@ let s:vim_version = '8.2.3452'
 let s:neovim_version = '0.6.0'
 
 function! s:compare_version(v1, v2) abort
-  let v1 = map(split(a:v1, '\.'), { _, v -> v + 0 })
-  let v2 = map(split(a:v2, '\.'), { _, v -> v + 0 })
-  for i in range(max([len(v1), len(v2)]))
-    let t1 = get(v1, i, 0)
-    let t2 = get(v2, i, 0)
-    if t1 isnot# t2
-      return t1 > t2 ? 1 : -1
+  let l:v1 = map(split(a:v1, '\.'), { _, v -> v + 0 })
+  let l:v2 = map(split(a:v2, '\.'), { _, v -> v + 0 })
+  for l:i in range(max([len(l:v1), len(l:v2)]))
+    let l:t1 = get(l:v1, l:i, 0)
+    let l:t2 = get(l:v2, l:i, 0)
+    if l:t1 isnot# l:t2
+      return l:t1 > l:t2 ? 1 : -1
     endif
   endfor
   return 0
 endfunction
 
 function! s:get_deno_version(deno) abort
-  let output = system(printf('%s --version', a:deno))
-  return matchstr(output, 'deno \zs[0-9.]\+')
+  let l:output = system(printf('%s --version', a:deno))
+  return matchstr(l:output, 'deno \zs[0-9.]\+')
 endfunction
 
 function! s:check_deno_executable() abort
@@ -43,19 +43,19 @@ function! s:check_deno_executable() abort
 endfunction
 
 function! s:check_deno_version() abort
-  let deno_version = s:get_deno_version(g:denops#deno)
+  let l:deno_version = s:get_deno_version(g:denops#deno)
   call health#report_info(printf(
         \ 'Supported Deno version: `%s`',
         \ s:deno_version,
         \))
   call health#report_info(printf(
         \ 'Detected Deno version: `%s`',
-        \ deno_version,
+        \ l:deno_version,
         \))
-  if empty(deno_version)
+  if empty(l:deno_version)
     call health#report_error('Unable to detect version of deno, make sure your deno runtime is correct.')
     return
-  elseif s:compare_version(deno_version, s:deno_version) < 0
+  elseif s:compare_version(l:deno_version, s:deno_version) < 0
     call health#report_error(printf(
           \ 'Unsupported Deno version is detected. You need to upgrade it to `%s` or later.',
           \ s:deno_version,
@@ -110,12 +110,12 @@ function! s:check_denops() abort
 endfunction
 
 function! s:check_denops_status() abort
-  let server_status = denops#server#status()
+  let l:server_status = denops#server#status()
   call health#report_info(printf(
         \ 'Denops status: `%s`',
-        \ server_status,
+        \ l:server_status,
         \))
-  if server_status ==# 'stopped'
+  if l:server_status ==# 'stopped'
     call health#report_error('Denops is stopped. Execute `:message` command to find reasons.')
     return
   endif

--- a/denops/@denops-private/cli.ts
+++ b/denops/@denops-private/cli.ts
@@ -64,7 +64,7 @@ for await (const conn of listener) {
   // Create host and service
   using(new hostClass(r2, writer), async (host) => {
     await using(new Service(host), async (service) => {
-      await service.waitClosed();
+      await service.host.waitClosed();
       if (!quiet) {
         console.log(
           `${remoteAddr.hostname}:${remoteAddr.port} (${hostClass.name}) is closed`,

--- a/denops/@denops-private/host/invoker.ts
+++ b/denops/@denops-private/host/invoker.ts
@@ -42,14 +42,14 @@ export class Invoker {
     this.#service.dispatch(name, fn, args)
       .then(async (r) => {
         try {
-          await this.#service.call("denops#callback#call", success, r);
+          await this.#service.host.call("denops#callback#call", success, r);
         } catch (e) {
           console.error(`${e.stack ?? e.toString()}`);
         }
       })
       .catch(async (e) => {
         try {
-          await this.#service.call(
+          await this.#service.host.call(
             "denops#callback#call",
             failure,
             toErrorObject(e),

--- a/denops/@denops/test/tester.ts
+++ b/denops/@denops/test/tester.ts
@@ -64,7 +64,10 @@ async function withDenops(
         },
       }),
       async (session) => {
-        const meta = await session.call("call", "denops#util#meta") as Meta;
+        const meta = await session.call(
+          "call",
+          "denops#_internal#meta#get",
+        ) as Meta;
         const denops: Denops = new DenopsImpl(pluginName, meta, session);
         const runner = async () => {
           await main(denops);

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -108,6 +108,11 @@ VARIABLE						*denops-variable*
 
 	Default: 0
 
+*g:denops#disable_deprecation_warning_message*
+	Set 1 to disable deprecation warning messages.
+
+	Default: 0
+
 *g:denops#server#deno*
 	Executable program of Deno for starting a server.
 	Default: |g:denops#deno|

--- a/plugin/denops/debug.vim
+++ b/plugin/denops/debug.vim
@@ -6,7 +6,7 @@ let g:loaded_denops_debug = 1
 augroup denops_debug_plugin_internal
   autocmd!
   autocmd User DenopsReady,DenopsStarted,DenopsStopped
-        \  call denops#util#debug(expand('<amatch>:t'))
+        \  call denops#_internal#echo#debug(expand('<amatch>:t'))
   autocmd User DenopsPluginPre:*,DenopsPluginPost:*
-        \  call denops#util#debug(expand('<amatch>:t'))
+        \  call denops#_internal#echo#debug(expand('<amatch>:t'))
 augroup END


### PR DESCRIPTION
I noticed that some denops plugin accidentally use denops's internal features like (`denops#util#....`) so I renamed them to `denops#_internal#...` and make previous functions deprecated.

Additionally, some minor refactorings are applied.