### PR TITLE
:boom: Refine server to fix shared server reconnection

### DIFF
--- a/autoload/denops.vim
+++ b/autoload/denops.vim
@@ -16,6 +16,10 @@ function! denops#request_async(plugin, method, params, success, failure) abort
   return denops#server#request('invoke', ['dispatchAsync', [a:plugin, a:method, a:params, l:success, l:failure]])
 endfunction
 
+function! denops#restart() abort
+  call denops#server#notify('kill', [0])
+endfunction
+
 " Configuration
 call denops#_internal#conf#define('denops#disabled', 0)
 call denops#_internal#conf#define('denops#deno', 'deno')

--- a/autoload/denops/_internal/rpc/nvim.vim
+++ b/autoload/denops/_internal/rpc/nvim.vim
@@ -1,0 +1,51 @@
+function! denops#_internal#rpc#nvim#connect(addr, ...) abort
+  let l:options = extend({
+        \ 'on_close': { -> 0 },
+        \}, a:0 ? a:1 : {},
+        \)
+  let l:id = sockconnect('tcp', a:addr, {
+        \ 'rpc': v:true,
+        \})
+  if l:id is# 0
+    throw printf('Failed to connect `%s`', a:addr)
+  endif
+  let l:chan = {
+        \ '_id': l:id,
+        \ '_on_close': l:options.on_close,
+        \}
+  let l:chan._healthcheck_timer = timer_start(
+        \ g:denops#_internal#rpc#nvim#healthcheck_interval,
+        \ funcref('s:healthcheck', [l:chan]),
+        \ { 'repeat': -1 },
+        \)
+  return l:chan
+endfunction
+
+function! denops#_internal#rpc#nvim#close(chan) abort
+  call timer_stop(a:chan._ping_timer)
+  call chanclose(a:chan._id)
+  call a:chan._on_close(a:chan)
+endfunction
+
+function! denops#_internal#rpc#nvim#notify(chan, method, params) abort
+  return call('rpcnotify', [a:chan._id, a:method] + a:params)
+endfunction
+
+function! denops#_internal#rpc#nvim#request(chan, method, params) abort
+  return call('rpcrequest', [a:chan._id, a:method] + a:params)
+endfunction
+
+" NOTE:
+" Neovim does not provide 'on_close' like callback so we need to check if the
+" channel is alive by frequent pseudo RPC requests.
+" https://github.com/neovim/neovim/issues/21164
+function! s:healthcheck(chan, timer) abort
+  try
+    call rpcnotify(a:chan._id, 'void')
+  catch
+    call timer_stop(a:chan._healthcheck_timer)
+    call a:chan._on_close(a:chan)
+  endtry
+endfunction
+
+call denops#_internal#conf#define('denops#_internal#rpc#nvim#healthcheck_interval', 100)

--- a/autoload/denops/_internal/rpc/vim.vim
+++ b/autoload/denops/_internal/rpc/vim.vim
@@ -1,0 +1,35 @@
+function! denops#_internal#rpc#vim#connect(addr, ...) abort
+  let l:options = extend({
+        \ 'on_close': { -> 0 },
+        \}, a:0 ? a:1 : {},
+        \)
+  let l:chan = ch_open(a:addr, {
+        \ 'mode': 'json',
+        \ 'drop': 'auto',
+        \ 'noblock': 1,
+        \ 'timeout': g:denops#_internal#rpc#vim#timeout,
+        \ 'close_cb': l:options.on_close,
+        \})
+  if ch_status(l:chan) !=# 'open'
+    throw printf('Failed to connect `%s`', a:addr)
+  endif
+  return l:chan
+endfunction
+
+function! denops#_internal#rpc#vim#close(chan) abort
+  return ch_close(a:chan)
+endfunction
+
+function! denops#_internal#rpc#vim#notify(chan, method, params) abort
+  return ch_sendraw(a:chan, json_encode([0, [a:method] + a:params]) . "\n")
+endfunction
+
+function! denops#_internal#rpc#vim#request(chan, method, params) abort
+  let [l:ok, l:err] = ch_evalexpr(a:chan, [a:method] + a:params)
+  if l:err isnot# v:null
+    throw l:err
+  endif
+  return l:ok
+endfunction
+
+call denops#_internal#conf#define('denops#_internal#rpc#vim#timeout', 1000 * 60 * 60 * 24 * 7)

