### PR TITLE
Add g:denops#deno_dir to set deno cache directory

### DIFF
--- a/autoload/denops.vim
+++ b/autoload/denops.vim
@@ -19,6 +19,7 @@ endfunction
 " Configuration
 call denops#_internal#conf#define('denops#disabled', 0)
 call denops#_internal#conf#define('denops#deno', 'deno')
+call denops#_internal#conf#define('denops#deno_dir', v:null)
 call denops#_internal#conf#define('denops#debug', 0)
 call denops#_internal#conf#define('denops#trace', 0)
 call denops#_internal#conf#define('denops#disable_deprecation_warning_message', 0)

--- a/autoload/denops/_internal/server/proc.vim
+++ b/autoload/denops/_internal/server/proc.vim
@@ -71,13 +71,17 @@ function! s:start(options) abort
         \ '--identity',
         \ '--port', '0',
         \]
+  let l:env = {
+        \   'NO_COLOR': 1,
+        \   'DENO_NO_PROMPT': 1,
+        \ }
+  if g:denops#deno_dir isnot# v:null
+    let l:env['DENO_DIR'] = g:denops#deno_dir
+  endif
   let l:store = {'prepared': 0}
   let s:stopped_on_purpose = 0
   let s:job = denops#_internal#job#start(l:args, {
-        \ 'env': {
-        \   'NO_COLOR': 1,
-        \   'DENO_NO_PROMPT': 1,
-        \ },
+        \ 'env': l:env,
         \ 'on_stdout': { _job, data, _event -> s:on_stdout(l:store, data) },
         \ 'on_stderr': { _job, data, _event -> s:on_stderr(data) },
         \ 'on_exit': { _job, status, _event -> s:on_exit(a:options, status) },

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -81,6 +81,12 @@ VARIABLE						*denops-variable*
 	Deno if 'deno' is not in PATH.
 	Default: 'deno'
 
+*g:denops#deno_dir*
+	Cache directory of Deno. If unspecified, the cache directory is
+        determined by the DENO_DIR environment variable or internally by
+        'deno'.
+	Default: |v:null|
+
 *g:denops#debug*
 	Set 1 to enable debug mode. In debug mode, the additional debug
 	messages of denops itself will be shown.


### PR DESCRIPTION
- 👍 allow specifying deno cache directory by g:denops#deno_dir
- 📝 document g:denops#deno_dir

In the current implementation, denops shares the deno cache directory with system.
This may lead slow startup of denops plugins when cache invalidates.

The typical invalidation occurs when the versions of deno are different among system and denops.

To improve the experience, I want to isolate deno version and cache directory for denops like below.

``` vim
let g:denops#deno = /path/to/deno/bin/deno
let g:denops#deno_dir = /path/to/deno/cache
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option `denops#deno_dir` to customize the Deno cache directory.

- **Documentation**
  - Updated documentation to include the new `g:denops#deno_dir` variable and its usage.

- **Bug Fixes**
  - Ensured that the `DENO_DIR` environment variable is set correctly based on user configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->