### PR TITLE
Remove --unstable flag in default

### DIFF
--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -151,7 +151,6 @@ augroup END
 call denops#_internal#conf#define('denops#server#deno_args', [
       \ '-q',
       \ '--no-lock',
-      \ '--unstable',
       \ '-A',
       \])
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,9 +1,9 @@
 {
   "lock": false,
   "tasks": {
-    "test": "deno test --unstable -A --parallel --shuffle --doc --coverage=.coverage",
-    "check": "deno check --unstable $(find . -name '*.ts')",
-    "coverage": "deno coverage --unstable .coverage",
+    "test": "deno test -A --parallel --shuffle --doc --coverage=.coverage",
+    "check": "deno check $(find . -name '*.ts')",
+    "coverage": "deno coverage .coverage",
     "upgrade": "deno run -q -A https://deno.land/x/molt@0.11.0/cli.ts ./**/*.ts",
     "upgrade:commit": "deno task -q upgrade --commit --prefix :package: --pre-commit=fmt"
   }

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -105,7 +105,7 @@ VARIABLE						*denops-variable*
 
 *g:denops#server#deno_args*
 	Program arguments of Deno for starting a server.
-	Default: ['-q', '--no-lock', '--unstable', '-A']
+	Default: ['-q', '--no-lock', '-A']
 
 *g:denops#server#restart_delay*
 	Restart delay in milliseconds to avoid #136.


### PR DESCRIPTION
Because `--unstable` flag will be removed in Deno 2.0 and Deno 1.40 has the warnings.

~~It should not be merged yet.  Because if `--unstable` flag is removed, Deno kv storage cannot be used.~~

Deno KV works in Deno 1.40 without `--unstable`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the `--unstable` flag to enhance stability and compatibility.
	- Adjusted server restart delay to prevent related issues.
- **Documentation**
	- Updated default program arguments in documentation.
- **Chores**
	- Updated the `molt` module to version `0.11.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->