--- a/autoload/denops/_internal/server/chan.vim
+++ b/autoload/denops/_internal/server/chan.vim
@@ -1,0 +1,144 @@
+let s:chan = v:null
+let s:addr = v:null
+let s:options = v:null
+let s:closed_on_purpose = 0
+let s:exiting = 0
+
+let s:host = has('nvim') ? 'nvim' : 'vim'
+let s:rpcconnect = function(printf('denops#_internal#rpc#%s#connect', s:host))
+let s:rpcclose = function(printf('denops#_internal#rpc#%s#close', s:host))
+let s:rpcnotify = function(printf('denops#_internal#rpc#%s#notify', s:host))
+let s:rpcrequest = function(printf('denops#_internal#rpc#%s#request', s:host))
+
+" Args:
+"   addr: string
+"   options: {
+"     retry_interval: number
+"     retry_threshold: number
+"     reconnect_on_close: boolean
+"     reconnect_delay: number
+"     reconnect_interval: number
+"     reconnect_threshold: number
+"   }
+" Return:
+"   boolean
+function! denops#_internal#server#chan#connect(addr, options) abort
+  if s:chan isnot# v:null
+    throw '[denops] Channel already exists'
+  endif
+  let l:retry_threshold = a:options.retry_threshold
+  let l:retry_interval = a:options.retry_interval
+  let l:previous_exception = ''
+  for l:i in range(l:retry_threshold)
+    call denops#_internal#echo#debug(printf(
+          \ 'Connecting to channel `%s` [%d/%d]',
+          \ a:addr,
+          \ l:i + 1,
+          \ l:retry_threshold + 1,
+          \))
+    try
+      call s:connect(a:addr, a:options)
+      return v:true
+    catch
+      call denops#_internal#echo#debug(printf(
+            \ 'Failed to connect channel `%s` [%d/%d]: %s',
+            \ a:addr,
+            \ l:i + 1,
+            \ l:retry_threshold + 1,
+            \ v:exception,
+            \))
+      let l:previous_exception = v:exception
+    endtry
+    execute printf('sleep %dm', l:retry_interval)
+  endfor
+  call denops#_internal#echo#error(printf(
+        \ 'Failed to connect channel `%s`: %s',
+        \ a:addr,
+        \ l:previous_exception,
+        \))
+endfunction
+
+function! denops#_internal#server#chan#close() abort
+  if s:chan is# v:null
+    throw '[denops] Channel does not exist yet'
+  endif
+  let s:closed_on_purpose = 1
+  call s:rpcclose(s:chan)
+  let s:chan = v:null
+endfunction
+
+function! denops#_internal#server#chan#is_connected() abort
+  return s:chan isnot# v:null
+endfunction
+
+function! denops#_internal#server#chan#notify(method, params) abort
+  if s:chan is# v:null
+    throw '[denops] Channel is not ready yet'
+  endif
+  return s:rpcnotify(s:chan, a:method, a:params)
+endfunction
+
+function! denops#_internal#server#chan#request(method, params) abort
+  if s:chan is# v:null
+    throw '[denops] Channel is not ready yet'
+  endif
+  return s:rpcrequest(s:chan, a:method, a:params)
+endfunction
+
+function! s:connect(addr, options) abort
+  let s:closed_on_purpose = 0
+  let s:chan = s:rpcconnect(a:addr, {
+        \ 'on_close': { -> s:on_close(a:options) },
+        \})
+  let s:addr = a:addr
+  let s:options = a:options
+  call denops#_internal#echo#debug(printf('Channel connected (%s)', a:addr))
+  doautocmd <nomodeline> User DenopsReady
+endfunction
+
+function! s:on_close(options) abort
+  let s:chan = v:null
+  call denops#_internal#echo#debug(printf('Channel closed (%s)', s:addr))
+  doautocmd <nomodeline> User DenopsClosed
+  if !a:options.reconnect_on_close || s:closed_on_purpose || s:exiting
+    return
+  endif
+  " Reconnect
+  if s:reconnect_guard(a:options)
+    return
+  endif
+  call denops#_internal#echo#warn('Channel closed. Reconnecting...')
+  call timer_start(
+        \ a:options.reconnect_delay,
+        \ { -> denops#_internal#server#chan#connect(s:addr, s:options) },
+        \)
+endfunction
+
+function! s:reconnect_guard(options) abort
+  let l:reconnect_threshold = a:options.reconnect_threshold
+  let l:reconnect_interval = a:options.reconnect_interval
+  let s:reconnect_count = get(s:, 'reconnect_count', 0) + 1
+  if s:reconnect_count >= l:reconnect_threshold
+    call denops#_internal#echo#warn(printf(
+          \ 'Channel closed %d times within %d millisec. Denops is disabled to avoid infinity reconnect loop.',
+          \ l:reconnect_threshold,
+          \ l:reconnect_interval,
+          \))
+    let g:denops#disabled = 1
+    return 1
+  endif
+  if exists('s:reset_reconnect_count_delayer')
+    call timer_stop(s:reset_reconnect_count_delayer)
+  endif
+  let s:reset_reconnect_count_delayer = timer_start(
+        \ l:reconnect_interval,
+        \ { -> extend(s:, { 'reconnect_count': 0 }) },
+        \)
+endfunction
+
+augroup denops_internal_server_chan_internal
+  autocmd!
+  autocmd VimLeave * let s:exiting = 1
+  autocmd User DenopsReady :
+  autocmd User DenopsClosed :
+augroup END

