### PR TITLE
:shower: Do NOT use CSS directive

### DIFF
--- a/denops/@denops/test/mod.ts
+++ b/denops/@denops/test/mod.ts
@@ -5,8 +5,7 @@
  * @module
  */
 console.warn(
-  "%c[WARN] denops_core: This module is deprecated. Use https://deno.land/x/denops_test/mod.ts instead.",
-  "color: yellow;",
+  "denops_core: This module is deprecated. Use https://deno.land/x/denops_test/mod.ts instead.",
 );
 
 export { test } from "./tester.ts";


### PR DESCRIPTION
The output is redirected to echomsg so highlight doesn't work anyway.