### PR TITLE
☕ Disable release workflow on forked repositories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'vim-denops'
     strategy:
       matrix:
         # NOTE:


### PR DESCRIPTION
Cause I found it awkward to see the workflow always fails on my fork.