### PR TITLE
:bug: Do NOT throw an error on `denops#server#close`

### DIFF
--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -29,9 +29,7 @@ function! denops#server#stop() abort
 endfunction
 
 function! denops#server#restart() abort
-  if denops#_internal#server#proc#is_started()
-    call denops#server#stop()
-  endif
+  call denops#server#stop()
   call denops#server#start()
 endfunction
 
@@ -58,13 +56,14 @@ function! denops#server#connect() abort
 endfunction
 
 function! denops#server#close() abort
+  if !denops#_internal#server#chan#is_connected()
+    return
+  endif
   call denops#_internal#server#chan#close()
 endfunction
 
 function! denops#server#reconnect() abort
-  if denops#_internal#server#chan#is_connected()
-    call denops#server#close()
-  endif
+  call denops#server#close()
   call denops#server#connect()
 endfunction
 


### PR DESCRIPTION
Close #337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in channel operations by adding a debug message when attempting to close a non-existent channel.
	- Simplified logic in `denops#server#restart()` and `denops#server#reconnect()` functions for better control flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->