--- a/autoload/denops/_internal/server/proc.vim
+++ b/autoload/denops/_internal/server/proc.vim
@@ -1,0 +1,171 @@
+let s:SCRIPT = denops#_internal#path#script(['@denops-private', 'cli.ts'])
+
+let s:job = v:null
+let s:options = v:null
+let s:stopped_on_purpose = 0
+let s:exiting = 0
+
+" Args:
+"   options: {
+"     retry_interval: number
+"     retry_threshold: number
+"     restart_on_exit: boolean
+"     restart_delay: number
+"     restart_interval: number
+"     restart_threshold: number
+"   }
+" Return:
+"   boolean
+function! denops#_internal#server#proc#start(options) abort
+  if s:job isnot# v:null
+    throw '[denops] Server already exists'
+  endif
+  let l:retry_interval = a:options.retry_interval
+  let l:retry_threshold = a:options.retry_threshold
+  let l:previous_exception = ''
+  for l:i in range(l:retry_threshold)
+    call denops#_internal#echo#debug(printf(
+          \ 'Spawn server [%d/%d]',
+          \ l:i + 1,
+          \ l:retry_threshold + 1,
+          \))
+    try
+      call s:start(a:options)
+      return v:true
+    catch
+      call denops#_internal#echo#debug(printf(
+            \ 'Failed to spawn server [%d/%d]: %s',
+            \ l:i + 1,
+            \ l:retry_threshold + 1,
+            \ v:exception,
+            \))
+      let l:previous_exception = v:exception
+    endtry
+    execute printf('sleep %dm', l:retry_interval)
+  endfor
+  call denops#_internal#echo#error(printf(
+        \ 'Failed to spawn server: %s',
+        \ l:previous_exception,
+        \))
+endfunction
+
+function! denops#_internal#server#proc#stop() abort
+  if s:job is# v:null
+    throw '[denops] Server does not exist yet'
+  endif
+  let s:stopped_on_purpose = 1
+  call denops#_internal#job#stop(s:job)
+  let s:job = v:null
+endfunction
+
+function! denops#_internal#server#proc#is_started() abort
+  return s:job isnot# v:null
+endfunction
+
+function! s:start(options) abort
+  let l:args = [g:denops#_internal#server#proc#deno, 'run']
+  let l:args += g:denops#_internal#server#proc#deno_args
+  let l:args += [
+        \ s:SCRIPT,
+        \ '--quiet',
+        \ '--identity',
+        \ '--port', '0',
+        \]
+  if g:denops#trace
+    let l:args += ['--trace']
+  endif
+  let l:store = {'prepared': 0}
+  let s:stopped_on_purpose = 0
+  let s:job = denops#_internal#job#start(l:args, {
+        \ 'env': {
+        \   'NO_COLOR': 1,
+        \   'DENO_NO_PROMPT': 1,
+        \ },
+        \ 'on_stdout': { _job, data, _event -> s:on_stdout(l:store, data) },
+        \ 'on_stderr': { _job, data, _event -> s:on_stderr(data) },
+        \ 'on_exit': { _job, status, _event -> s:on_exit(a:options, status) },
+        \})
+  let s:options = a:options
+  call denops#_internal#echo#debug(printf('Server started: %s', l:args))
+  doautocmd <nomodeline> User DenopsProcessStarted
+endfunction
+
+function! s:on_stdout(store, data) abort
+  if a:store.prepared
+    for l:line in split(a:data, '\n')
+      echomsg printf('[denops] %s', substitute(l:line, '\t', '    ', 'g'))
+    endfor
+    return
+  endif
+  let a:store.prepared = 1
+  let l:addr = substitute(a:data, '\r\?\n$', '', 'g')
+  call denops#_internal#echo#debug(printf('Server listen: %s', l:addr))
+  execute printf('doautocmd <nomodeline> User DenopsProcessListen:%s', l:addr)
+endfunction
+
+function! s:on_stderr(data) abort
+  echohl ErrorMsg
+  for l:line in split(a:data, '\n')
+    echomsg printf('[denops] %s', substitute(l:line, '\t', '    ', 'g'))
+  endfor
+  echohl None
+endfunction
+
+function! s:on_exit(options, status) abort
+  let s:job = v:null
+  call denops#_internal#echo#debug(printf('Server stopped: %s', a:status))
+  execute printf('doautocmd <nomodeline> User DenopsProcessStopped:%s', a:status)
+  if !a:options.restart_on_exit || s:stopped_on_purpose || s:exiting
+    return
+  endif
+  " Restart
+  if s:restart_guard(a:options)
+    return
+  endif
+  call denops#_internal#echo#warn(printf(
+        \ 'Server stopped (%d). Restarting...',
+        \ a:status,
+        \))
+  call timer_start(
+        \ a:options.restart_delay,
+        \ { -> denops#_internal#server#proc#start(s:options) },
+        \)
+endfunction
+
+function! s:restart_guard(options) abort
+  let l:restart_threshold = a:options.restart_threshold
+  let l:restart_interval = a:options.restart_interval
+  let s:restart_count = get(s:, 'restart_count', 0) + 1
+  if s:restart_count >= l:restart_threshold
+    call denops#_internal#echo#warn(printf(
+          \ 'Server stopped %d times within %d millisec. Denops is disabled to avoid infinity restart loop.',
+          \ l:restart_threshold,
+          \ l:restart_interval,
+          \))
+    let g:denops#disabled = 1
+    return 1
+  endif
+  if exists('s:reset_restart_count_delayer')
+    call timer_stop(s:reset_restart_count_delayer)
+  endif
+  let s:reset_restart_count_delayer = timer_start(
+        \ l:restart_interval,
+        \ { -> extend(s:, { 'restart_count': 0 }) },
+        \)
+endfunction
+
+augroup denops_internal_server_proc_internal
+  autocmd!
+  autocmd VimLeave * let s:exiting = 1
+  autocmd User DenopsProcessStarted :
+  autocmd User DenopsProcessListen:* :
+  autocmd User DenopsProcessStopped:* :
+augroup END
+
+call denops#_internal#conf#define('denops#_internal#server#proc#deno', g:denops#deno)
+call denops#_internal#conf#define('denops#_internal#server#proc#deno_args', filter([
+      \ '-q',
+      \ g:denops#type_check ? '' : '--no-check',
+      \ '--unstable',
+      \ '-A',
+      \], { _, v -> !empty(v) }))

