### PR TITLE
:+1: Add `denops#cache#update()` function to update Deno module cache of denops itself and denops plugins in `runtimepath`

### DIFF
--- a/autoload/denops.vim
+++ b/autoload/denops.vim
@@ -1,18 +1,18 @@
-function! denops#notify(plugin, method, params) abort
+function! denops#notify(name, method, params) abort
   call denops#_internal#server#chan#notify(
         \ 'invoke',
-        \ ['dispatch', [a:plugin, a:method, a:params]],
+        \ ['dispatch', [a:name, a:method, a:params]],
         \)
 endfunction
 
-function! denops#request(plugin, method, params) abort
+function! denops#request(name, method, params) abort
   return denops#_internal#server#chan#request(
         \ 'invoke',
-        \ ['dispatch', [a:plugin, a:method, a:params]],
+        \ ['dispatch', [a:name, a:method, a:params]],
         \)
 endfunction
 
-function! denops#request_async(plugin, method, params, success, failure) abort
+function! denops#request_async(name, method, params, success, failure) abort
   let l:success = denops#callback#register(a:success, {
         \ 'once': v:true,
         \})
@@ -21,7 +21,7 @@ function! denops#request_async(plugin, method, params, success, failure) abort
         \})
   return denops#_internal#server#chan#notify(
         \ 'invoke',
-        \ ['dispatchAsync', [a:plugin, a:method, a:params, l:success, l:failure]],
+        \ ['dispatchAsync', [a:name, a:method, a:params, l:success, l:failure]],
         \)
 endfunction
 

