### PR TITLE
:+1: Use vim9script to improve performance on Vim

### DIFF
--- a/autoload/denops/api/vim.vim
+++ b/autoload/denops/api/vim.vim
@@ -1,36 +1,75 @@
-" NOTE:
-" This is a workaround function to detect errors in Vim while Vim 8.2.3081 or
-" above SILENCE any errors occurred in `call` channel command.
-" https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
-function! denops#api#vim#call(fn, args) abort
-  try
-    let l:result = call(a:fn, a:args)
-    if g:denops#debug
-      " Check if the result is serializable
-      call json_encode(l:result)
-    endif
-    return [l:result, '']
-  catch
-    return [v:null, v:exception . "\n" . v:throwpoint]
-  endtry
-endfunction
+if !has('vim9script')
+  " NOTE:
+  " This is a workaround function to detect errors in Vim while Vim 8.2.3081 or
+  " above SILENCE any errors occurred in `call` channel command.
+  " https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
+  function! denops#api#vim#call(fn, args) abort
+    try
+      let l:result = call(a:fn, a:args)
+      if g:denops#debug
+        " Check if the result is serializable
+        call json_encode(l:result)
+      endif
+      return [l:result, '']
+    catch
+      return [v:null, v:exception . "\n" . v:throwpoint]
+    endtry
+  endfunction
 
-" NOTE:
-" This is a workaround function to detect errors in Vim while Vim 8.2.3081 or
-" above SILENCE any errors occurred in `call` channel command.
-" https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
-function! denops#api#vim#batch(calls) abort
-  let l:results = []
-  try
-    for l:Call in a:calls
-      call add(l:results, call(l:Call[0], l:Call[1:]))
-    endfor
-    if g:denops#debug
-      " Check if the result is serializable
-      call json_encode(l:results)
-    endif
-    return [l:results, '']
-  catch
-    return [l:results, v:exception . "\n" . v:throwpoint]
-  endtry
-endfunction
+  " NOTE:
+  " This is a workaround function to detect errors in Vim while Vim 8.2.3081 or
+  " above SILENCE any errors occurred in `call` channel command.
+  " https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
+  function! denops#api#vim#batch(calls) abort
+    let l:results = []
+    try
+      for l:Call in a:calls
+        call add(l:results, call(l:Call[0], l:Call[1:]))
+      endfor
+      if g:denops#debug
+        " Check if the result is serializable
+        call json_encode(l:results)
+      endif
+      return [l:results, '']
+    catch
+      return [l:results, v:exception . "\n" . v:throwpoint]
+    endtry
+  endfunction
+else
+  " NOTE:
+  " This is a workaround function to detect errors in Vim while Vim 8.2.3081 or
+  " above SILENCE any errors occurred in `call` channel command.
+  " https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
+  def denops#api#vim#call(fn: any, args: list<any>): list<any>
+    try
+      var result = call(fn, args)
+      if g:denops#debug
+        # Check if the result is serializable
+        json_encode(result)
+      endif
+      return [result, '']
+    catch
+      return [null, v:exception .. "\n" .. v:throwpoint]
+    endtry
+  enddef
+
+  " NOTE:
+  " This is a workaround function to detect errors in Vim while Vim 8.2.3081 or
+  " above SILENCE any errors occurred in `call` channel command.
+  " https://github.com/vim/vim/commit/11a632d60bde616feb298d180108819ebb1d04a0
+  def denops#api#vim#batch(calls: list<any>): list<any>
+    var results = []
+    try
+      for call_item in calls
+        add(results, call(call_item[0], slice(call_item, 1)))
+      endfor
+      if g:denops#debug
+        # Check if the result is serializable
+        json_encode(results)
+      endif
+      return [results, '']
+    catch
+      return [results, v:exception .. "\n" .. v:throwpoint]
+    endtry
+  enddef
+endif


### PR DESCRIPTION
SSIA

### Before

```
info
  size:   64 bytes
  count:  1000
  n:      100
denops.call()
  sum:     12541 ms
  mean:    125.4 ms
  median:  120.3 ms
  stddev:  22.0
  stderr:  2.2 ms
  opms:    8.1±0.1 ops/ms
  cpms:    519.0±5.4 chars/ms
denops.batch()
  sum:     582 ms
  mean:    5.8 ms
  median:  5.5 ms
  stddev:  2.5
  stderr:  0.2 ms
  opms:    178.4±1.7 ops/ms
  cpms:    11418.2±111.7 chars/ms
```

### After

```
info
  size:   64 bytes
  count:  1000
  n:      100
denops.call()
  sum:     12124 ms
  mean:    121.2 ms
  median:  115.7 ms
  stddev:  23.1
  stderr:  2.3 ms
  opms:    8.4±0.1 ops/ms
  cpms:    538.1±5.9 chars/ms
denops.batch()
  sum:     408 ms
  mean:    4.1 ms
  median:  3.3 ms
  stddev:  4.7
  stderr:  0.5 ms
  opms:    289.0±4.4 ops/ms
  cpms:    18493.5±279.4 chars/ms
```