--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -160,7 +160,7 @@ augroup denops_autoload_plugin_internal
   autocmd!
   autocmd User DenopsPluginPost:* call s:DenopsPluginPost()
   autocmd User DenopsPluginFail:* call s:DenopsPluginFail()
-  autocmd User DenopsStopped let s:loaded_plugins = {}
+  autocmd User DenopsClosed let s:loaded_plugins = {}
 augroup END
 
 call denops#_internal#conf#define('denops#plugin#wait_interval', 10)

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -1,255 +1,124 @@
-let s:script = denops#_internal#path#script(['@denops-private', 'cli.ts'])
-let s:engine = has('nvim') ? 'nvim' : 'vim'
-let s:vim_exiting = 0
-let s:stopped_on_purpose = 0
-let s:job = v:null
-let s:chan = v:null
 let s:STATUS_STOPPED = 'stopped'
 let s:STATUS_STARTING = 'starting'
 let s:STATUS_RUNNING = 'running'
 
+
+" Local server
+function! denops#server#start() abort
+  if g:denops#disabled || denops#_internal#server#proc#is_started() 
+    return
+  endif
+  return denops#_internal#server#proc#start({
+        \ 'retry_interval': g:denops#server#retry_interval,
+        \ 'retry_threshold': g:denops#server#retry_threshold,
+        \ 'restart_on_exit': v:true,
+        \ 'restart_delay': g:denops#server#restart_delay,
+        \ 'restart_interval': g:denops#server#restart_interval,
+        \ 'restart_threshold': g:denops#server#restart_threshold,
+        \})
+endfunction
+
+function! denops#server#stop() abort
+  if !denops#_internal#server#proc#is_started() 
+    return
+  endif
+  call denops#_internal#server#proc#stop()
+endfunction
+
+function! denops#server#restart() abort
+  if denops#_internal#server#proc#is_started()
+    call denops#server#stop()
+  endif
+  call denops#server#start()
+endfunction
+
+
+" Shared server
 function! denops#server#connect() abort
-  if g:denops#disabled
+  if g:denops#disabled || denops#_internal#server#chan#is_connected()
     return
   endif
   let l:addr = get(g:, 'denops_server_addr')
   if empty(l:addr)
-    call denops#_internal#echo#error('denops shared server address (g:denops_server_addr) is not given')
+    call denops#_internal#echo#error(
+          \ 'denops shared server address (g:denops_server_addr) is not given',
+          \)
     return
   endif
