### PR TITLE
:muscle: Use type alias instead of comments

### DIFF
--- a/denops/@denops-private/host.ts
+++ b/denops/@denops-private/host.ts
@@ -45,6 +45,7 @@ export type HostConstructor = {
 };
 
 // Minimum interface of Service that Host is relies on
+type CallbackId = string;
 export type Service = {
   bind(host: Host): void;
   load(name: string, script: string): Promise<void>;
@@ -54,8 +55,8 @@ export type Service = {
     name: string,
     fn: string,
     args: unknown[],
-    success: string, // Callback ID
-    failure: string, // Callback ID
+    success: CallbackId,
+    failure: CallbackId,
   ): Promise<void>;
 };
 


### PR DESCRIPTION
It seems the latest deno fmt try to format the comments like

```
from /home/runner/work/denops.vim/denops.vim/denops/@denops-private/host.ts:
57 | -    success: string, // Callback ID
57 | +    success: string // Callback ID
58 | -    failure: string, // Callback ID
58 | +    ,
59 | +    failure: string // Callback ID
59 | -  ): Promise<void>;
60 | +    ,
61 | +  ): Promise<void>;
```

But the comment was mainly for documentation, so it is better to use type alias instead of comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced type definitions for better clarity and maintenance in service interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->