### PR TITLE
:+1: Add `denops#interrupt()`

### DIFF
--- a/autoload/denops.vim
+++ b/autoload/denops.vim
@@ -25,6 +25,14 @@ function! denops#request_async(name, method, params, success, failure) abort
         \)
 endfunction
 
+function! denops#interrupt(...) abort
+  let l:args = a:0 ? [a:1] : []
+  call denops#server#wait_async({ -> denops#_internal#server#chan#notify(
+        \ 'invoke',
+        \ ['interrupt', l:args],
+        \)})
+endfunction
+
 " Configuration
 call denops#_internal#conf#define('denops#disabled', 0)
 call denops#_internal#conf#define('denops#deno', 'deno')

--- a/denops/@denops-private/denops.ts
+++ b/denops/@denops-private/denops.ts
@@ -8,7 +8,10 @@ const isBatchReturn = is.TupleOf([is.Array, is.String] as const);
 
 export type Host = Pick<HostOrigin, "redraw" | "call" | "batch">;
 
-export type Service = Pick<ServiceOrigin, "dispatch" | "waitLoaded">;
+export type Service = Pick<
+  ServiceOrigin,
+  "dispatch" | "waitLoaded" | "interrupted"
+>;
 
 export class DenopsImpl implements Denops {
   readonly name: string;
@@ -30,6 +33,10 @@ export class DenopsImpl implements Denops {
     this.meta = meta;
     this.#host = host;
     this.#service = service;
+  }
+
+  get interrupted(): AbortSignal {
+    return this.#service.interrupted;
   }
 
   redraw(force?: boolean): Promise<void> {

--- a/denops/@denops-private/denops_test.ts
+++ b/denops/@denops-private/denops_test.ts
@@ -1,5 +1,5 @@
 import type { Meta } from "jsr:@denops/core@6.0.6";
-import { assertEquals } from "jsr:@std/assert@0.225.1";
+import { assertEquals, assertInstanceOf } from "jsr:@std/assert@0.225.1";
 import { assertSpyCall, stub } from "jsr:@std/testing@0.224.0/mock";
 import { promiseState } from "jsr:@lambdalisue/async@2.1.1";
 import { unimplemented } from "jsr:@lambdalisue/errorutil@1.0.0";
@@ -20,8 +20,13 @@ Deno.test("DenopsImpl", async (t) => {
   const service: Service = {
     dispatch: () => unimplemented(),
     waitLoaded: () => unimplemented(),
+    interrupted: new AbortController().signal,
   };
   const denops = new DenopsImpl("dummy", meta, host, service);
+
+  await t.step("interrupted returns AbortSignal instance", () => {
+    assertInstanceOf(denops.interrupted, AbortSignal);
+  });
 
   await t.step("redraw() calls host.redraw()", async () => {
     using s = stub(host, "redraw");

--- a/denops/@denops-private/host.ts
+++ b/denops/@denops-private/host.ts
@@ -50,6 +50,7 @@ export type Service = {
   bind(host: Host): void;
   load(name: string, script: string): Promise<void>;
   reload(name: string): Promise<void>;
+  interrupt(reason?: unknown): void;
   dispatch(name: string, fn: string, args: unknown[]): Promise<unknown>;
   dispatchAsync(
     name: string,
@@ -74,6 +75,11 @@ export function invoke(
       return service.reload(
         ...ensure(args, is.TupleOf([is.String] as const)),
       );
+    case "interrupt":
+      service.interrupt(
+        ...ensure(args, is.ParametersOf([is.OptionalOf(is.Unknown)] as const)),
+      );
+      return Promise.resolve();
     case "dispatch":
       return service.dispatch(
         ...ensure(args, is.TupleOf([is.String, is.String, is.Array] as const)),

--- a/denops/@denops-private/host/nvim_test.ts
+++ b/denops/@denops-private/host/nvim_test.ts
@@ -24,6 +24,7 @@ Deno.test("Neovim", async (t) => {
         bind: () => unimplemented(),
         load: () => unimplemented(),
         reload: () => unimplemented(),
+        interrupt: () => unimplemented(),
         dispatch: () => unimplemented(),
         dispatchAsync: () => unimplemented(),
       };

--- a/denops/@denops-private/host/vim_test.ts
+++ b/denops/@denops-private/host/vim_test.ts
@@ -19,6 +19,7 @@ Deno.test("Vim", async (t) => {
         bind: () => unimplemented(),
         load: () => unimplemented(),
         reload: () => unimplemented(),
+        interrupt: () => unimplemented(),
         dispatch: () => unimplemented(),
         dispatchAsync: () => unimplemented(),
       };

--- a/denops/@denops-private/host_test.ts
+++ b/denops/@denops-private/host_test.ts
@@ -12,6 +12,7 @@ Deno.test("invoke", async (t) => {
   const service: Omit<Service, "bind"> = {
     load: () => unimplemented(),
     reload: () => unimplemented(),
+    interrupt: () => unimplemented(),
     dispatch: () => unimplemented(),
     dispatchAsync: () => unimplemented(),
   };
@@ -42,6 +43,28 @@ Deno.test("invoke", async (t) => {
     await t.step("invalid args", () => {
       using s = stub(service, "reload");
       assertThrows(() => invoke(service, "reload", []), AssertError);
+      assertSpyCalls(s, 0);
+    });
+  });
+
+  await t.step("calls 'interrupt'", async (t) => {
+    await t.step("ok", async () => {
+      using s = stub(service, "interrupt");
+      await invoke(service, "interrupt", []);
+      assertSpyCalls(s, 1);
+      assertSpyCall(s, 0, { args: [] });
+    });
+
+    await t.step("ok (with reason)", async () => {
+      using s = stub(service, "interrupt");
+      await invoke(service, "interrupt", ["reason"]);
+      assertSpyCalls(s, 1);
+      assertSpyCall(s, 0, { args: ["reason"] });
+    });
+
+    await t.step("invalid args", () => {
+      using s = stub(service, "interrupt");
+      assertThrows(() => invoke(service, "interrupt", ["a", "b"]), AssertError);
       assertSpyCalls(s, 0);
     });
   });

--- a/denops/@denops-private/service_test.ts
+++ b/denops/@denops-private/service_test.ts
@@ -3,6 +3,7 @@ import {
   assertEquals,
   assertMatch,
   assertRejects,
+  assertThrows,
 } from "jsr:@std/assert@0.225.1";
 import {
   assertSpyCall,
@@ -387,6 +388,26 @@ Deno.test("Service", async (t) => {
           "Failed to call failure callback 'failure': Error: invalid call",
         ],
       });
+    },
+  );
+
+  await t.step(
+    "interrupt() sends interrupt signal to `interrupted` attribute",
+    () => {
+      const signal = service.interrupted;
+      signal.throwIfAborted(); // Should not throw
+      service.interrupt();
+      assertThrows(() => signal.throwIfAborted());
+    },
+  );
+
+  await t.step(
+    "interrupt() sends interrupt signal to `interrupted` attribute with reason",
+    () => {
+      const signal = service.interrupted;
+      signal.throwIfAborted(); // Should not throw
+      service.interrupt("test");
+      assertThrows(() => signal.throwIfAborted(), "test");
     },
   );
 });

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -200,6 +200,26 @@ denops#request_async({name}, {method}, {params}, {success}, {failure})
 	      \ { e -> s:failure(e) },
 	      \)
 <
+						*denops#interrupt()*
+denops#interrupt([{reason}])
+	Interrupts the process of plugins. It is assumed to be used to
+	interrupt the process of plugins when the user presses a key or
+	issues a command.
+	{reason} is an optional string to describe the reason for the
+	interruption.
+	Note that the interruption is not guaranteed to be immediate.
+
+	Use the following mapping to interrupt the process of plugins:
+>
+	" For normal/visual/select mode
+	noremap <silent> <C-c> <Cmd>call denops#interrupt()<CR><C-c>
+
+	" For insert mode
+	inoremap <silent> <C-c> <Cmd>call denops#interrupt()<CR><C-c>
+
+	" For command mode
+	cnoremap <silent> <C-c> <Cmd>call denops#interrupt()<CR><C-c>
+<
 						*denops#cache#update()*
 denops#cache#update([{options}])
 	Update Deno module cache of denops itself and denops plugins in

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -29,6 +29,23 @@ API Reference: https://deno.land/x/denops_std/mod.ts
 USAGE							*denops-usage*
 
 -----------------------------------------------------------------------------
+RECOMMENDED					*denops-recommended*
+
+Add the following recommended settings to your |vimrc| or |init.vim|:
+>
+	" Interrupt the process of plugins via <C-c>
+	noremap <silent> <C-c> <Cmd>call denops#interrupt()<CR><C-c>
+	inoremap <silent> <C-c> <Cmd>call denops#interrupt()<CR><C-c>
+	cnoremap <silent> <C-c> <Cmd>call denops#interrupt()<CR><C-c>
+
+	" Restart Denops server
+	command! DenopsRestart call denops#server#restart()
+
+	" Fix Deno module cache issue
+	command! DenopsFixCache call denops#cache#update(#{reload: v:true})
+<
+
+-----------------------------------------------------------------------------
 SHARED SERVER					*denops-shared-server*
 
 Typically, a Denops server starts for each Vim/Neovim instance, but there are


### PR DESCRIPTION
Close #307 

- [x] Add tests
- [x] Add documentations
- [x] Expose `denops.interrupted` on deno-denops-core
    - https://github.com/vim-denops/deno-denops-core/pull/8

### For manual test

Create a denops plugin called `interrupt-test` with the following code

```ts
import type { Denops as DenopsOrigin } from "https://deno.land/x/denops_core@v6.0.4/mod.ts";
import { abortable, delay } from "https://deno.land/std@0.211.0/async/mod.ts";

export function main(denops: Denops): void {
  denops.dispatcher = {
    start: async () => {
      const signal = denops.interrupted;
      try {
        for (let i = 0; i < 100; i++) {
          signal.throwIfAborted();
          await abortable(denops.cmd(`echo 'Hello ${i}'`), signal);
          await delay(100, { signal });
        }
      } catch (e) {
        if (e instanceof DOMException && e.name === "AbortError") {
          await denops.cmd("echo 'Interrupted'");
          return;
        }
        throw e;
      }
    },
  };
}

// Assume that Denops v7.0 add `interrupted` attribute to Denops
type Denops = DenopsOrigin & {
  interrupted: AbortSignal;
};
```

Then add `<C-c>` mapping like

```vim
nnoremap <silent> <C-c> <Cmd>call denops#interrupt()<CR>
```

Then

1. Invoke `call denops#notify('interrupt-test', 'start', [])
2. Interrupt with `<C-c>`
3. If `Interrupted` is echoed, success.

https://github.com/vim-denops/denops.vim/assets/546312/dd096372-ffff-4bf3-96dc-05a4cec88587

