### PR TITLE
fix typo? in the document: "denops#call#register"

### DIFF
--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -361,12 +361,12 @@ denops#callback#register({callback}[, {options}])
 			Default: |v:false|
 >
 	" Persistent callback
-	let id = denops#call#register({ a, b -> a + b })
+	let id = denops#callback#register({ a, b -> a + b })
 	let ret1 = denops#callback#call(id, 1, 2)
 	let ret2 = denops#callback#call(id, 2, 3)
 
 	" One-time callback
-	let id = denops#call#register({ a, b -> a + b }, { 'once': v:true })
+	let id = denops#callback#register({ a, b -> a + b }, { 'once': v:true })
 	let ret1 = denops#callback#call(id, 1, 2)
 <
 						*denops#callback#unregister()*


### PR DESCRIPTION
fixed to: "denops#callback#register"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed the function for registering callbacks to improve clarity and usage.
	- Enhanced callback registration to support both persistent and one-time callbacks.

- **Documentation**
	- Updated documentation to reflect changes in callback registration function and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->