### PR TITLE
:+1: Print human-readable error object in console output

### DIFF
--- a/denops/@denops-private/worker.ts
+++ b/denops/@denops-private/worker.ts
@@ -26,7 +26,9 @@ async function detectHost(
 
 function formatArgs(args: unknown[]): string[] {
   return args.map((v) => {
-    if (typeof v === "string") {
+    if (v instanceof Error) {
+      return `${v.stack ?? v}`;
+    } else if (typeof v === "string") {
       return v;
     }
     return JSON.stringify(v);


### PR DESCRIPTION
Improve `console.*` methods when specify `Error` object.
This is for debugging purposes used by plugin developers.

Example of use:
```ts
try {
  somethingError();
} catch (e: unknown) {
  console.error(e);
}
```

Example output:
```
[denops] TypeError: This is my something error
[denops]     at innerSomethingError (file:///your/plugin/denops/foo.ts:50:12)
[denops]     at somethingError (file:///your/plugin/denops/foo.ts:30:10)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error logging by including stack traces for better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->