### PR TITLE
:+1: Automatically wait the target plugin on `denops.dispatch()`

### DIFF
--- a/denops/@denops-private/denops.ts
+++ b/denops/@denops-private/denops.ts
@@ -13,7 +13,7 @@ const isBatchReturn = is.TupleOf([is.Array, is.String] as const);
 
 export type Host = Pick<HostOrigin, "redraw" | "call" | "batch">;
 
-export type Service = Pick<ServiceOrigin, "dispatch">;
+export type Service = Pick<ServiceOrigin, "dispatch" | "waitLoaded">;
 
 export class DenopsImpl implements Denops {
   readonly name: string;
@@ -67,12 +67,13 @@ export class DenopsImpl implements Denops {
     return this.#host.call("denops#api#eval", expr, ctx);
   }
 
-  dispatch(
+  async dispatch(
     name: string,
     fn: string,
     ...args: unknown[]
   ): Promise<unknown> {
-    return this.#service.dispatch(name, fn, args);
+    await this.#service.waitLoaded(name);
+    return await this.#service.dispatch(name, fn, args);
   }
 }
 

--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -28,7 +28,7 @@ export class Service implements Disposable {
     suffix = "",
   ): Promise<void> {
     if (!this.#host) {
-      throw new Error("No host is bound to the service");
+      return Promise.reject(new Error("No host is bound to the service"));
     }
     let plugin = this.#plugins.get(name);
     if (plugin) {

--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -6,11 +6,18 @@ import { toFileUrl } from "https://deno.land/std@0.217.0/path/mod.ts";
 import { toErrorObject } from "https://deno.land/x/errorutil@v0.1.1/mod.ts";
 import { DenopsImpl, Host } from "./denops.ts";
 
+// We can use `PromiseWithResolvers<void>` but Deno 1.38 doesn't have `PromiseWithResolvers`
+type Waiter = {
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
 /**
  * Service manage plugins and is visible from the host (Vim/Neovim) through `invoke()` function.
  */
 export class Service implements Disposable {
   #plugins: Map<string, Plugin> = new Map();
+  #waiters: Map<string, Waiter> = new Map();
   #meta: Meta;
   #host?: Host;
 
@@ -18,29 +25,37 @@ export class Service implements Disposable {
     this.#meta = meta;
   }
 
+  #getWaiter(name: string): Waiter {
+    if (!this.#waiters.has(name)) {
+      this.#waiters.set(name, Promise.withResolvers());
+    }
+    return this.#waiters.get(name)!;
+  }
+
   bind(host: Host): void {
     this.#host = host;
   }
 
-  load(
+  async load(
     name: string,
     script: string,
     suffix = "",
   ): Promise<void> {
     if (!this.#host) {
-      return Promise.reject(new Error("No host is bound to the service"));
+      throw new Error("No host is bound to the service");
     }
     let plugin = this.#plugins.get(name);
     if (plugin) {
       if (this.#meta.mode === "debug") {
         console.log(`A denops plugin '${name}' is already loaded. Skip`);
       }
-      return Promise.resolve();
+      return;
     }
     const denops = new DenopsImpl(name, this.#meta, this.#host, this);
     plugin = new Plugin(denops, name, script);
     this.#plugins.set(name, plugin);
-    return plugin.load(suffix);
+    await plugin.load(suffix);
+    this.#getWaiter(name).resolve();
   }
 
   reload(
@@ -54,10 +69,15 @@ export class Service implements Disposable {
       return Promise.resolve();
     }
     this.#plugins.delete(name);
+    this.#waiters.delete(name);
     // Import module with fragment so that reload works properly
     // https://github.com/vim-denops/denops.vim/issues/227
     const suffix = `#${performance.now()}`;
     return this.load(name, plugin.script, suffix);
+  }
+
+  waitLoaded(name: string): Promise<void> {
+    return this.#getWaiter(name).promise;
   }
 
   async #dispatch(name: string, fn: string, args: unknown[]): Promise<unknown> {

--- a/denops/@denops-private/service_test.ts
+++ b/denops/@denops-private/service_test.ts
@@ -2,7 +2,6 @@ import {
   assert,
   assertMatch,
   assertRejects,
-  assertThrows,
 } from "https://deno.land/std@0.217.0/assert/mod.ts";
 import {
   assertSpyCall,
@@ -33,8 +32,8 @@ Deno.test("Service", async (t) => {
   };
   const service = new Service(meta);
 
-  await t.step("load() throws an error when no host is bound", () => {
-    assertThrows(
+  await t.step("load() rejects an error when no host is bound", async () => {
+    await assertRejects(
       () => service.load("dummy", scriptValid),
       Error,
       "No host is bound to the service",


### PR DESCRIPTION
Now, denops.dispatch() automatically waits for the target plugin to load, enabling child plugins (e.g., Shougo/ddu-ui-filter for Shougo/ddu) to call the parent plugin's API at any time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Modified the `Service` type to include `waitLoaded` in addition to `dispatch`.
  - Asynchronously wait for plugin loading before dispatching commands.
  - Added a new method `waitLoaded()` to the `service` object.

- **Bug Fixes**
  - Replaced `assertThrows` with `assertRejects` in the `load()` method test for better error handling.

- **Documentation**
  - Updated imports in test files for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->