### PR TITLE
:herb: add cli tests

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,7 +3,7 @@
     "check": "deno check **/*.ts",
     "test": "LANG=C deno test -A --parallel --shuffle --doc",
     "test:coverage": "deno task test --coverage=.coverage",
-    "coverage": "deno coverage .coverage --exclude=cli.ts --exclude=worker.ts --exclude=testdata/",
+    "coverage": "deno coverage .coverage",
     "update": "deno run --allow-env --allow-read --allow-write=. --allow-run=git,deno --allow-net=jsr.io,registry.npmjs.org jsr:@molt/cli **/*.ts",
     "update:commit": "deno task -q update --commit --pre-commit=fmt,lint"
   },

--- a/denops/@denops-private/cli.ts
+++ b/denops/@denops-private/cli.ts
@@ -2,7 +2,7 @@ import {
   readableStreamFromWorker,
   writableStreamFromWorker,
 } from "jsr:@lambdalisue/workerio@4.0.0";
-import { parseArgs } from "jsr:@std/cli/parse-args";
+import { parseArgs } from "jsr:@std/cli@0.224.3/parse-args";
 
 // Disable "Native acceleration" feature of `msgpackr` as an workaround of Deno panic.
 // https://github.com/denoland/deno/issues/23792

--- a/denops/@denops-private/testutil/mock.ts
+++ b/denops/@denops-private/testutil/mock.ts
@@ -1,0 +1,103 @@
+import { AssertionError, unimplemented } from "jsr:@std/assert@0.225.2";
+
+/** Returns a Promise that is never resolves or rejects. */
+export function pendingPromise(): Promise<never> {
+  return new Promise<never>(() => {});
+}
+
+/** Returns a fake `TcpListener` instance. */
+export function createFakeTcpListener(): Deno.TcpListener {
+  let closeWaiter: PromiseWithResolvers<never> | undefined = Promise
+    .withResolvers();
+  closeWaiter.promise.catch(() => {});
+  return {
+    get addr(): Deno.NetAddr {
+      return unimplemented();
+    },
+    get rid() {
+      return unimplemented();
+    },
+    ref: () => unimplemented(),
+    unref: () => unimplemented(),
+    accept: () => pendingPromise(),
+    close() {
+      // NOTE: Listener.close() throws if already closed.
+      if (closeWaiter == null) {
+        throw new AssertionError("fake-tcp-listner-already-closed");
+      }
+      closeWaiter.reject("listener-closed");
+      closeWaiter = undefined;
+    },
+    async *[Symbol.asyncIterator]() {
+      // NOTE: Listener[@@asyncIterator]() returns immediately if already closed.
+      if (closeWaiter == null) {
+        return;
+      }
+      try {
+        for (;;) {
+          yield Promise.race([this.accept(), closeWaiter.promise]);
+        }
+      } catch (e) {
+        if (e !== "listener-closed") {
+          throw e;
+        }
+      }
+    },
+    [Symbol.dispose]() {
+      // NOTE: Listener[@@dispose]() does not calls .close() if already closed.
+      if (closeWaiter != null) {
+        this.close();
+      }
+    },
+  };
+}
+
+/** Returns a fake `TcpConn` instance. */
+export function createFakeTcpConn(): Deno.TcpConn {
+  return {
+    get localAddr() {
+      return unimplemented();
+    },
+    get remoteAddr() {
+      return unimplemented();
+    },
+    get rid() {
+      return unimplemented();
+    },
+    get readable() {
+      return unimplemented();
+    },
+    get writable() {
+      return unimplemented();
+    },
+    ref: () => unimplemented(),
+    unref: () => unimplemented(),
+    setNoDelay: () => unimplemented(),
+    setKeepAlive: () => unimplemented(),
+    read: () => unimplemented(),
+    write: () => unimplemented(),
+    close: () => unimplemented(),
+    closeWrite: () => unimplemented(),
+    [Symbol.dispose]() {
+      try {
+        this.close();
+      } catch {
+        // NOTE: TcpConn[@@dispose]() does not throws if already closed.
+      }
+    },
+  };
+}
+
+/** Returns a fake `Worker` instance. */
+export function createFakeWorker(): Worker {
+  return {
+    onerror: () => unimplemented(),
+    onmessage: () => unimplemented(),
+    onmessageerror: () => unimplemented(),
+    postMessage: () => unimplemented(),
+    addEventListener: () => unimplemented(),
+    removeEventListener: () => unimplemented(),
+    dispatchEvent: () => unimplemented(),
+    terminate: () => unimplemented(),
+  };
+}

