### PR TITLE
Improve test

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,7 +1,7 @@
 {
   "tasks": {
     "check": "deno check **/*.ts",
-    "test": "deno test -A --parallel --shuffle --doc",
+    "test": "LANG=C deno test -A --parallel --shuffle --doc",
     "test:coverage": "deno task test --coverage=.coverage",
     "coverage": "deno coverage .coverage --exclude=cli.ts --exclude=worker.ts --exclude=testdata/",
     "update": "deno run --allow-env --allow-read --allow-write=. --allow-run=git,deno --allow-net=jsr.io,registry.npmjs.org jsr:@molt/cli **/*.ts",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -6,5 +6,8 @@
     "coverage": "deno coverage .coverage --exclude=cli.ts --exclude=worker.ts --exclude=testdata/",
     "update": "deno run --allow-env --allow-read --allow-write=. --allow-run=git,deno --allow-net=jsr.io,registry.npmjs.org jsr:@molt/cli **/*.ts",
     "update:commit": "deno task -q update --commit --pre-commit=fmt,lint"
-  }
+  },
+  "exclude": [
+    ".coverage/"
+  ]
 }

--- a/denops/@denops-private/testutil/host.ts
+++ b/denops/@denops-private/testutil/host.ts
@@ -3,16 +3,17 @@ import { Neovim } from "../host/nvim.ts";
 import { Vim } from "../host/vim.ts";
 import { withNeovim, WithOptions, withVim } from "./with.ts";
 
-export type HostFn<T> = (host: Host) => Promise<T>;
+export type HostFn<T> = (host: Host) => T;
 
