### PR TITLE
:+1: RPC request directly from lua to avoid conversion with Vim script

### DIFF
--- a/autoload/denops/_internal/rpc/nvim.vim
+++ b/autoload/denops/_internal/rpc/nvim.vim
@@ -13,6 +13,7 @@ function! denops#_internal#rpc#nvim#connect(addr, ...) abort
         \ '_id': l:id,
         \ '_on_close': l:options.on_close,
         \}
+  call luaeval('require("denops")._set_channel(_A[1])', [l:id])
   let l:chan._healthcheck_timer = timer_start(
         \ g:denops#_internal#rpc#nvim#healthcheck_interval,
         \ funcref('s:healthcheck', [l:chan]),

--- a/lua/denops.lua
+++ b/lua/denops.lua
@@ -1,0 +1,27 @@
+local M = {}
+
+local channel = 0
+
+function M._set_channel(id)
+  channel = id
+end
+
+function M.request(plugin, method, params)
+  if vim.g["denops#disabled"] == 1 then
+    return
+  elseif channel == 0 then
+    error("[denops] Channel is not ready yet")
+  end
+  return vim.rpcrequest(channel, "invoke", "dispatch", { plugin, method, params })
+end
+
+function M.notify(plugin, method, params)
+  if vim.g["denops#disabled"] == 1 then
+    return
+  elseif channel == 0 then
+    error("[denops] Channel is not ready yet")
+  end
+  vim.rpcnotify(channel, "invoke", "dispatch", { plugin, method, params })
+end
+
+return M


### PR DESCRIPTION
SSIA
Conversion may affect performance.

# Test

- denops/rc/main.ts
```typescript
import { Denops } from "https://deno.land/x/denops_std@v5.2.0/mod.ts";

export function main(denops: Denops) {
  denops.dispatcher = {
    nochange(x: unknown): unknown {
      return x;
    },
  };
}
```

- time.lua
```lua
local x = vim.lsp.protocol.make_client_capabilities()

-- vim.fn['denops#request']()
local start = vim.fn.reltime()
for _ = 1, 1000 do
  _ = vim.fn["denops#request"]("rc", "nochange", { x })
end
print(("vim.fn['denops#request'](): %.4f s"):format(vim.fn.reltimefloat(vim.fn.reltime(start))))

-- require('denops').request()
start = vim.fn.reltime()
for _ = 1, 1000 do
  _ = require("denops").request("rc", "nochange", { x })
end
print(("require('denops').request(): %.4f s"):format(vim.fn.reltimefloat(vim.fn.reltime(start))))
```

- Source `time.lua`.

```vim
source %
```

- Result
```
vim.fn['denops#request'](): 0.5875 s
require('denops').request(): 0.4746 s
```
