### PR TITLE
Print time when debug mode

### DIFF
--- a/autoload/denops/_internal/echo.vim
+++ b/autoload/denops/_internal/echo.vim
@@ -28,10 +28,11 @@ function! denops#_internal#echo#error(...) abort
   call s:echomsg('ErrorMsg', a:000)
 endfunction
 
+let s:start = reltime()
 function! s:echomsg(hl, msg) abort
   execute printf('echohl %s', a:hl)
   for l:line in split(join(a:msg), '\n')
-    echomsg printf('[denops] %s', l:line)
+    echomsg printf('[denops] %s %s', reltimestr(reltime(s:start)), l:line)
   endfor
   echohl None
 endfunction


### PR DESCRIPTION
I think it is useful to optimize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced message display with timing information, showing the relative time since a start point alongside the message content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

```
[denops]   0.000075 Spawn server [1/4]
[denops]   0.007895 Server started: ['deno', 'run', '-q', '-A', '--unstable-kv', '/home/shougo/work/denops.vim/denops/@denops-private/cli.ts', '--quiet', '--id
entity', '--port', '0']
[denops]   0.231389 Server listen: 127.0.0.1:39325
[denops]   0.231663 Connecting to channel `127.0.0.1:39325` [1/4]
[denops]   0.234281 Channel connected (127.0.0.1:39325)
[denops]   0.478193 DenopsReady
[denops]   0.484017 2 plugins are discovered
[denops]   0.484258 load plugin: ['kensaku', '/home/shougo/.cache/dpp/repos/github.com/lambdalisue/kensaku.vim/denops/kensaku/main.ts']
[denops]   0.484643 load plugin: ['skkeleton', '/home/shougo/work/skkeleton/denops/skkeleton/main.ts']
[denops]   0.485152 load plugin: ['ddc', '/home/shougo/work/ddc.vim/denops/ddc/app.ts']
[denops]   0.485637 load plugin: ['ddu', '/home/shougo/work/ddu.vim/denops/ddu/app.ts']
[denops]   0.531763 DenopsPluginPre:kensaku
[denops]   1.061115 DenopsPluginPre:skkeleton
[denops]   2.175855 DenopsPluginPre:ddc
[denops]   2.176733 DenopsPluginPost:kensaku
[denops]   2.990363 DenopsPluginPre:ddu
[denops]   3.000417 DenopsPluginPost:ddc
[denops]   3.006040 DenopsPluginPost:ddu
[denops]   3.007388 DenopsPluginPost:skkeleton
```