### PR TITLE
:+1: Change deno args to follow latest Deno

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         runner:
           - ubuntu-latest
         version:
-          - "1.27.0"
+          - "1.28.0"
           - "1.x"
     runs-on: ${{ matrix.runner }}
     steps:
@@ -61,7 +61,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         version:
-          - "1.27.0"
+          - "1.28.0"
           - "1.x"
         host_version:
           - vim: "v9.0.0472"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To start the shared server, execute the following command in the denops.vim
 repository top
 
 ```
-deno run -A --no-check ./denops/@denops-private/cli.ts
+deno run -A --no-lock ./denops/@denops-private/cli.ts
 ```
 
 Then specify the server address in `g:denops_server_addr` as follows
@@ -83,7 +83,7 @@ If you'd like to specify hostname and port, use `--hostname` and `--port`
 command arguments as follows
 
 ```
-deno run -A --no-check \
+deno run -A --no-lock \
     ./denops/@denops-private/cli.ts \
     --hostname=0.0.0.0 \
     --port 12345

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <strong>Denops</strong><br>
 <sup>An ecosystem of Vim/Neovim which allows developers to write plugins in Deno.</sup>
 
-[![Deno 1.27.0 or above](https://img.shields.io/badge/Deno-Support%201.27.0-yellowgreen.svg?logo=deno)](https://github.com/denoland/deno/tree/v1.27.0)
+[![Deno 1.28.0 or above](https://img.shields.io/badge/Deno-Support%201.28.0-yellowgreen.svg?logo=deno)](https://github.com/denoland/deno/tree/v1.28.0)
 [![Vim 9.0.0472 or above](https://img.shields.io/badge/Vim-Support%209.0.0472-yellowgreen.svg?logo=vim)](https://github.com/vim/vim/tree/v9.0.0472)
 [![Neovim 0.8.0 or above](https://img.shields.io/badge/Neovim-Support%200.8.0-yellowgreen.svg?logo=neovim&logoColor=white)](https://github.com/neovim/neovim/tree/v0.8.0)
 

--- a/autoload/denops/_internal/server/proc.vim
+++ b/autoload/denops/_internal/server/proc.vim
@@ -164,8 +164,5 @@ augroup END
 
 call denops#_internal#conf#define('denops#_internal#server#proc#deno', g:denops#deno)
 call denops#_internal#conf#define('denops#_internal#server#proc#deno_args', filter([
-      \ '-q',
-      \ g:denops#type_check ? '' : '--no-check',
-      \ '--unstable',
-      \ '-A',
-      \], { _, v -> !empty(v) }))
+      \ g:denops#type_check ? '--check=all' : '',
+      \], { _, v -> !empty(v) }) + g:denops#server#deno_args)

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -122,3 +122,5 @@ call denops#_internal#conf#define('denops#server#restart_threshold', 3)
 call denops#_internal#conf#define('denops#server#reconnect_delay', 100)
 call denops#_internal#conf#define('denops#server#reconnect_interval', 1000)
 call denops#_internal#conf#define('denops#server#reconnect_threshold', 3)
+
+call denops#_internal#conf#define('denops#server#deno_args', ['-q', '--no-lock', '--unstable', '-A'])

--- a/autoload/health/denops.vim
+++ b/autoload/health/denops.vim
@@ -1,4 +1,4 @@
-let s:deno_version = '1.27.0'
+let s:deno_version = '1.28.0'
 let s:vim_version = '9.0.0472'
 let s:neovim_version = '0.8.0'
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,3 +1,6 @@
 // XXX
 // This file is required to workaround the following issue
 // https://github.com/vim-denops/denops.vim/issues/218
+{
+  "lock": false
+}

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -39,7 +39,7 @@ process launches and possibly improving usability.
 To start the shared server, execute the following command in the denops.vim 
 repository top
 >
-	deno run -A --no-check ./denops/@denops-private/cli.ts
+	deno run -A --no-lock ./denops/@denops-private/cli.ts
 <
 Then specify the server address in |g:denops_server_addr| as follows
 >
@@ -48,7 +48,7 @@ Then specify the server address in |g:denops_server_addr| as follows
 If you'd like to specify hostname and port, use "--hostname" and "--port"
 command arguments as follows
 >
-	deno run -A --no-check \
+	deno run -A --no-lock \
 		./denops/@denops-private/cli.ts \
 		--hostname=0.0.0.0 \
 		--port 12345
@@ -116,7 +116,7 @@ VARIABLE						*denops-variable*
 
 *g:denops#server#deno_args*
 	Program arguments of Deno for starting a server.
-	Default: ['-q', '--no-check', '--unstable', '-A']
+	Default: ['-q', '--no-lock', '--unstable', '-A']
 
 *g:denops#server#restart_delay*
 	Restart delay in milliseconds to avoid #136.


### PR DESCRIPTION
- Drop support for Deno prior to v1.28.0
- Type checking is disabled by default since v1.23
- Lockfile is not needed for denops.vim

BTW, should I modify tasks using Deno in Makefile?