-export type WithHostOptions<T> = Omit<WithOptions<T>, "fn"> & {
-  mode: "vim" | "nvim";
+export interface WithHostOptions<T> extends Omit<WithOptions<T>, "fn"> {
   fn: HostFn<T>;
-};
+  /** Run mode. */
+  mode: "vim" | "nvim";
+}
 
 export function withHost<T>(
   options: WithHostOptions<T>,
-): Promise<T> {
+): Promise<Awaited<T>> {
   const { mode, fn, ...withOptions } = options;
   if (mode === "vim") {
     return withVim({
@@ -35,29 +36,39 @@ export function withHost<T>(
   return Promise.reject(new TypeError(`Invalid mode: ${mode}`));
 }
 
-export type TestFn = (host: Host, t: Deno.TestContext) => Promise<void>;
+export type TestFn = (host: Host, t: Deno.TestContext) => void | Promise<void>;
 
-export type TestHostOptions = Omit<WithHostOptions<void>, "mode" | "fn"> & {
-  mode?: "vim" | "nvim" | "all";
-  name?: string;
+export interface TestHostOptions
+  extends
+    Omit<WithHostOptions<void | Promise<void>>, "fn" | "mode">,
+    Pick<Deno.TestDefinition, "ignore" | "only"> {
   fn: TestFn;
-};
+  /** Test mode. */
+  mode?: "vim" | "nvim" | "all";
+  /** Test name. */
+  name?: string;
+}
 
 export function testHost(
   options: TestHostOptions,
 ): void {
-  const { mode = "all", fn, name, ...hostOptions } = options;
+  const { mode = "all", fn, name, ignore, only, ...hostOptions } = options;
   if (mode === "all") {
     testHost({ ...options, mode: "vim" });
     testHost({ ...options, mode: "nvim" });
   } else if (mode === "vim" || mode === "nvim") {
     const prefix = name ? `${name} ` : "";
-    Deno.test(`${prefix}(${mode})`, async (t) => {
-      await withHost({
-        mode,
-        fn: (host) => fn(host, t),
-        ...hostOptions,
-      });
+    Deno.test({
+      ignore,
+      only,
+      name: `${prefix}(${mode})`,
+      fn: async (t) => {
+        await withHost<void | Promise<void>>({
+          mode,
+          fn: (host) => fn(host, t),
+          ...hostOptions,
+        });
+      },
     });
   } else {
     throw new TypeError(`Invalid mode: ${mode}`);

--- a/denops/@denops-private/testutil/shared_server.ts
+++ b/denops/@denops-private/testutil/shared_server.ts
@@ -1,0 +1,83 @@
+import { assert } from "jsr:@std/assert@0.225.2";
+import { deadline } from "jsr:@std/async@0.224.0/deadline";
+import { resolve } from "jsr:@std/path@0.224.0/resolve";
+import { TextLineStream } from "jsr:@std/streams@0.224.0/text-line-stream";
+import { pop } from "jsr:@lambdalisue/streamtools@1.0.0";
+import { getConfig } from "./conf.ts";
+
+const DEFAULT_TIMEOUT = 5000;
+
+export interface UseSharedServerOptions {
+  /** Print shared-server messages. */
+  verbose?: boolean;
+  /** Environment variables.  */
+  env?: Record<string, string>;
+  /** Timeout for shared server initialization. */
+  timeout?: number;
+}
+
+export interface UseSharedServerResult extends AsyncDisposable {
+  /** Address to connect to the shared server. */
+  addr: string;
+  /** Shared server standard output. */
+  stdout: ReadableStream<string>;
+}
+
+/**
+ * Start a shared server and return an address for testing.
+ */
+export async function useSharedServer(
+  options?: UseSharedServerOptions,
+): Promise<UseSharedServerResult> {
+  const { denopsPath, verbose, env, timeout = DEFAULT_TIMEOUT } = {
+    ...getConfig(),
+    ...options,
+  };
+  const aborter = new AbortController();
+  const { signal } = aborter;
+  const cmd = Deno.execPath();
+  const script = resolve(denopsPath, "denops/@denops-private/cli.ts");
+  const args = [
+    "run",
+    "-A",
+    "--no-lock",
+    script,
+    "--identity",
+    "--port",
+    "0",
+  ];
+  const proc = new Deno.Command(cmd, {
+    args,
+    stdout: "piped",
+    stderr: verbose ? "inherit" : "null",
+    env,
+    signal,
+  }).spawn();
+  try {
+    const [stdout, verboseStdout] = proc.stdout
+      .pipeThrough(new TextDecoderStream(), { signal })
+      .pipeThrough(new TextLineStream())
+      .tee();
+    if (verbose) {
+      verboseStdout.pipeTo(
+        new WritableStream({
+          write: (out) => console.log(out),
+        }),
+      ).catch(() => {});
+    }
+    const addr = await deadline(pop(stdout), timeout);
+    assert(typeof addr === "string");
+    return {
+      addr,
+      stdout,
+      async [Symbol.asyncDispose]() {
+        aborter.abort("useSharedServer disposed");
+        await proc.status;
+      },
+    };
+  } catch (e) {
+    aborter.abort(e);
+    await proc.status;
+    throw e;
+  }
+}

--- a/denops/@denops-private/testutil/shared_server_test.ts
+++ b/denops/@denops-private/testutil/shared_server_test.ts
@@ -1,0 +1,46 @@
+import {
+  assertInstanceOf,
+  assertMatch,
+  assertRejects,
+} from "jsr:@std/assert@0.225.2";
+import { delay } from "jsr:@std/async@^0.224.0/delay";
+import { stub } from "jsr:@std/testing@0.224.0/mock";
+import { useSharedServer } from "./shared_server.ts";
+
+Deno.test("useSharedServer()", async (t) => {
+  await t.step("returns `result.addr`", async () => {
+    await using server = await useSharedServer();
+    assertMatch(server.addr, /^127\.0\.0\.1:\d+$/);
+  });
+
+  await t.step("returns `result.stdout`", async () => {
+    await using server = await useSharedServer();
+    assertInstanceOf(server.stdout, ReadableStream);
+    const outputs: string[] = [];
+    server.stdout.pipeTo(
+      new WritableStream({
+        write: (line) => void outputs.push(line),
+      }),
+    ).catch(() => {});
+    await delay(100);
+    assertMatch(outputs.join("\n"), /Listen denops clients on/);
+  });
+
+  await t.step("calls console.log() if `verbose` is true", async () => {
+    using console_log = stub(console, "log");
+    await using _server = await useSharedServer({ verbose: true });
+    await delay(100);
+    const outputs = console_log.calls.flatMap((call) => call.args).join("\n");
+    assertMatch(outputs, /Listen denops clients on/);
+  });
+
+  await t.step("closes child process when rejectes", async () => {
+    await assertRejects(
+      async () => {
+        await useSharedServer({ timeout: 0 });
+      },
+      Error,
+      "Deadline",
+    );
+  });
+});

--- a/denops/@denops-private/testutil/wait_test.ts
+++ b/denops/@denops-private/testutil/wait_test.ts
@@ -1,0 +1,75 @@
+import { assertEquals, assertRejects } from "jsr:@std/assert@0.225.1";
+import {
+  assertSpyCalls,
+  resolvesNext,
+  returnsNext,
+  spy,
+} from "jsr:@std/testing@0.224.0/mock";
+import { FakeTime } from "jsr:@std/testing@0.224.0/time";
+import { wait } from "./wait.ts";
+
+Deno.test("wait()", async (t) => {
+  await t.step("calls `fn` periodically", async () => {
+    using time = new FakeTime();
+    const fn = spy(returnsNext([0, 0, 1]));
+    const p = wait(fn);
+    assertSpyCalls(fn, 1);
+    await time.tickAsync(50);
+    assertSpyCalls(fn, 2);
+    await time.tickAsync(50);
+    assertSpyCalls(fn, 3);
+    assertEquals(await p, 1);
+  });
+
+  await t.step("calls `fn` specified `interval`", async () => {
+    using time = new FakeTime();
+    const fn = spy(returnsNext([0, 0, 1]));
+    const p = wait(fn, { interval: 100 });
+    assertSpyCalls(fn, 1);
+    await time.tickAsync(100);
+    assertSpyCalls(fn, 2);
+    await time.tickAsync(100);
+    assertSpyCalls(fn, 3);
+    assertEquals(await p, 1);
+  });
+
+  await t.step("resolves with `fn` return value", async () => {
+    const fn = spy(returnsNext([42]));
+    const actual = await wait(fn);
+    assertEquals(actual, 42);
+  });
+
+  await t.step("resolves with only truthy `fn` return value", async () => {
+    const fn = spy(returnsNext([0, false, null, undefined, "", "foo"]));
+    const actualPromise = wait(fn, { interval: 0 });
+    assertEquals(await actualPromise, "foo");
+  });
+
+  await t.step("rejects when `fn` throws", async () => {
+    const fn = spy(returnsNext([new Error("fn-throws")]));
+    await assertRejects(() => wait(fn), Error, "fn-throws");
+  });
+
+  await t.step("rejects when `fn` rejects", async () => {
+    const fn = spy(resolvesNext([new Error("fn-throws")]));
+    await assertRejects(() => wait(fn), Error, "fn-throws");
+  });
+
+  await t.step("rejects when `timeout`", async () => {
+    using time = new FakeTime();
+    const fn = spy(returnsNext([0, 0]));
+    const p = wait(fn, { timeout: 150, interval: 100 });
+    await time.tickAsync(150);
+    await assertRejects(() => p, Error, "Timeout in 150 millisec.");
+    assertSpyCalls(fn, 2);
+  });
+
+  await t.step("rejects with `message`", async () => {
+    using time = new FakeTime();
+    const fn = spy(returnsNext([0, 0]));
+    const p = wait(fn, { message: "foo bar", timeout: 150, interval: 100 });
+    await time.tickAsync(150);
+    await assertRejects(() => p, Error, "Timeout in 150 millisec: foo bar");
+    assertSpyCalls(fn, 2);
+  });
+});

--- a/tests/denops/plugin_test.ts
+++ b/tests/denops/plugin_test.ts
@@ -1,0 +1,53 @@
+import { assertMatch } from "jsr:@std/assert@0.225.2";
+import {
+  testHost,
+  withHost,
+} from "../../denops/@denops-private/testutil/host.ts";
+import { useSharedServer } from "../../denops/@denops-private/testutil/shared_server.ts";
+import { wait } from "../../denops/@denops-private/testutil/wait.ts";
+
+testHost({
+  name:
+    "'plugin/denops.vim' starts a local server when sourced before VimEnter",
+  postlude: [
+    "runtime plugin/denops.vim",
+  ],
+  fn: async (host) => {
+    await wait(() => host.call("eval", "!has('vim_starting')"));
+    const actual = await host.call("denops#server#status") as string;
+    assertMatch(actual, /^(starting|preparing|running)$/);
+  },
+});
+
+testHost({
+  name: "'plugin/denops.vim' starts a local server when sourced after VimEnter",
+  fn: async (host) => {
+    await wait(() => host.call("eval", "!has('vim_starting')"));
+    await host.call("execute", [
+      "runtime plugin/denops.vim",
+    ], "");
+    const actual = await host.call("denops#server#status") as string;
+    assertMatch(actual, /^(starting|preparing|running)$/);
+  },
+});
+
+for (const mode of ["vim", "nvim"] as const) {
+  Deno.test(
+    `'plugin/denops.vim' connects to the shared server when sourced before VimEnter (${mode})`,
+    async () => {
+      await using server = await useSharedServer();
+      await withHost({
+        mode,
+        postlude: [
+          `let g:denops_server_addr = '${server.addr}'`,
+          "runtime plugin/denops.vim",
+        ],
+        fn: async (host) => {
+          await wait(() => host.call("eval", "!has('vim_starting')"));
+          const actual = await host.call("denops#server#status") as string;
+          assertMatch(actual, /^(preparing|running)$/);
+        },
+      });
+    },
+  );
+}

--- a/tests/denops/server_test.ts
+++ b/tests/denops/server_test.ts
@@ -3,19 +3,109 @@ import { testHost } from "../../denops/@denops-private/testutil/host.ts";
 import { wait } from "../../denops/@denops-private/testutil/wait.ts";
 
 testHost({
-  name: "denops#server#close() should fires DenopsClosed",
-  fn: async (host) => {
+  name: "denops#server#status()",
+  mode: "all",
+  fn: async (host, t) => {
     await host.call("execute", [
-      "source plugin/denops.vim",
-      "autocmd User DenopsReady let g:denops_ready_called = 1",
-      "autocmd User DenopsClosed let g:denops_closed_called = 1",
+      "autocmd User DenopsReady let g:denops_ready_fired = 1",
+      "autocmd User DenopsClosed let g:denops_closed_fired = 1",
     ], "");
-    await wait(() => host.call("exists", "g:denops_ready_called"));
-    assertEquals(await host.call("exists", "g:denops_closed_called"), 0);
-    await host.call("denops#server#close");
-    assertEquals(
-      await wait(() => host.call("exists", "g:denops_closed_called")),
-      1,
+
+    await t.step(
+      "returns 'stopped' when no server running",
+      async () => {
+        const actual = await host.call("denops#server#status");
+        assertEquals(actual, "stopped");
+      },
+    );
+
+    await t.step(
+      "returns 'starting' when denops#server#start() is called",
+      async () => {
+        await host.call("denops#server#start");
+        const actual = await host.call("denops#server#status");
+        assertEquals(actual, "starting");
+      },
+    );
+
+    await t.step(
+      "returns 'preparing' before DenopsReady is fired",
+      async () => {
+        const actual = await wait(() =>
+          host.call(
+            "eval",
+            "exists('g:denops_ready_fired') ? 'DenopsReady is fired'" +
+              ": denops#server#status() !=# 'starting' ? denops#server#status() : 0",
+          )
+        );
+        assertEquals(actual, "preparing");
+      },
+    );
+
+    await t.step(
+      "returns 'running' after DenopsReady is fired",
+      async () => {
+        await wait(() => host.call("exists", "g:denops_ready_fired"));
+        const actual = await host.call("denops#server#status");
+        assertEquals(actual, "running");
+      },
+    );
+
+    await t.step(
+      "returns 'stopped' after denops#server#stop() is called",
+      async () => {
+        await host.call("denops#server#stop");
+        await wait(() =>
+          host.call("eval", "denops#server#status() ==# 'stopped'")
+        );
+      },
+    );
+  },
+});
+
+testHost({
+  name: "Denops server",
+  mode: "all",
+  verbose: true,
+  fn: async (host, t) => {
+    await host.call("execute", [
+      "autocmd User DenopsReady let g:denops_ready_fired = 1",
+      "autocmd User DenopsClosed let g:denops_closed_fired = 1",
+      "source plugin/denops.vim",
+    ], "");
+
+    await t.step(
+      "'plugin/denops.vim' changes status to 'starting' when sourced",
+      async () => {
+        const actual = await host.call("denops#server#status");
+        assertEquals(actual, "starting");
+      },
+    );
+
+    await t.step(
+      "denops#server#status() returns 'running' after DenopsReady is fired",
+      async () => {
+        await wait(() => host.call("exists", "g:denops_ready_fired"));
+        const actual = await host.call("denops#server#status");
+        assertEquals(actual, "running");
+      },
+    );
+
+    await t.step(
+      "denops#server#close() closes the connection then DenopsClosed is fired",
+      async () => {
+        await host.call("denops#server#close");
+        await wait(() => host.call("exists", "g:denops_closed_fired"));
+      },
+    );
+
+    await t.step(
+      "denops#server#stop() stops the server process asynchronously",
+      async () => {
+        await host.call("denops#server#stop");
+        const actual = await host.call("denops#server#status");
+        assertEquals(actual, "stopped");
+      },
     );
   },
 });


### PR DESCRIPTION
Improve test typing.
Add test function option comments.
Add shared-server test helper.
Show verbose logs use `-V1` instead `redir`.
Error stack trace improved to easily understood.
Add `plugin/denops.vim` tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added support for specifying run mode (`vim` or `nvim`) in test utilities.
  - Enhanced wait function with improved timeout handling and custom error messages.
  - Introduced functionality for starting a shared server for testing purposes.

- **Improvements**
  - Test commands now include language settings for consistent output.
  - Expanded options for verbosity, prelude/postlude commands, and environment variables in test utilities.

- **Bug Fixes**
  - Improved error handling in test utilities to provide more informative messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->