-  return s:connect(l:addr)
-endfunction
-
-function! denops#server#start() abort
-  if g:denops#disabled
-    return
-  elseif denops#server#status() isnot# s:STATUS_STOPPED
-    call denops#_internal#echo#debug('Server is already starting or running. Skip')
-    return
-  endif
-  let l:args = [g:denops#server#deno, 'run']
-  let l:args += g:denops#server#deno_args
-  let l:args += [
-        \ s:script,
-        \ '--quiet',
-        \ '--identity',
-        \ '--port', '0',
-        \]
-  if g:denops#trace
-    let l:args += ['--trace']
-  endif
-  let s:stopped_on_purpose = 0
-  let s:chan = v:null
-  let s:job = denops#_internal#job#start(l:args, {
-        \ 'env': {
-        \   'NO_COLOR': 1,
-        \   'DENO_NO_PROMPT': 1,
-        \ },
-        \ 'on_stdout': funcref('s:on_stdout'),
-        \ 'on_stderr': funcref('s:on_stderr'),
-        \ 'on_exit': funcref('s:on_exit'),
+  return denops#_internal#server#chan#connect(l:addr, {
+        \ 'retry_interval': g:denops#server#retry_interval,
+        \ 'retry_threshold': g:denops#server#retry_threshold,
+        \ 'reconnect_on_close': v:true,
+        \ 'reconnect_delay': g:denops#server#reconnect_delay,
+        \ 'reconnect_interval': g:denops#server#reconnect_interval,
+        \ 'reconnect_threshold': g:denops#server#reconnect_threshold,
         \})
-  call denops#_internal#echo#debug(printf('Server spawned: %s', l:args))
-  doautocmd <nomodeline> User DenopsStarted
 endfunction
 
-function! denops#server#stop() abort
-  if s:job isnot# v:null
-    call s:stop(v:false)
-  endif
+function! denops#server#close() abort
+  call denops#_internal#server#chan#close()
 endfunction
 
-function! denops#server#restart() abort
-  if s:job isnot# v:null
-    call s:stop(v:true)
-  else
-    call denops#server#start()
+function! denops#server#reconnect() abort
+  if denops#_internal#server#chan#is_connected()
+    call denops#server#close()
   endif
+  call denops#server#connect()
 endfunction
 
 function! denops#server#status() abort
-  if s:chan isnot# v:null
+  if denops#_internal#server#chan#is_connected()
     return s:STATUS_RUNNING
-  elseif s:job isnot# v:null
+  elseif denops#_internal#server#proc#is_started()
     return s:STATUS_STARTING
-  else
-    return s:STATUS_STOPPED
   endif
+  return s:STATUS_STOPPED
 endfunction
 
 function! denops#server#notify(method, params) abort
   if g:denops#disabled
     return
-  elseif denops#server#status() isnot# s:STATUS_RUNNING
-    throw printf('The server is not ready yet')
   endif
-  return s:notify(s:chan, a:method, a:params)
+  return denops#_internal#server#chan#notify(a:method, a:params)
 endfunction
 
 function! denops#server#request(method, params) abort
   if g:denops#disabled
     return
-  elseif denops#server#status() isnot# s:STATUS_RUNNING
-    throw printf('The server is not ready yet')
   endif
-  return s:request(s:chan, a:method, a:params)
+  return denops#_internal#server#chan#request(a:method, a:params)
 endfunction
 
-function! s:on_stdout(_job, data, _event) abort
-  if s:chan isnot# v:null
-    for l:line in split(a:data, '\n')
-      echomsg printf('[denops] %s', substitute(l:line, '\t', '    ', 'g'))
-    endfor
-    return
-  endif
-  let l:addr = substitute(a:data, '\r\?\n$', '', 'g')
-  if !s:connect(l:addr)
-    call denops#server#stop()
-    call s:on_stderr(a:data)
-    return
-  endif
+function! s:DenopsProcessListen(expr) abort
+  let l:addr = matchstr(a:expr, '^DenopsProcessListen:\zs.*')
+  call denops#_internal#server#chan#connect(l:addr, {
+        \ 'retry_interval': g:denops#server#retry_interval,
+        \ 'retry_threshold': g:denops#server#retry_threshold,
+        \ 'reconnect_on_close': v:false,
+        \ 'reconnect_delay': g:denops#server#reconnect_delay,
+        \ 'reconnect_interval': g:denops#server#reconnect_interval,
+        \ 'reconnect_threshold': g:denops#server#reconnect_threshold,
+        \})
 endfunction
