### PR TITLE
:bug: `denops#server#close()` should fires DenopsClosed event

### DIFF
--- a/autoload/denops/_internal/rpc/nvim.vim
+++ b/autoload/denops/_internal/rpc/nvim.vim
@@ -24,7 +24,7 @@ endfunction
 function! denops#_internal#rpc#nvim#close(chan) abort
   call timer_stop(a:chan._healthcheck_timer)
   call chanclose(a:chan._id)
-  call a:chan._on_close(a:chan)
+  call timer_start(0, { -> a:chan._on_close(a:chan) })
 endfunction
 
 function! denops#_internal#rpc#nvim#notify(chan, method, params) abort

--- a/autoload/denops/_internal/rpc/vim.vim
+++ b/autoload/denops/_internal/rpc/vim.vim
@@ -3,29 +3,34 @@ function! denops#_internal#rpc#vim#connect(addr, ...) abort
         \ 'on_close': { -> 0 },
         \}, a:0 ? a:1 : {},
         \)
-  let l:chan = ch_open(a:addr, {
+  let l:chan = {
+        \ '_on_close': l:options.on_close,
+        \}
+  let l:chan._handle = ch_open(a:addr, {
         \ 'mode': 'json',
         \ 'drop': 'auto',
         \ 'noblock': 1,
         \ 'timeout': g:denops#_internal#rpc#vim#timeout,
-        \ 'close_cb': l:options.on_close,
+        \ 'close_cb': { -> l:chan._on_close(l:chan) },
         \})
-  if ch_status(l:chan) !=# 'open'
+  if ch_status(l:chan._handle) !=# 'open'
     throw printf('Failed to connect `%s`', a:addr)
   endif
   return l:chan
 endfunction
 
 function! denops#_internal#rpc#vim#close(chan) abort
-  return ch_close(a:chan)
+  " NOTE: 'close_cb' specified on `ch_open` is not invoked when `ch_close` called.
+  call ch_close(a:chan._handle)
+  call timer_start(0, { -> a:chan._on_close(a:chan) })
 endfunction
 
 function! denops#_internal#rpc#vim#notify(chan, method, params) abort
-  return ch_sendraw(a:chan, json_encode([0, [a:method] + a:params]) . "\n")
+  return ch_sendraw(a:chan._handle, json_encode([0, [a:method] + a:params]) . "\n")
 endfunction
 
 function! denops#_internal#rpc#vim#request(chan, method, params) abort
-  let [l:ok, l:err] = ch_evalexpr(a:chan, [a:method] + a:params)
+  let [l:ok, l:err] = ch_evalexpr(a:chan._handle, [a:method] + a:params)
   if l:err isnot# v:null
     throw l:err
   endif

--- a/autoload/denops/_internal/test.vim
+++ b/autoload/denops/_internal/test.vim
@@ -8,10 +8,10 @@ if has('nvim')
   endfunction
 else
   function! denops#_internal#test#notify(method, params) abort
-    return denops#_internal#rpc#vim#notify(g:denops_test_channel, a:method, a:params)
+    return denops#_internal#rpc#vim#notify(#{ _handle: g:denops_test_channel }, a:method, a:params)
   endfunction
 
   function! denops#_internal#test#request(method, params) abort
-    return denops#_internal#rpc#vim#request(g:denops_test_channel, a:method, a:params)
+    return denops#_internal#rpc#vim#request(#{ _handle: g:denops_test_channel }, a:method, a:params)
   endfunction
 endif

--- a/denops/@denops-private/testutil/host.ts
+++ b/denops/@denops-private/testutil/host.ts
@@ -1,0 +1,65 @@
+import { Host } from "../host.ts";
+import { Neovim } from "../host/nvim.ts";
+import { Vim } from "../host/vim.ts";
+import { withNeovim, WithOptions, withVim } from "./with.ts";
+
+export type HostFn<T> = (host: Host) => Promise<T>;
+
+export type WithHostOptions<T> = Omit<WithOptions<T>, "fn"> & {
+  mode: "vim" | "nvim";
+  fn: HostFn<T>;
+};
+
+export function withHost<T>(
+  options: WithHostOptions<T>,
+): Promise<T> {
+  const { mode, fn, ...withOptions } = options;
+  if (mode === "vim") {
+    return withVim({
+      fn: async (reader, writer) => {
+        await using host = new Vim(reader, writer);
+        return await fn(host);
+      },
+      ...withOptions,
+    });
+  }
+  if (mode === "nvim") {
+    return withNeovim({
+      fn: async (reader, writer) => {
+        await using host = new Neovim(reader, writer);
+        return await fn(host);
+      },
+      ...withOptions,
+    });
+  }
+  return Promise.reject(new TypeError(`Invalid mode: ${mode}`));
+}
+
+export type TestFn = (host: Host, t: Deno.TestContext) => Promise<void>;
+
+export type TestHostOptions = Omit<WithHostOptions<void>, "mode" | "fn"> & {
+  mode?: "vim" | "nvim" | "all";
+  name?: string;
+  fn: TestFn;
+};
+
+export function testHost(
+  options: TestHostOptions,
+): void {
+  const { mode = "all", fn, name, ...hostOptions } = options;
+  if (mode === "all") {
+    testHost({ ...options, mode: "vim" });
+    testHost({ ...options, mode: "nvim" });
+  } else if (mode === "vim" || mode === "nvim") {
+    const prefix = name ? `${name} ` : "";
+    Deno.test(`${prefix}(${mode})`, async (t) => {
+      await withHost({
+        mode,
+        fn: (host) => fn(host, t),
+        ...hostOptions,
+      });
+    });
+  } else {
+    throw new TypeError(`Invalid mode: ${mode}`);
+  }
+}

--- a/denops/@denops-private/testutil/wait.ts
+++ b/denops/@denops-private/testutil/wait.ts
@@ -1,0 +1,40 @@
+export type WaitOptions = {
+  /**
+   * Timeout period to an exception is thrown.
+   * @default {10_000}
+   */
+  timeout?: number;
+  /**
+   * Polling interval.
+   * @default {50}
+   */
+  interval?: number;
+};
+
+/**
+ * Calls `fn` periodically and returns the result if it is TRUE.
+ * An exception is thrown when the timeout expires.
+ */
+export function wait(
+  fn: () => unknown | Promise<unknown>,
+  options?: WaitOptions,
+): Promise<unknown> {
+  const { timeout = 10_000, interval = 50 } = options ?? {};
+  return new Promise((resolve, reject) => {
+    let i: number | undefined;
+    const t = setTimeout(() => {
+      clearTimeout(i);
+      reject(new Error(`Timeout waitTrue in ${timeout} millisec`));
+    }, timeout);
+    const next = async () => {
+      const res = await fn();
+      if (res) {
+        clearTimeout(t);
+        resolve(res);
+      } else {
+        i = setTimeout(next, interval);
+      }
+    };
+    next();
+  });
+}

--- a/tests/denops/server_test.ts
+++ b/tests/denops/server_test.ts
@@ -1,0 +1,21 @@
+import { assertEquals } from "jsr:@std/assert@0.225.2";
+import { testHost } from "../../denops/@denops-private/testutil/host.ts";
+import { wait } from "../../denops/@denops-private/testutil/wait.ts";
+
+testHost({
+  name: "denops#server#close() should fires DenopsClosed",
+  fn: async (host) => {
+    await host.call("execute", [
+      "source plugin/denops.vim",
+      "autocmd User DenopsReady let g:denops_ready_called = 1",
+      "autocmd User DenopsClosed let g:denops_closed_called = 1",
+    ], "");
+    await wait(() => host.call("exists", "g:denops_ready_called"));
+    assertEquals(await host.call("exists", "g:denops_closed_called"), 0);
+    await host.call("denops#server#close");
+    assertEquals(
+      await wait(() => host.call("exists", "g:denops_closed_called")),
+      1,
+    );
+  },
+});


### PR DESCRIPTION
## Actual

- vim: `denops#server#close()` does NOT fires `DenopsClosed` event.
- nvim: `denops#server#close()` fires `DenopsClosed` event.

## Expected

Both fires `DenopsClosed` event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated import paths for external modules in `worker.ts` to improve maintainability and flexibility.
  - Adjusted version requirements in `denops.vim` to align with Vim and Neovim updates.

- **Improvements**
  - Enhanced import statements in `version.ts` and `conf.ts` for better module resolution and version control.
  - Improved code readability and maintainability by updating import paths in `util.ts` and `conf_test.ts`.

- **Bug Fixes**
  - Resolved import statement issues in `version.ts` to ensure correct module usage.
  - Fixed import paths in `conf.ts` and `conf_test.ts` for consistent module resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->