### PR TITLE
🚀 Use notify instead to make registration asynchronous

### DIFF
--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -137,7 +137,7 @@ function! s:register(plugin, script, meta, options) abort
   let l:script = denops#_internal#path#norm(a:script)
   let l:args = [a:plugin, l:script, a:meta, a:options]
   call denops#_internal#echo#debug(printf('register plugin: %s', l:args))
-  return denops#server#request('invoke', ['register', l:args])
+  call denops#server#notify('invoke', ['register', l:args])
 endfunction
 
 function! s:find_plugin(plugin) abort


### PR DESCRIPTION
We asssumed that this change would improve loading performance of denops plugins.