### PR TITLE
:coffee: Change action-setup-vim to rhysd/action-setup-vim

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,35 +68,33 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: "${{ matrix.version }}"
-      - uses: thinca/action-setup-vim@v1
+      - uses: rhysd/action-setup-vim@v1
         id: vim
         with:
-          vim_type: "Vim"
-          vim_version: "${{ matrix.host_version.vim }}"
-          download: "never"
+          version: "${{ matrix.host_version.vim }}"
       - name: Check Vim
         run: |
           echo ${DENOPS_TEST_VIM}
           ${DENOPS_TEST_VIM} --version
         env:
-          DENOPS_TEST_VIM: ${{ steps.vim.outputs.executable_path }}
-      - uses: thinca/action-setup-vim@v1
+          DENOPS_TEST_VIM: ${{ steps.vim.outputs.executable }}
+      - uses: rhysd/action-setup-vim@v1
         id: nvim
         with:
-          vim_type: "Neovim"
-          vim_version: "${{ matrix.host_version.nvim }}"
+          neovim: true
+          version: "${{ matrix.host_version.nvim }}"
       - name: Check Neovim
         run: |
           echo ${DENOPS_TEST_NVIM}
           ${DENOPS_TEST_NVIM} --version
         env:
-          DENOPS_TEST_NVIM: ${{ steps.nvim.outputs.executable_path }}
+          DENOPS_TEST_NVIM: ${{ steps.nvim.outputs.executable }}
       - name: Test
         run: deno task test
         env:
           DENOPS_TEST_DENOPS_PATH: "./"
-          DENOPS_TEST_VIM_EXECUTABLE: ${{ steps.vim.outputs.executable_path }}
-          DENOPS_TEST_NVIM_EXECUTABLE: ${{ steps.nvim.outputs.executable_path }}
+          DENOPS_TEST_VIM_EXECUTABLE: ${{ steps.vim.outputs.executable }}
+          DENOPS_TEST_NVIM_EXECUTABLE: ${{ steps.nvim.outputs.executable }}
         timeout-minutes: 5
       - run: |
           deno coverage --unstable .coverage --lcov > coverage.lcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: "0 7 * * 0"
   push:
-    branches:
-      - main
     paths:
       - "**.md"
       - "**.ts"


### PR DESCRIPTION
Just trying to fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the GitHub Actions workflow to enhance the setup process for Vim and Neovim environments.

- **Refactor**
  - Streamlined the configuration parameters for setting up Vim and Neovim in the continuous integration pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->