-
-function! s:on_stderr(_job, data, _event) abort
-  echohl ErrorMsg
-  for l:line in split(a:data, '\n')
-    echomsg printf('[denops] %s', substitute(l:line, '\t', '    ', 'g'))
-  endfor
-  echohl None
-endfunction
-
-function! s:on_exit(_job, status, _event) abort
-  let s:job = v:null
-  let s:chan = v:null
-  call denops#_internal#echo#debug(printf('Server stopped: %s', a:status))
-  doautocmd <nomodeline> User DenopsStopped
-  if s:stopped_on_purpose || v:dying || v:exiting || s:vim_exiting
-    return
-  endif
-  " Restart asynchronously to avoid #136
-  call timer_start(g:denops#server#restart_delay, { -> s:restart(a:status) })
-endfunction
-
-function! s:connect(addr) abort
-  let l:waiter = printf('sleep %dm', g:denops#server#reconnect_interval)
-  let l:threshold = g:denops#server#reconnect_threshold
-  let l:previous_exception = ''
-  for l:i in range(l:threshold)
-    call denops#_internal#echo#debug(printf('Connecting to `%s`', a:addr))
-    try
-      let s:chan = s:raw_connect(a:addr)
-      doautocmd <nomodeline> User DenopsReady
-      return v:true
-    catch
-      call denops#_internal#echo#debug(printf('Failed to connect `%s`: %s', a:addr, v:exception))
-      let l:previous_exception = v:exception
-    endtry
-    execute l:waiter
-  endfor
-  call denops#_internal#echo#error(printf('Failed to connect `%s`: %s', a:addr, l:previous_exception))
-endfunction
-
-function! s:stop(restart) abort
-  let s:stopped_on_purpose = a:restart ? 0 : 1
-  call denops#_internal#job#stop(s:job)
-endfunction
-
-function! s:restart(status) abort
-  if s:restart_guard()
-    return
-  endif
-  call denops#_internal#echo#warn(printf(
-        \ 'Server stopped (%d). Restarting...',
-        \ a:status,
-        \))
-  call denops#server#start()
-  call denops#_internal#echo#info('Server is restarted.')
-endfunction
-
-function! s:restart_guard() abort
-  let s:restart_count = get(s:, 'restart_count', 0) + 1
-  if s:restart_count >= g:denops#server#restart_threshold
-    call denops#_internal#echo#warn(printf(
-          \ 'Server stopped %d times within %d millisec. Denops become disabled to avoid infinity restart loop.',
-          \ g:denops#server#restart_threshold,
-          \ g:denops#server#restart_interval,
-          \))
-    let g:denops#disabled = 1
-    return 1
-  endif
-  if exists('s:reset_restart_count_delayer')
-    call timer_stop(s:reset_restart_count_delayer)
-  endif
-  let s:reset_restart_count_delayer = timer_start(
-        \ g:denops#server#restart_interval,
-        \ { -> extend(s:, { 'restart_count': 0 }) },
-        \)
-endfunction
-
-if has('nvim')
-  function! s:raw_connect(address) abort
-    let l:chan = sockconnect('tcp', a:address, {
-          \ 'rpc': v:true,
-          \})
-    if l:chan is# 0
-      throw printf('Failed to connect `%s`', a:address)
-    endif
-    return l:chan
-  endfunction
-
-  function! s:notify(chan, method, params) abort
-    return call('rpcnotify', [a:chan, a:method] + a:params)
-  endfunction
-
-  function! s:request(chan, method, params) abort
-    return call('rpcrequest', [a:chan, a:method] + a:params)
-  endfunction
-else
-  function! s:raw_connect(address) abort
-    let l:chan = ch_open(a:address, {
-          \ 'mode': 'json',
-          \ 'drop': 'auto',
-          \ 'noblock': 1,
-          \ 'timeout': 1000 * 60 * 60 * 24 * 7,
-          \})
-    if ch_status(l:chan) !=# 'open'
-      throw printf('Failed to connect `%s`', a:address)
-    endif
-    return l:chan
-  endfunction
-
-  function! s:notify(chan, method, params) abort
-    return ch_sendraw(a:chan, json_encode([0, [a:method] + a:params]) . "\n")
-  endfunction
-
-  function! s:request(chan, method, params) abort
-    let [l:ok, l:err] = ch_evalexpr(a:chan, [a:method] + a:params)
-    if l:err isnot# v:null
-      throw l:err
-    endif
-    return l:ok
-  endfunction
-endif
 
 augroup denops_server_internal
   autocmd!
-  autocmd User DenopsStarted :
-  autocmd User DenopsStopped :
-  autocmd User DenopsReady :
-  autocmd VimLeave * let s:vim_exiting = 1
+  autocmd User DenopsProcessListen:* call s:DenopsProcessListen(expand('<amatch>'))
 augroup END
 
-call denops#_internal#conf#define('denops#server#deno', g:denops#deno)
-call denops#_internal#conf#define('denops#server#deno_args', filter([
-      \ '-q',
-      \ g:denops#type_check ? '' : '--no-check',
-      \ '--unstable',
-      \ '-A',
-      \], { _, v -> !empty(v) }))
+augroup denops_server_internal_deprecated
+  autocmd!
+  autocmd User DenopsProcessStarted doautocmd <nomodeline> User DenopsStarted
+  autocmd User DenopsClosed doautocmd <nomodeline> User DenopsStopped
+augroup END
+
+call denops#_internal#conf#define('denops#server#retry_interval', 500)
+call denops#_internal#conf#define('denops#server#retry_threshold', 3)
 
 call denops#_internal#conf#define('denops#server#restart_delay', 100)
 call denops#_internal#conf#define('denops#server#restart_interval', 10000)
 call denops#_internal#conf#define('denops#server#restart_threshold', 3)
 