--- a/denops/@denops-private/testutil/mock_test.ts
+++ b/denops/@denops-private/testutil/mock_test.ts
@@ -1,0 +1,337 @@
+import {
+  assert,
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+} from "jsr:@std/assert@^0.225.2";
+import { promiseState } from "jsr:@lambdalisue/async@2.1.1";
+import {
+  createFakeTcpConn,
+  createFakeTcpListener,
+  createFakeWorker,
+  pendingPromise,
+} from "./mock.ts";
+import { assertThrows } from "jsr:@std/assert@^0.225.1/assert-throws";
+import {
+  assertSpyCalls,
+  resolvesNext,
+  spy,
+  stub,
+} from "jsr:@std/testing@0.224.0/mock";
+
+// deno-lint-ignore no-explicit-any
+type AnyFn = (...args: any[]) => unknown;
+
+// deno-lint-ignore no-explicit-any
+type AnyRecord = Record<PropertyKey, any>;
+
+type MethodKeyOf<T extends AnyRecord> = ({
+  [K in keyof T]: T[K] extends AnyFn ? K : never;
+})[keyof T];
+
+type GetterKeyOf<T extends AnyRecord> = ({
+  [K in keyof T]: T[K] extends AnyFn ? never : K;
+})[keyof T];
+
+Deno.test("pendingPromise()", async (t) => {
+  await t.step("returns a pending Promise", async () => {
+    const actual = pendingPromise();
+
+    assertInstanceOf(actual, Promise);
+    assertEquals(await promiseState(actual), "pending");
+  });
+});
+
+Deno.test("createFakeTcpListener()", async (t) => {
+  await t.step("returns a TcpListener like object", async (t) => {
+    const listener = createFakeTcpListener();
+
+    await t.step("has own key", async (t) => {
+      const keys = Reflect.ownKeys(
+        {
+          addr: 0,
+          rid: 0,
+          ref: 0,
+          unref: 0,
+          accept: 0,
+          close: 0,
+          [Symbol.asyncIterator]: 0,
+          [Symbol.dispose]: 0,
+        } as const satisfies Record<keyof Deno.TcpListener, 0>,
+      );
+      for (const key of keys) {
+        await t.step(key.toString(), () => {
+          assert(key in listener);
+        });
+      }
+    });
+
+    await t.step("unimplements", async (t) => {
+      const unimplementedProps = [
+        "addr",
+        "rid",
+      ] as const satisfies readonly GetterKeyOf<Deno.TcpListener>[];
+      for (const key of unimplementedProps) {
+        await t.step(`.${key}`, () => {
+          assertThrows(() => listener[key], Error, "Unimplemented");
+        });
+      }
+
+      const unimplementedMethods = [
+        "ref",
+        "unref",
+      ] as const satisfies readonly MethodKeyOf<Deno.TcpListener>[];
+      for (const key of unimplementedMethods) {
+        await t.step(`.${key}()`, () => {
+          assertThrows(() => listener[key](), Error, "Unimplemented");
+        });
+      }
+    });
+
+    await t.step(".accept()", async (t) => {
+      await t.step("returns a pending Promise", async () => {
+        const promise = listener.accept();
+
+        assertInstanceOf(promise, Promise);
+        assertEquals(await promiseState(promise), "pending");
+      });
+    });
+
+    await t.step(".close()", async (t) => {
+      const iterator = listener[Symbol.asyncIterator]();
+      const resultPromise = iterator.next();
+
+      await t.step("closes the conn iterator", async () => {
+        assertEquals(await promiseState(resultPromise), "pending");
+
+        listener.close();
+
+        assertEquals(await promiseState(resultPromise), "fulfilled");
+        assertEquals(await resultPromise, {
+          done: true,
+          value: undefined,
+        });
+      });
+
+      await t.step("throws if already closed", () => {
+        assertThrows(() => listener.close(), Error, "closed");
+      });
+    });
+
+    await t.step("[Symbol.asyncIterator]()", async (t) => {
+      // deno-lint-ignore no-explicit-any
+      const firstAcceptWaiter = Promise.withResolvers<any>();
+      const listener = createFakeTcpListener();
+      using listener_accept = stub(
+        listener,
+        "accept",
+        resolvesNext([
+          firstAcceptWaiter.promise,
+          pendingPromise(),
+        ]),
+      );
+
+      let iterator: AsyncIterator<Deno.TcpConn>;
+      await t.step("returns the conn iterator", () => {
+        iterator = listener[Symbol.asyncIterator]();
+
+        assertInstanceOf(iterator.next, Function);
+      });
+
+      await t.step("yield a TcpConn when .accept() resolves", async () => {
+        const resultPromise = iterator.next();
+
+        assertSpyCalls(listener_accept, 1);
+        assertEquals(await promiseState(resultPromise), "pending");
+
+        firstAcceptWaiter.resolve("fake-tcp-conn");
+
+        assertEquals(await promiseState(resultPromise), "fulfilled");
+        assertEquals(await resultPromise, {
+          done: false,
+          // deno-lint-ignore no-explicit-any
+          value: "fake-tcp-conn" as any,
+        });
+      });
+
+      await t.step("rejects when .accept() rejcets", async () => {
+        const listener = createFakeTcpListener();
+        using listener_accept = stub(
+          listener,
+          "accept",
+          resolvesNext([
+            Promise.reject("fake-tcp-listener-accept-error"),
+          ]),
+        );
+
+        const iterator = listener[Symbol.asyncIterator]();
+        const error = await assertRejects(() => iterator.next());
+
+        assertEquals(error, "fake-tcp-listener-accept-error");
+        assertSpyCalls(listener_accept, 1);
+      });
+
+      await t.step(
+        "returns the closed iterator after .close() calls",
+        async () => {
+          listener.close();
+
+          const iterator = listener[Symbol.asyncIterator]();
+          const result = await iterator.next();
+
+          assertEquals(result, { done: true, value: undefined });
+        },
+      );
+    });
+
+    await t.step("[Symbol.dispose]()", async (t) => {
+      const listener = createFakeTcpListener();
+      const listener_close = spy(listener, "close");
+
+      await t.step("calls .close()", () => {
+        assertSpyCalls(listener_close, 0);
+
+        listener[Symbol.dispose]();
+
+        assertSpyCalls(listener_close, 1);
+      });
+
+      await t.step("does not calls .close() if already closed", () => {
+        assertSpyCalls(listener_close, 1);
+
+        listener[Symbol.dispose]();
+
+        assertSpyCalls(listener_close, 1);
+      });
+    });
+  });
+});
+
+Deno.test("createFakeTcpConn()", async (t) => {
+  await t.step("returns a TcpConn like object", async (t) => {
+    const conn = createFakeTcpConn();
+
+    await t.step("has own key", async (t) => {
+      const keys = Reflect.ownKeys(
+        {
+          localAddr: 0,
+          remoteAddr: 0,
+          readable: 0,
+          writable: 0,
+          rid: 0,
+          ref: 0,
+          unref: 0,
+          setNoDelay: 0,
+          setKeepAlive: 0,
+          read: 0,
+          write: 0,
+          close: 0,
+          closeWrite: 0,
+          [Symbol.dispose]: 0,
+        } as const satisfies Record<keyof Deno.TcpConn, 0>,
+      );
+      for (const key of keys) {
+        await t.step(key.toString(), () => {
+          assert(key in conn);
+        });
+      }
+    });
+
+    await t.step("unimplements", async (t) => {
+      const unimplementedProps = [
+        "localAddr",
+        "remoteAddr",
+        "rid",
+        "readable",
+        "writable",
+      ] as const satisfies readonly GetterKeyOf<Deno.TcpConn>[];
+      for (const key of unimplementedProps) {
+        await t.step(`.${key}`, () => {
+          assertThrows(() => conn[key], Error, "Unimplemented");
+        });
+      }
+
+      const unimplementedMethods = [
+        "ref",
+        "unref",
+        "setNoDelay",
+        "setKeepAlive",
+        "read",
+        "write",
+        "close",
+        "closeWrite",
+      ] as const satisfies readonly MethodKeyOf<Deno.TcpConn>[];
+      for (const key of unimplementedMethods) {
+        await t.step(`.${key}()`, () => {
+          assertThrows(() => (conn[key] as AnyFn)(), Error, "Unimplemented");
+        });
+      }
+    });
+
+    await t.step("[Symbol.dispose]()", async (t) => {
+      await t.step("calls .close()", () => {
+        using listener_close = stub(conn, "close");
+        assertSpyCalls(listener_close, 0);
+
+        conn[Symbol.dispose]();
+
+        assertSpyCalls(listener_close, 1);
+      });
+
+      await t.step("does not throws if .close() throws", () => {
+        using listener_close = stub(conn, "close", () => {
+          throw "fake-close-throws-a-error";
+        });
+        assertSpyCalls(listener_close, 0);
+
+        conn[Symbol.dispose]();
+
+        assertSpyCalls(listener_close, 1);
+      });
+    });
+  });
+});
+
+Deno.test("createFakeWorker()", async (t) => {
+  await t.step("returns a Worker like object", async (t) => {
+    const worker = createFakeWorker();
+
+    await t.step("has own key", async (t) => {
+      const keys = Reflect.ownKeys(
+        {
+          onerror: 0,
+          onmessage: 0,
+          onmessageerror: 0,
+          postMessage: 0,
+          addEventListener: 0,
+          removeEventListener: 0,
+          dispatchEvent: 0,
+          terminate: 0,
+        } as const satisfies Record<keyof Worker, 0>,
+      );
+      for (const key of keys) {
+        await t.step(key.toString(), () => {
+          assert(key in worker);
+        });
+      }
+    });
+
+    await t.step("unimplements", async (t) => {
+      const unimplementedMethods = [
+        "onerror",
+        "onmessage",
+        "onmessageerror",
+        "postMessage",
+        "addEventListener",
+        "removeEventListener",
+        "dispatchEvent",
+        "terminate",
+      ] as const satisfies readonly MethodKeyOf<Worker>[];
+      for (const key of unimplementedMethods) {
+        await t.step(`.${key}()`, () => {
+          assertThrows(() => (worker[key] as AnyFn)(), Error, "Unimplemented");
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
- Export `main()` from *cli.ts* to *cli_main.ts*.
  - `args` is now an argument of `main()`.
  - No other production code has changed.
- Add mock helpers.
- Add tests for *cli_main.ts* implements with mock helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced functionality for handling TCP connections and worker threads in Deno.

- **Refactor**
  - Refactored internal logic for handling connections to improve maintainability and modularity.

- **Tests**
  - Added comprehensive test cases for new TCP connection handling features, including stubs and mocks for various scenarios.

- **Chores**
  - Updated configuration scripts for better path management in coverage reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->