### PR TITLE
:bug: Fix denops crash on UnhandledRejection error

### DIFF
--- a/denops/@denops-private/worker.ts
+++ b/denops/@denops-private/worker.ts
@@ -75,6 +75,7 @@ async function main(): Promise<void> {
       ...formatArgs(args),
     );
   };
+
   // Start service
   using service = new Service(meta);
   await host.init(service);
@@ -83,6 +84,12 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
+  // Avoid denops server crash via UnhandledRejection
+  globalThis.addEventListener("unhandledrejection", (event) => {
+    event.preventDefault();
+    console.error(`Unhandled rejection:`, event.reason);
+  });
+
   await main().catch((err) => {
     console.error(
       `Internal error occurred in Worker`,


### PR DESCRIPTION
Without this PR, errors on for example `setTimeout` cause Denops crash like

![CleanShot 2024-02-29 at 22 17 26](https://github.com/vim-denops/denops.vim/assets/546312/00808be1-fb95-4464-ad62-8484cf23e7c3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Enhanced stability by preventing server crashes from unhandled rejections with a global event listener.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->