-call denops#_internal#conf#define('denops#server#reconnect_interval', 100)
+call denops#_internal#conf#define('denops#server#reconnect_delay', 100)
+call denops#_internal#conf#define('denops#server#reconnect_interval', 1000)
 call denops#_internal#conf#define('denops#server#reconnect_threshold', 3)

--- a/denops/@denops-private/host/nvim.ts
+++ b/denops/@denops-private/host/nvim.ts
@@ -43,6 +43,10 @@ export class Neovim implements Host {
 
   register(invoker: Invoker): void {
     this.#session.dispatcher = {
+      void() {
+        return Promise.resolve();
+      },
+
       async invoke(method: unknown, args: unknown): Promise<unknown> {
         assertString(method);
         assertArray(args);

--- a/denops/@denops-private/host/nvim.ts
+++ b/denops/@denops-private/host/nvim.ts
@@ -1,5 +1,6 @@
 import {
   assertArray,
+  assertNumber,
   assertString,
 } from "https://deno.land/x/unknownutil@v2.1.0/mod.ts#^";
 import { Session } from "https://deno.land/x/msgpack_rpc@v3.1.6/mod.ts#^";
@@ -45,6 +46,12 @@ export class Neovim implements Host {
     this.#session.dispatcher = {
       void() {
         return Promise.resolve();
+      },
+
+      kill(code: unknown) {
+        code = code ?? 1;
+        assertNumber(code);
+        Deno.exit(code);
       },
 
       async invoke(method: unknown, args: unknown): Promise<unknown> {

--- a/denops/@denops-private/host/vim.ts
+++ b/denops/@denops-private/host/vim.ts
@@ -76,7 +76,10 @@ export class Vim implements Host {
 }
 
 async function dispatch(invoker: Invoker, expr: unknown): Promise<unknown> {
-  if (isInvokeMessage(expr)) {
+  if (isKillMessage(expr)) {
+    const [_, code] = expr;
+    Deno.exit(code);
+  } else if (isInvokeMessage(expr)) {
     const [_, method, args] = expr;
     if (!isInvokerMethod(method)) {
       throw new Error(`Method '${method}' is not defined in the invoker`);
@@ -88,6 +91,17 @@ async function dispatch(invoker: Invoker, expr: unknown): Promise<unknown> {
       `Unexpected JSON channel message is received: ${JSON.stringify(expr)}`,
     );
   }
+}
+
+type KillMessage = ["kill", number];
+
+function isKillMessage(data: unknown): data is KillMessage {
+  return (
+    Array.isArray(data) &&
+    data.length === 2 &&
+    data[0] === "kill" &&
+    typeof data[1] === "number"
+  );
 }
 
 type InvokeMessage = ["invoke", string, unknown[]];

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -194,6 +194,10 @@ denops#request_async({plugin}, {method}, {params}, {success}, {failure})
 	      \ { e -> s:failure(e) },
 	      \)
 <
+						*denops#restart()*
+denops#restart()
+	Kill a local/shared denops server process to prompt restart.
+
 						*denops#server#start()*
 denops#server#start()
 	Start a denops server process and connect to the channel. It does

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -196,23 +196,46 @@ denops#request_async({plugin}, {method}, {params}, {success}, {failure})
 <
 						*denops#server#start()*
 denops#server#start()
-	Start a denops server.
-	It will skip internal process if server is already running.
+	Start a denops server process and connect to the channel. It does
+	nothing when the server is already started.
+
 	It is automatically called 1) on |VimEnter| autocmd when denops is
 	in |runtimepath| during Vim startup, 2) immediately when denops is
 	added to |runtimepath| after Vim startup.
-	It will invoke |User| |DenopsReady| autocmd to discover denops plugins.
-	See |denops#plugin#discover()| for detail.
+
 	Note that the server is automatically restarted when the process is
 	stopped unexpectedly.
 
 						*denops#server#stop()*
 denops#server#stop()
-	Stop a denops server immediately.
+	Stop a denops server. It does nothing when the server is not started
+	yet.
 
 						*denops#server#restart()*
 denops#server#restart()
 	Restart a denops server.
+
+						*denops#server#connect()*
+denops#server#connect()
+	Connect to a |denops-shared-server| channel. It does nothing when the
+	channel is already established.
+
+	It is automatically called 1) on |VimEnter| autocmd when denops is
+	in |runtimepath| during Vim startup, 2) immediately when denops is
+	added to |runtimepath| after Vim startup when |g:denops_server_addr|
+	is specified. Otherwise it echo errors.
+
+	Note that the channel is automatically re-established when the channel
+	is closed unexpectedly.
+
+						*denops#server#close()*
+denops#server#stop()
+	Close the channel. It does nothing when the channel is not established
+	yet.
+
+						*denops#server#reconnect()*
+denops#server#reconnect()
+	Reconnect to a denops shared server.
 
 						*denops#server#status()*
 denops#server#status()
@@ -223,15 +246,8 @@ denops#server#status()
 	"starting"	Server is starting.
 	"running"	Server is running (ready).
 
-						*denops#server#connect()*
-denops#server#connect()
-	Connect to a |denops-shared-server|.
-	It is automatically called 1) on |VimEnter| autocmd when denops is
-	in |runtimepath| during Vim startup, 2) immediately when denops is
-	added to |runtimepath| after Vim startup when |g:denops_server_addr|
-	is specified. Otherwise it echo errors.
-	It will invoke |User| |DenopsReady| autocmd to discover denops plugins.
-	See |denops#plugin#discover()| for detail.
+	Note that "starting" is never returned when a |denops-shared-server|
+	is used.
 
 						*denops#plugin#is_loaded()*
 denops#plugin#is_loaded({plugin})