--- a/autoload/denops/_internal/plugin.vim
+++ b/autoload/denops/_internal/plugin.vim
@@ -1,0 +1,24 @@
+function! denops#_internal#plugin#collect() abort
+  let l:pattern = denops#_internal#path#join(['denops', '*', 'main.ts'])
+  let l:plugins = []
+  for l:script in globpath(&runtimepath, l:pattern, 1, 1, 1)
+    let l:name = fnamemodify(l:script, ':h:t')
+    if l:name[:0] ==# '@' || !filereadable(l:script)
+      continue
+    endif
+    call add(l:plugins, #{ name: l:name, script: l:script })
+  endfor
+  return l:plugins
+endfunction
+
+function! denops#_internal#plugin#find(name) abort
+  let l:pattern = denops#_internal#path#join(['denops', a:name, 'main.ts'])
+  for l:script in globpath(&runtimepath, l:pattern, 1, 1, 1)
+    let l:name = fnamemodify(l:script, ':h:t')
+    if l:name[:0] ==# '@' || !filereadable(l:script)
+      continue
+    endif
+    return #{ name: l:name, script: l:script }
+  endfor
+  throw printf('No denops plugin for "%s" exists', a:name)
+endfunction

--- a/autoload/denops/cache.vim
+++ b/autoload/denops/cache.vim
@@ -1,0 +1,46 @@
+let s:root = expand('<sfile>:p:h:h:h')
+let s:job = v:null
+
+function! denops#cache#update(...) abort
+  let l:options = extend(#{ reload: v:false }, a:0 ? a:1 : {})
+  let l:entryfiles = extend([
+        \ denops#_internal#path#join([s:root, 'denops', '@denops-private', 'mod.ts']),
+        \], map(denops#_internal#plugin#collect(), { _, v -> v.script }))
+
+  let l:args = [g:denops#deno, 'cache']
+
+  if l:options.reload
+    let l:args = add(l:args, '--reload')
+    echomsg '[denops] Forcibly update cache of the following files.'
+  else
+    echomsg '[denops] Update cache of the following files. Call `denops#cache#update(#{reload: v:true})` to forcibly update.'
+  endif
+
+  for l:entryfile in l:entryfiles
+    echomsg printf('[denops] %s', l:entryfile)
+  endfor
+  let l:args = extend(l:args, l:entryfiles)
+
+  let s:job = denops#_internal#job#start(l:args, #{
+        \ on_stderr: funcref('s:on_stderr'),
+        \ on_exit: funcref('s:on_exit'),
+        \ env: #{
+        \   NO_COLOR: 1,
+        \   DENO_NO_PROMPT: 1,
+        \ },
+        \})
+  call denops#_internal#wait#for(60 * 1000, { -> s:job is# v:null }, 100)
+  echomsg '[denops] Deno cache is updated.'
+endfunction
+
+function! s:on_stderr(job, data, event) abort
+  echohl Comment
+  for l:line in split(a:data, '\n')
+    echomsg printf('[denops] %s', substitute(l:line, '\t', '    ', 'g'))
+  endfor
+  echohl None
+endfunction
+
+function! s:on_exit(job, status, event) abort
+  let s:job = v:null
+endfunction

--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -122,14 +122,6 @@ function! s:gather_plugins(plugins) abort
   endfor
 endfunction
 
-function! s:options(base, default) abort
-  let l:options = extend(a:default, a:base)
-  if l:options.mode !~# '^\(reload\|skip\|error\)$'
-    throw printf('Unknown mode "%s" is specified', l:options.mode)
-  endif
-  return l:options
-endfunction
-
 function! s:find_plugin(name) abort
   for l:script in globpath(&runtimepath, denops#_internal#path#join(['denops', a:name, 'main.ts']), 1, 1, 1)
     let l:name = fnamemodify(l:script, ':h:t')

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -200,6 +200,16 @@ denops#request_async({name}, {method}, {params}, {success}, {failure})
 	      \ { e -> s:failure(e) },
 	      \)
 <
+						*denops#cache#update()*
+denops#cache#update([{options}])
+	Update Deno module cache of denops itself and denops plugins in
+	|runtimepath|.
+
+	The following {options} is available
+
+	"reload"	|v:true| to force update ("--reload" flag of "deno
+			cache") command.
+
 						*denops#server#start()*
 denops#server#start()
 	Starts a denops server process and connects to the channel. It does

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -158,26 +158,26 @@ VARIABLE						*denops-variable*
 FUNCTION						*denops-function*
 
 						*denops#notify()*
-denops#notify({plugin}, {method}, {params})
-	Calls API {method} of {plugin} with {params} and returns immediately
-	without waiting for a result.
+denops#notify({name}, {method}, {params})
+	Calls API {method} of {name} plugin with {params} and returns
+	immediately without waiting for a result.
 	Use |denops#request()| instead if you need a result.
         Note: It does not redraw in the Vim environment. Manually execute
         |:redraw| if needed.
 
 						*denops#request()*
-denops#request({plugin}, {method}, {params})
-	Calls API {method} of {plugin} with {params} and waits for a result,
-	then returns it.
+denops#request({name}, {method}, {params})
+	Calls API {method} of {name} plugin with {params} and waits for a
+	result, then returns it.
 	Use |denops#notify()| instead if you don't need a result.
 	Use |denops#request_async()| instead if you need a result
 	asynchronously.
 
 						*denops#request_async()*
-denops#request_async({plugin}, {method}, {params}, {success}, {failure})
-	Calls API {method} of {plugin} with {params} and returns immediately.
-	Once the call succeeds, the {success} callback is called with a
-	result.
+denops#request_async({name}, {method}, {params}, {success}, {failure})
+	Calls API {method} of {name} plugin with {params} and returns
+	immediately. Once the call succeeds, the {success} callback is called
+	with a result.
 	Otherwise, the {failure} callback is called with an error.
 	Use |denops#notify()| instead if you don't need a result.
 	Use |denops#request()| instead if you need a result synchronously.
@@ -282,14 +282,14 @@ denops#server#wait_async({callback})
 	callbacks registered are called in order of registration.
 
 						*denops#plugin#is_loaded()*
-denops#plugin#is_loaded({plugin})
-	Returns 1 if a {plugin} plugin is already loaded. Otherwise, returns
+denops#plugin#is_loaded({name})
+	Returns 1 if a {name} plugin is already loaded. Otherwise, returns
 	0.
 
 						*denops#plugin#wait()*
-denops#plugin#wait({plugin}[, {options}])
-	Waits synchronously until a {plugin} plugin is loaded. It returns
-	immediately when the {plugin} plugin is already loaded.
+denops#plugin#wait({name}[, {options}])
+	Waits synchronously until a {name} plugin is loaded. It returns
+	immediately when the {name} plugin is already loaded.
 	It returns -1 if it times out, -2 if the server is not yet ready or
 	interrupted, or -3 if the plugin initialization failed.
 	Developers need to consider this return value to decide whether to
@@ -305,15 +305,15 @@ denops#plugin#wait({plugin}[, {options}])
 			Default: 0
 
 						*denops#plugin#wait_async()*
-denops#plugin#wait_async({plugin}, {callback})
-	Waits asynchronously until a {plugin} plugin is loaded and invokes a
-	{callback}. It invokes the {callback} immediately when the {plugin}
+denops#plugin#wait_async({name}, {callback})
+	Waits asynchronously until a {name} plugin is loaded and invokes a
+	{callback}. It invokes the {callback} immediately when the {name}
 	plugin is already loaded. If this function is called multiple times
-	for the same {plugin} plugin, callbacks registered for the plugin are
+	for the same {name} plugin, callbacks registered for the plugin are
 	called in order of registration.
 
 						*denops#plugin#register()*
-denops#plugin#register({plugin}[, {script}[, {options}]])
+denops#plugin#register({name}[, {script}[, {options}]])
 	DEPRECATED: Use |denops#plugin#load()| instead.
 
 	Developers who would like to support previous denops versions should
@@ -344,7 +344,7 @@ denops#plugin#discover()
         by |denops#server#start()|.
 
 						*denops#plugin#load()*
-denops#plugin#load({plugin}, {script})
+denops#plugin#load({name}, {script})
 	Loads a denops plugin. Use this function to load denops plugins that
 	are not discovered by |denops#plugin#discover()|.
 	It invokes |User| |DenopsPluginPre|:{plugin} just before denops
@@ -353,12 +353,12 @@ denops#plugin#load({plugin}, {script})
 	function of the plugin.
 
 						*denops#plugin#reload()*
-denops#plugin#reload({plugin})
+denops#plugin#reload({name})
 	Reloads a denops plugin.
 
 						*denops#plugin#check_type()*
-denops#plugin#check_type([{plugin}])
-	Runs Deno's type check feature for {plugin} or all registered plugins.
+denops#plugin#check_type([{name}])
+	Runs Deno's type check feature for {name} or all registered plugins.
 	The result of the check will be displayed in |message-history|.
 
 						*denops#callback#register()*


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added functionality to collect and find Denops plugins based on specified patterns.
	- Introduced a Vim script to update the cache for Deno scripts used in Denops environment.
	- Added a new function to update the Deno module cache with options like "reload."

- **Refactor**
	- Standardized parameter names in various plugin management functions for clarity and consistency.

- **Documentation**
	- Included examples and usage of the new caching functionality in the documentation.

- **Chores**
	- Enhanced CI workflow to include more file paths for triggering the workflow and added a caching step for efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->