### PR TITLE
:bug: Fix MessagePack-RPC error handling

### DIFF
--- a/denops/@denops-private/error.ts
+++ b/denops/@denops-private/error.ts
@@ -1,0 +1,29 @@
+import {
+  isObject,
+  isString,
+} from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+
+export function errorSerializer(err: unknown): unknown {
+  if (err instanceof Error) {
+    return JSON.stringify({
+      name: err.name,
+      message: err.message || String(err),
+      stack: err.stack,
+    });
+  }
+  return String(err);
+}
+
+export function errorDeserializer(err: unknown): unknown {
+  if (isString(err)) {
+    try {
+      const obj = JSON.parse(err);
+      if (isObject(obj) && isString(obj.message)) {
+        return Object.assign(new Error(obj.message), obj);
+      }
+    } catch {
+      // Do NOTHING
+    }
+  }
+  return err;
+}

--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -10,7 +10,7 @@ import {
 import {
   Client,
   Session,
-} from "https://deno.land/x/messagepack_rpc@v1.0.0/mod.ts#^";
+} from "https://deno.land/x/messagepack_rpc@v2.0.0/mod.ts#^";
 import {
   readableStreamFromWorker,
   writableStreamFromWorker,
@@ -18,6 +18,7 @@ import {
 import { Disposable } from "https://deno.land/x/disposable@v1.1.1/mod.ts#^";
 import { Host } from "./host/base.ts";
 import { Invoker, RegisterOptions, ReloadOptions } from "./host/invoker.ts";
+import { errorDeserializer, errorSerializer } from "./error.ts";
 import type { Meta } from "../@denops/mod.ts";
 
 const workerScript = "./worker/script.ts";
@@ -84,7 +85,7 @@ export class Service implements Disposable {
       script,
       worker,
       session,
-      client: new Client(session),
+      client: new Client(session, { errorDeserializer }),
     });
   }
 
@@ -142,7 +143,9 @@ function buildServiceSession(
   writer: WritableStream<Uint8Array>,
   service: Service,
 ) {
-  const session = new Session(reader, writer);
+  const session = new Session(reader, writer, {
+    errorSerializer,
+  });
   session.onMessageError = (error, message) => {
     if (error instanceof Error && error.name === "Interrupted") {
       return;


### PR DESCRIPTION
Upgrade messagepack_rpc to controll how to serialize/deserialize error object in MessagePack-RPC

Close #259

With `InvokeError` on https://github.com/vim-denops/denops-error-test.vim

```
Error detected while processing function denops#request[1]..denops#server#request[4]..denops#_internal#server#chan#request[4]..denops#_internal#rpc#nvim#request:
line    1:
Error invoking 'invoke' on channel 8:
Error: This is error from denops-error-test.vim
    at Object.error (file:///Users/alisue/ghq/github.com/vim-denops/denops-error-test.vim/denops/error-test/main.ts#62.92325:6:13)
    at dispatch (https://deno.land/x/messagepack_rpc@v2.0.0/dispatcher.ts:36:36)
    at Session.#dispatch (https://deno.land/x/messagepack_rpc@v2.0.0/session.ts:244:28)
    at Session.#handleRequestMessage (https://deno.land/x/messagepack_rpc@v2.0.0/session.ts:271:53)
    at Session.#handleMessage (https://deno.land/x/messagepack_rpc@v2.0.0/session.ts:255:37)
    at Object.write (https://deno.land/x/messagepack_rpc@v2.0.0/session.ts:159:63)
    at Module.invokeCallbackFunction (ext:deno_webidl/00_webidl.js:966:16)
    at WritableStreamDefaultController.writeAlgorithm (ext:deno_web/06_streams.js:3673:14)
    at writableStreamDefaultControllerProcessWrite (ext:deno_web/06_streams.js:4175:55)
    at writableStreamDefaultControllerAdvanceQueueIfNeeded (ext:deno_web/06_streams.js:4078:5)
```