### PR TITLE
handle DenopsProcessListen obscurely

### DIFF
--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -90,7 +90,7 @@ function! denops#server#request(method, params) abort
 endfunction
 
 function! s:DenopsProcessListen(expr) abort
-  let l:addr = matchstr(a:expr, '^DenopsProcessListen:\zs.*')
+  let l:addr = matchstr(a:expr, '\<DenopsProcessListen:\zs.*')
   call denops#_internal#server#chan#connect(l:addr, {
         \ 'retry_interval': g:denops#server#retry_interval,
         \ 'retry_threshold': g:denops#server#retry_threshold,


### PR DESCRIPTION
On older version of Vim (Vim 8.2 bundled on Ubuntu 22.04), `<amatch>` return full-path like `/path/to/DenopsProcessListen:localhost:54321`.