### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/denops/@denops-private/cli.ts
+++ b/denops/@denops-private/cli.ts
@@ -1,6 +1,6 @@
-import { parse } from "https://deno.land/std@0.194.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.204.0/flags/mod.ts";
 import { pop } from "https://deno.land/x/streamtools@v0.5.0/mod.ts";
-import { using as usingResource } from "https://deno.land/x/disposable@v1.1.1/mod.ts#^";
+import { using as usingResource } from "https://deno.land/x/disposable@v1.2.0/mod.ts#^";
 import { Service } from "./service.ts";
 import { Vim } from "./host/vim.ts";
 import { Neovim } from "./host/nvim.ts";

--- a/denops/@denops-private/error.ts
+++ b/denops/@denops-private/error.ts
@@ -1,4 +1,4 @@
-import { is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts#^";
+import { is } from "https://deno.land/x/unknownutil@v3.10.0/mod.ts#^";
 
 export function errorSerializer(err: unknown): unknown {
   if (err instanceof Error) {

--- a/denops/@denops-private/host/base.ts
+++ b/denops/@denops-private/host/base.ts
@@ -1,4 +1,4 @@
-import type { Disposable } from "https://deno.land/x/disposable@v1.1.1/mod.ts#^";
+import type { Disposable } from "https://deno.land/x/disposable@v1.2.0/mod.ts#^";
 import { Invoker } from "./invoker.ts";
 
 /**

--- a/denops/@denops-private/host/invoker.ts
+++ b/denops/@denops-private/host/invoker.ts
@@ -1,4 +1,4 @@
-import { is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts#^";
+import { is } from "https://deno.land/x/unknownutil@v3.10.0/mod.ts#^";
 import { Service } from "../service.ts";
 import type { Meta } from "../../@denops/mod.ts";
 

--- a/denops/@denops-private/host/nvim.ts
+++ b/denops/@denops-private/host/nvim.ts
@@ -1,4 +1,4 @@
-import { assert, is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts#^";
+import { assert, is } from "https://deno.land/x/unknownutil@v3.10.0/mod.ts#^";
 import {
   Client,
   Session,

--- a/denops/@denops-private/impl_test.ts
+++ b/denops/@denops-private/impl_test.ts
@@ -1,8 +1,8 @@
-import * as path from "https://deno.land/std@0.194.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.204.0/path/mod.ts";
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.194.0/testing/asserts.ts";
+} from "https://deno.land/std@0.204.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts#^";
 import { BatchError } from "../@denops/mod.ts";
 

--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -1,5 +1,5 @@
-import { toFileUrl } from "https://deno.land/std@0.194.0/path/mod.ts";
-import { assert, is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts#^";
+import { toFileUrl } from "https://deno.land/std@0.204.0/path/mod.ts";
+import { assert, is } from "https://deno.land/x/unknownutil@v3.10.0/mod.ts#^";
 import {
   Client,
   Session,
@@ -8,7 +8,7 @@ import {
   readableStreamFromWorker,
   writableStreamFromWorker,
 } from "https://deno.land/x/workerio@v3.1.0/mod.ts#^";
-import { Disposable } from "https://deno.land/x/disposable@v1.1.1/mod.ts#^";
+import { Disposable } from "https://deno.land/x/disposable@v1.2.0/mod.ts#^";
 import { Host } from "./host/base.ts";
 import { Invoker, RegisterOptions, ReloadOptions } from "./host/invoker.ts";
 import { traceReadableStream, traceWritableStream } from "./trace_stream.ts";

--- a/denops/@denops-private/version.ts
+++ b/denops/@denops-private/version.ts
@@ -1,8 +1,8 @@
 import {
   dirname,
   fromFileUrl,
-} from "https://deno.land/std@0.197.0/path/mod.ts";
-import { parse, SemVer } from "https://deno.land/std@0.197.0/semver/mod.ts";
+} from "https://deno.land/std@0.204.0/path/mod.ts";
+import { parse, SemVer } from "https://deno.land/std@0.204.0/semver/mod.ts";
 
 const decoder = new TextDecoder();
 

--- a/denops/@denops-private/worker/script.ts
+++ b/denops/@denops-private/worker/script.ts
@@ -1,4 +1,4 @@
-import { assert, is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts#^";
+import { assert, is } from "https://deno.land/x/unknownutil@v3.10.0/mod.ts#^";
 import {
   Client,
   Session,


### PR DESCRIPTION
The output of `make update` is

```
/home/runner/work/denops.vim/denops.vim/denops/@denops-private/error.ts
[1/1] Looking for releases: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^
[1/1] Attempting update: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ -> v3.10.0
[1/1] Update successful: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ -> v3.10.0

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/trace_stream.ts
[1/3] Looking for releases: https://deno.land/x/streamtools@v0.5.0/mod.ts
[1/3] Using latest: https://deno.land/x/streamtools@v0.5.0/mod.ts
[2/3] Looking for releases: https://deno.land/x/messagepack@v1.0.0/mod.ts
[2/3] Using latest: https://deno.land/x/messagepack@v1.0.0/mod.ts
[3/3] Looking for releases: https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts
[3/3] Using latest: https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/impl.ts

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/cli.ts
[1/3] Looking for releases: https://deno.land/std@0.194.0/flags/mod.ts
[1/3] Attempting update: https://deno.land/std@0.194.0/flags/mod.ts -> 0.204.0
[1/3] Update successful: https://deno.land/std@0.194.0/flags/mod.ts -> 0.204.0
[2/3] Looking for releases: https://deno.land/x/streamtools@v0.5.0/mod.ts
[2/3] Using latest: https://deno.land/x/streamtools@v0.5.0/mod.ts
[3/3] Looking for releases: https://deno.land/x/disposable@v1.1.1/mod.ts#^
[3/3] Attempting update: https://deno.land/x/disposable@v1.1.1/mod.ts#^ -> v1.2.0
[3/3] Update successful: https://deno.land/x/disposable@v1.1.1/mod.ts#^ -> v1.2.0

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/version.ts
[1/2] Looking for releases: https://deno.land/std@0.197.0/path/mod.ts
[1/2] Attempting update: https://deno.land/std@0.197.0/path/mod.ts -> 0.204.0
[1/2] Update successful: https://deno.land/std@0.197.0/path/mod.ts -> 0.204.0
[2/2] Looking for releases: https://deno.land/std@0.197.0/semver/mod.ts
[2/2] Attempting update: https://deno.land/std@0.197.0/semver/mod.ts -> 0.204.0
[2/2] Update successful: https://deno.land/std@0.197.0/semver/mod.ts -> 0.204.0

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/worker/patch_console.ts

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/worker/script.ts
[1/3] Looking for releases: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^
[1/3] Attempting update: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ -> v3.10.0
[1/3] Update successful: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ -> v3.10.0
[2/3] Looking for releases: https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts#^
[2/3] Using latest: https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts#^
[3/3] Looking for releases: https://deno.land/x/workerio@v3.1.0/mod.ts#^
[3/3] Using latest: https://deno.land/x/workerio@v3.1.0/mod.ts#^

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/service.ts
[1/5] Looking for releases: https://deno.land/std@0.194.0/path/mod.ts
[1/5] Attempting update: https://deno.land/std@0.194.0/path/mod.ts -> 0.204.0
[1/5] Update successful: https://deno.land/std@0.194.0/path/mod.ts -> 0.204.0
[2/5] Looking for releases: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^
[2/5] Attempting update: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ -> v3.10.0
[2/5] Update successful: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ -> v3.10.0
[3/5] Looking for releases: https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts#^
[3/5] Using latest: https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts#^
[4/5] Looking for releases: https://deno.land/x/workerio@v3.1.0/mod.ts#^
[4/5] Using latest: https://deno.land/x/workerio@v3.1.0/mod.ts#^
[5/5] Looking for releases: https://deno.land/x/disposable@v1.1.1/mod.ts#^
[5/5] Attempting update: https://deno.land/x/disposable@v1.1.1/mod.ts#^ -> v1.2.0
[5/5] Update successful: https://deno.land/x/disposable@v1.1.1/mod.ts#^ -> v1.2.0

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/impl_test.ts
[1/3] Looking for releases: https://deno.land/std@0.194.0/path/mod.ts
[1/3] Attempting update: https://deno.land/std@0.194.0/path/mod.ts -> 0.204.0
[1/3] Update successful: https://deno.land/std@0.194.0/path/mod.ts -> 0.204.0
[2/3] Looking for releases: https://deno.land/std@0.194.0/testing/asserts.ts
[2/3] Attempting update: https://deno.land/std@0.194.0/testing/asserts.ts -> 0.204.0
[2/3] Update successful: https://deno.land/std@0.194.0/testing/asserts.ts -> 0.204.0
[3/3] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts#^
[3/3] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts#^

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/defs.ts

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/host/base.ts
[1/1] Looking for releases: https://deno.land/x/disposable@v1.1.1/mod.ts#^
[1/1] Attempting update: https://deno.land/x/disposable@v1.1.1/mod.ts#^ -> v1.2.0
[1/1] Update successful: https://deno.land/x/disposable@v1.1.1/mod.ts#^ -> v1.2.0

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/host/invoker.ts
[1/1] Looking for releases: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^
[1/1] Attempting update: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ -> v3.10.0
[1/1] Update successful: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ -> v3.10.0

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/host/vim.ts
[1/1] Looking for releases: https://deno.land/x/vim_channel_command@v2.0.0/mod.ts
[1/1] Using latest: https://deno.land/x/vim_channel_command@v2.0.0/mod.ts

/home/runner/work/denops.vim/denops.vim/denops/@denops-private/host/nvim.ts
[1/2] Looking for releases: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^
[1/2] Attempting update: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ -> v3.10.0
[1/2] Update successful: https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ -> v3.10.0
[2/2] Looking for releases: https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts#^
[2/2] Using latest: https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts#^

/home/runner/work/denops.vim/denops.vim/denops/@denops/mod.ts

/home/runner/work/denops.vim/denops.vim/denops/@denops/denops.ts

Already latest version:
https://deno.land/x/streamtools@v0.5.0/mod.ts == v0.5.0
https://deno.land/x/messagepack@v1.0.0/mod.ts == v1.0.0
https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts == v2.0.3
https://deno.land/x/streamtools@v0.5.0/mod.ts == v0.5.0
https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts#^ == v2.0.3
https://deno.land/x/workerio@v3.1.0/mod.ts#^ == v3.1.0
https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts#^ == v2.0.3
https://deno.land/x/workerio@v3.1.0/mod.ts#^ == v3.1.0
https://deno.land/x/denops_test@v1.4.0/mod.ts#^ == v1.4.0
https://deno.land/x/vim_channel_command@v2.0.0/mod.ts == v2.0.0
https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts#^ == v2.0.3

Successfully updated:
https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ v3.2.0 -> v3.10.0
https://deno.land/std@0.194.0/flags/mod.ts 0.194.0 -> 0.204.0
https://deno.land/x/disposable@v1.1.1/mod.ts#^ v1.1.1 -> v1.2.0
https://deno.land/std@0.197.0/path/mod.ts 0.197.0 -> 0.204.0
https://deno.land/std@0.197.0/semver/mod.ts 0.197.0 -> 0.204.0
https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ v3.2.0 -> v3.10.0
https://deno.land/std@0.194.0/path/mod.ts 0.194.0 -> 0.204.0
https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ v3.2.0 -> v3.10.0
https://deno.land/x/disposable@v1.1.1/mod.ts#^ v1.1.1 -> v1.2.0
https://deno.land/std@0.194.0/path/mod.ts 0.194.0 -> 0.204.0
https://deno.land/std@0.194.0/testing/asserts.ts 0.194.0 -> 0.204.0
https://deno.land/x/disposable@v1.1.1/mod.ts#^ v1.1.1 -> v1.2.0
https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ v3.2.0 -> v3.10.0
https://deno.land/x/unknownutil@v3.2.0/mod.ts#^ v3.2.0 -> v3.10.0

```