@@ -349,20 +365,37 @@ denops#callback#clear()
 AUTOCMD						*denops-autocmd*
 
 DenopsReady						*DenopsReady*
-	Invoked when a denops become ready. Note that it is not mean that all
-	of denops plugins are ready.
+	Fired when a connection (channel) with Denops is established.
+	Note that this is not when all plug-ins are available.
+
+DenopsClosed						*DenopsClosed*
+	Fired when the connection (channel) with Denops is broken.
+	It is assumed to be used to release resources such as cache.
 
 DenopsPluginPre:{plugin}				*DenopsPluginPre*
-	Invoked just before denops call a "main" function of a plugin {plugin}.
+	Fired before the "main" function of each plugin is called.
+	{plugin} is the name of the target plugin.
 
 DenopsPluginPost:{plugin}				*DenopsPluginPost*
-	Invoked just after denops called a "main" function of a plugin {plugin}.
+	Fired after the "main" function of each plugin is called.
+	{plugin} is the name of the target plugin.
+
+DenopsProcessStarted					*DenopsProcessStarted*
+	Fires when the Denops local server process is started.
+	It is never fired in shared server mode.
+
+DenopsProcessStopped:{exitcode}				*DenopsProcessStopped*
+	Fired when the Denops local server process is stopped.
+	It is never fired in shared server mode.
 
 DenopsStarted						*DenopsStarted*
-	Invoked when a denops server is started.
+	DEPRECATED:
+	Use |DenopsProcessStarted| autocmd instead.
 
 DenopsStopped						*DenopsStopped*
-	Invoked when a denops server is stopped.
+	DEPRECATED:
+	Use |DenopsClosed| autocmd instead to release resources.
+	Use |DenopsProcessStopped| autocmd to detect 
 
 =============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/plugin/denops/debug.vim
+++ b/plugin/denops/debug.vim
@@ -5,7 +5,9 @@ let g:loaded_denops_debug = 1
 
 augroup denops_debug_plugin_internal
   autocmd!
-  autocmd User DenopsReady,DenopsStarted,DenopsStopped
+  autocmd User DenopsReady,DenopsClosed
+        \  call denops#_internal#echo#debug(expand('<amatch>:t'))
+  autocmd User DenopsStarted,DenopsListen:*,DenopsStopped:*
         \  call denops#_internal#echo#debug(expand('<amatch>:t'))
   autocmd User DenopsPluginPre:*,DenopsPluginPost:*
         \  call denops#_internal#echo#debug(expand('<amatch>:t'))


### PR DESCRIPTION
Close #206 and more

### :+1: Added

- `DenopsProcessStarted` autocmd that fired when the denops local server is spawned
- `DenopsProcessStopped:{exitcode}` autocmd that fired when the denops local server is stopped
- `DenopsClosed` autocmd that fired when the denops channel is closed. **Recommended way to invoke teardown code**
- `denops#restart()` function to restart a local/shared denops server

### :boom: Deprecated

- `DenopsStarted` autocmd. Use `DenopsProcessStarted` instead
- `DenopsStopped` autocmd. Use `DenopsClosed` or `DenopsProcessStopped` autocmd

### :question: How can I properly support reconnection on my denops plugin?

1. Re-initialize your plugin on `DenopsPluginPost:{plugin}` autocmd
2. Tear down your plugin on `DenopsClosed` autocmd if necessary
3. Tear down your plugin on `DenopsStopped` autocmd if necessary for old denops (optional)
