### PR TITLE
:+1: Patch several methods of `console` to show Worker name for easy debugging

### DIFF
--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -78,7 +78,7 @@ export class Service implements Disposable {
       },
     );
     const scriptUrl = resolveScriptUrl(script);
-    worker.postMessage({ name, scriptUrl, meta });
+    worker.postMessage({ scriptUrl, meta });
     const session = buildServiceSession(
       name,
       meta,

--- a/denops/@denops-private/worker/patch_console.ts
+++ b/denops/@denops-private/worker/patch_console.ts
@@ -1,0 +1,42 @@
+const marker = Symbol("patchConsole");
+
+type PatchedConsole = Console & { [marker]?: boolean };
+
+/**
+ * Patch several methods of `console` to globally add `prefix`
+ */
+export function patchConsole(
+  prefix: string,
+  console: PatchedConsole = globalThis.console,
+): void {
+  if (console[marker]) {
+    return;
+  }
+  // Patch simple methods
+  const simpleTargets = [
+    "debug",
+    "dirxml",
+    "error",
+    "group",
+    "groupCollapsed",
+    "info",
+    "log",
+    "trace",
+    "warn",
+  ] as const;
+  for (const target of simpleTargets) {
+    const ori = console[target];
+    console[target] = (...data) => {
+      ori.apply(console, [`${prefix}`, ...data]);
+    };
+  }
+  // Patch complex methods
+  const assertOri = console.assert;
+  console.assert = (condition, ...data) => {
+    assertOri.apply(console, [condition, `${prefix}`, ...data]);
+  };
+  const timeLogOri = console.timeLog;
+  console.timeLog = (label, ...data) => {
+    timeLogOri.apply(console, [label, `${prefix}`, ...data]);
+  };
+}

--- a/denops/@denops-private/worker/script.ts
+++ b/denops/@denops-private/worker/script.ts
@@ -13,6 +13,7 @@ import {
 import { responseTimeout } from "../defs.ts";
 import type { Denops, Meta } from "../../@denops/mod.ts";
 import { DenopsImpl } from "../impl.ts";
+import { patchConsole } from "./patch_console.ts";
 
 const worker = self as unknown as Worker & { name: string };
 
@@ -106,6 +107,9 @@ function isMeta(v: unknown): v is Meta {
   }
   return true;
 }
+
+// Patch console with worker name for easy debugging
+patchConsole(`(${worker.name})`);
 
 // Wait startup arguments and start 'main'
 worker.addEventListener("message", (event: MessageEvent<unknown>) => {

--- a/denops/@denops-private/worker/script.ts
+++ b/denops/@denops-private/worker/script.ts
@@ -14,10 +14,9 @@ import { responseTimeout } from "../defs.ts";
 import type { Denops, Meta } from "../../@denops/mod.ts";
 import { DenopsImpl } from "../impl.ts";
 
-const worker = self as unknown as Worker;
+const worker = self as unknown as Worker & { name: string };
 
 async function main(
-  name: string,
   scriptUrl: string,
   meta: Meta,
 ): Promise<void> {
@@ -30,7 +29,7 @@ async function main(
         if (e.name === "Interrupted") {
           return;
         }
-        console.error(`Unexpected error occurred in '${name}'`, e);
+        console.error(`Unexpected error occurred in '${worker.name}'`, e);
       },
     }),
     async (session) => {
@@ -46,34 +45,38 @@ async function main(
           reason = reason.stack;
         }
         console.error(
-          `Unhandled rejection is detected. Worker of '${name}' will be reloaded: ${reason}`,
+          `Unhandled rejection is detected. Worker of '${worker.name}' will be reloaded: ${reason}`,
         );
         // Reload the worker because "Unhandled promises" error occured.
         session.notify("reload");
         // Avoid process death
         ev.preventDefault();
       });
-      const denops: Denops = new DenopsImpl(name, meta, session);
+      const denops: Denops = new DenopsImpl(worker.name, meta, session);
       try {
         // Import module with fragment so that reload works properly
         // https://github.com/vim-denops/denops.vim/issues/227
         const mod = await import(`${scriptUrl}#${performance.now()}`);
-        await denops.cmd(`doautocmd <nomodeline> User DenopsPluginPre:${name}`)
-          .catch((e) =>
-            console.warn(`Failed to emit DenopsPluginPre:${name}: ${e}`)
-          );
-        await mod.main(denops);
-        await denops.cmd(`doautocmd <nomodeline> User DenopsPluginPost:${name}`)
-          .catch((e) =>
-            console.warn(`Failed to emit DenopsPluginPost:${name}: ${e}`)
-          );
-      } catch (e) {
-        console.error(`${name}: ${e}`);
         await denops.cmd(
-          `doautocmd <nomodeline> User DenopsPluginFail:${name}`,
+          `doautocmd <nomodeline> User DenopsPluginPre:${worker.name}`,
         )
           .catch((e) =>
-            console.warn(`Failed to emit DenopsPluginFail:${name}: ${e}`)
+            console.warn(`Failed to emit DenopsPluginPre:${worker.name}: ${e}`)
+          );
+        await mod.main(denops);
+        await denops.cmd(
+          `doautocmd <nomodeline> User DenopsPluginPost:${worker.name}`,
+        )
+          .catch((e) =>
+            console.warn(`Failed to emit DenopsPluginPost:${worker.name}: ${e}`)
+          );
+      } catch (e) {
+        console.error(`${worker.name}: ${e}`);
+        await denops.cmd(
+          `doautocmd <nomodeline> User DenopsPluginFail:${worker.name}`,
+        )
+          .catch((e) =>
+            console.warn(`Failed to emit DenopsPluginFail:${worker.name}: ${e}`)
           );
       } finally {
         await session.waitClosed();
@@ -107,15 +110,14 @@ function isMeta(v: unknown): v is Meta {
 // Wait startup arguments and start 'main'
 worker.addEventListener("message", (event: MessageEvent<unknown>) => {
   assertObject(event.data);
-  assertString(event.data.name);
   assertString(event.data.scriptUrl);
   if (!isMeta(event.data.meta)) {
     throw new Error(`Invalid 'meta' is passed: ${event.data.meta}`);
   }
-  const { name, scriptUrl, meta } = event.data;
-  main(name, scriptUrl, meta).catch((e) => {
+  const { scriptUrl, meta } = event.data;
+  main(scriptUrl, meta).catch((e) => {
     console.error(
-      `Unexpected error occurred in '${name}' (${scriptUrl}): ${e}`,
+      `Unexpected error occurred in '${scriptUrl}': ${e}`,
     );
   });
 }, { once: true });

--- a/denops/@denops-private/worker/script.ts
+++ b/denops/@denops-private/worker/script.ts
@@ -30,7 +30,7 @@ async function main(
         if (e.name === "Interrupted") {
           return;
         }
-        console.error(`Unexpected error occurred in '${worker.name}'`, e);
+        console.error("Unexpected error occurred", e);
       },
     }),
     async (session) => {
@@ -46,7 +46,7 @@ async function main(
           reason = reason.stack;
         }
         console.error(
-          `Unhandled rejection is detected. Worker of '${worker.name}' will be reloaded: ${reason}`,
+          `Unhandled rejection is detected. Worker will be reloaded: ${reason}`,
         );
         // Reload the worker because "Unhandled promises" error occured.
         session.notify("reload");
@@ -72,7 +72,7 @@ async function main(
             console.warn(`Failed to emit DenopsPluginPost:${worker.name}: ${e}`)
           );
       } catch (e) {
-        console.error(`${worker.name}: ${e}`);
+        console.error(e);
         await denops.cmd(
           `doautocmd <nomodeline> User DenopsPluginFail:${worker.name}`,
         )


### PR DESCRIPTION
It's a bit tough work to find which denops plugin shows message like below

```
[denops] [WARN] denops_core: This module is deprecated. Use https://deno.land/x/denops_test/mod.ts instead.
```

With this PR, the message above would look like

```
[denops] [WARN] (gin) denops_core: This module is deprecated. Use https://deno.land/x/denops_test/mod.ts instead.
```

Usually, this kind of hack is bad practice and should be avoided but `console` feature in denops plugin is quite limited due to technical reasons so we decided to forget about grandma's wisdom and fall into the dark side 😈 