### PR TITLE
Put a link for denops_std API reference

### DIFF
--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -20,8 +20,9 @@ using Deno.
 
 Visit the Denops Document or Wiki for guidance on creating denops plugins.
 
-https://vim-denops.github.io/denops-documentation/
-https://github.com/vim-denops/denops.vim/wiki
+Denops Document: https://vim-denops.github.io/denops-documentation/
+Wiki: https://github.com/vim-denops/denops.vim/wiki
+API Reference: https://deno.land/x/denops_std/mod.ts
 
 
 =============================================================================


### PR DESCRIPTION
The API for `denops_std` is documented in deno.land, but I still often get lost trying to reach it.

https://deno.land/x/denops_std/mod.ts

I would like to put a link to the `denops_std` API reference in the help document.

Referred issue: #329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated URLs for Denops Document and Wiki.
	- Added a new link to the API Reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->