### PR TITLE
Fix flaky tests and refactor tests

### DIFF
--- a/denops/@denops-private/denops_test.ts
+++ b/denops/@denops-private/denops_test.ts
@@ -24,110 +24,80 @@ Deno.test("DenopsImpl", async (t) => {
   const denops = new DenopsImpl("dummy", meta, host, service);
 
   await t.step("redraw() calls host.redraw()", async () => {
-    const s = stub(host, "redraw");
-    try {
-      await denops.redraw();
-      assertSpyCall(s, 0, { args: [undefined] });
+    using s = stub(host, "redraw");
+    await denops.redraw();
+    assertSpyCall(s, 0, { args: [undefined] });
 
-      await denops.redraw(false);
-      assertSpyCall(s, 1, { args: [false] });
+    await denops.redraw(false);
+    assertSpyCall(s, 1, { args: [false] });
 
-      await denops.redraw(true);
-      assertSpyCall(s, 2, { args: [true] });
-    } finally {
-      s.restore();
-    }
+    await denops.redraw(true);
+    assertSpyCall(s, 2, { args: [true] });
   });
 
   await t.step("call() calls host.call()", async () => {
-    const s = stub(host, "call");
-    try {
-      await denops.call("abs", -4);
-      assertSpyCall(s, 0, { args: ["abs", -4] });
+    using s = stub(host, "call");
+    await denops.call("abs", -4);
+    assertSpyCall(s, 0, { args: ["abs", -4] });
 
-      await denops.call("abs", 10);
-      assertSpyCall(s, 1, { args: ["abs", 10] });
-    } finally {
-      s.restore();
-    }
+    await denops.call("abs", 10);
+    assertSpyCall(s, 1, { args: ["abs", 10] });
   });
 
   await t.step("batch() calls host.batch()", async () => {
-    const s = stub(
+    using s = stub(
       host,
       "batch",
       () => Promise.resolve([[], ""] as [unknown[], string]),
     );
-    try {
-      await denops.batch(["abs", -4], ["abs", 10], ["abs", -9]);
-      assertSpyCall(s, 0, {
-        args: [["abs", -4], ["abs", 10], ["abs", -9]],
-      });
-    } finally {
-      s.restore();
-    }
+    await denops.batch(["abs", -4], ["abs", 10], ["abs", -9]);
+    assertSpyCall(s, 0, {
+      args: [["abs", -4], ["abs", 10], ["abs", -9]],
+    });
   });
 
   await t.step("cmd() calls host.call()", async () => {
-    const s = stub(host, "call");
-    try {
-      await denops.cmd("echo 'foo'");
-      assertSpyCall(s, 0, {
-        args: ["denops#api#cmd", "echo 'foo'", {}],
-      });
-    } finally {
-      s.restore();
-    }
+    using s = stub(host, "call");
+    await denops.cmd("echo 'foo'");
+    assertSpyCall(s, 0, {
+      args: ["denops#api#cmd", "echo 'foo'", {}],
+    });
   });
 
   await t.step("eval() calls host.call()", async () => {
-    const s = stub(host, "call");
-    try {
-      await denops.eval("v:version");
-      assertSpyCall(s, 0, {
-        args: ["denops#api#eval", "v:version", {}],
-      });
-    } finally {
-      s.restore();
-    }
+    using s = stub(host, "call");
+    await denops.eval("v:version");
+    assertSpyCall(s, 0, {
+      args: ["denops#api#eval", "v:version", {}],
+    });
   });
 
   await t.step("dispatch() calls service.dispatch()", async () => {
-    const s1 = stub(service, "waitLoaded", () => Promise.resolve());
-    const s2 = stub(service, "dispatch", () => Promise.resolve());
-    try {
-      await denops.dispatch("dummy", "fn", "args");
-      assertSpyCall(s1, 0, {
-        args: ["dummy"],
-      });
-      assertSpyCall(s2, 0, {
-        args: ["dummy", "fn", ["args"]],
-      });
-    } finally {
-      s1.restore();
-      s2.restore();
-    }
+    using s1 = stub(service, "waitLoaded", () => Promise.resolve());
+    using s2 = stub(service, "dispatch", () => Promise.resolve());
+    await denops.dispatch("dummy", "fn", "args");
+    assertSpyCall(s1, 0, {
+      args: ["dummy"],
+    });
+    assertSpyCall(s2, 0, {
+      args: ["dummy", "fn", ["args"]],
+    });
   });
 
   await t.step(
     "dispatch() internally waits 'service.waitLoaded()' before 'service.dispatch()'",
     async () => {
       const { promise, resolve } = Promise.withResolvers<void>();
-      const s1 = stub(service, "waitLoaded", () => promise);
-      const s2 = stub(service, "dispatch", () => Promise.resolve());
-      try {
-        const p = denops.dispatch("dummy", "fn", "args");
-        assertEquals(await promiseState(p), "pending");
-        assertEquals(s1.calls.length, 1);
-        assertEquals(s2.calls.length, 0);
-        resolve();
-        assertEquals(await promiseState(p), "fulfilled");
-        assertEquals(s1.calls.length, 1);
-        assertEquals(s2.calls.length, 1);
-      } finally {
-        s1.restore();
-        s2.restore();
-      }
+      using s1 = stub(service, "waitLoaded", () => promise);
+      using s2 = stub(service, "dispatch", () => Promise.resolve());
+      const p = denops.dispatch("dummy", "fn", "args");
+      assertEquals(await promiseState(p), "pending");
+      assertEquals(s1.calls.length, 1);
+      assertEquals(s2.calls.length, 0);
+      resolve();
+      assertEquals(await promiseState(p), "fulfilled");
+      assertEquals(s1.calls.length, 1);
+      assertEquals(s2.calls.length, 1);
     },
   );
 });

--- a/denops/@denops-private/host/nvim_test.ts
+++ b/denops/@denops-private/host/nvim_test.ts
@@ -40,13 +40,9 @@ Deno.test("Neovim", async (t) => {
       );
 
       await t.step("init() calls Service.bind()", async () => {
-        const s = stub(service, "bind");
-        try {
-          await host.init(service);
-          assertSpyCall(s, 0, { args: [host] });
-        } finally {
-          s.restore();
-        }
+        using s = stub(service, "bind");
+        await host.init(service);
+        assertSpyCall(s, 0, { args: [host] });
       });
 
       await t.step("redraw() does nothing", async () => {
@@ -114,34 +110,26 @@ Deno.test("Neovim", async (t) => {
       await t.step(
         "'invoke' message calls Service method",
         async () => {
-          const s = stub(service, "reload");
-          try {
-            await host.call(
-              "denops#_internal#test#request",
-              "invoke",
-              ["reload", ["dummy"]],
-            );
-            assertSpyCall(s, 0, { args: ["dummy"] });
-          } finally {
-            s.restore();
-          }
+          using s = stub(service, "reload");
+          await host.call(
+            "denops#_internal#test#request",
+            "invoke",
+            ["reload", ["dummy"]],
+          );
+          assertSpyCall(s, 0, { args: ["dummy"] });
         },
       );
 
       await t.step(
         "'nvim_error_event' message shows error message",
         async () => {
-          const s = stub(console, "error");
-          try {
-            await host.call(
-              "denops#_internal#test#request",
-              "nvim_error_event",
-              [0, "message"],
-            );
-            assertSpyCall(s, 0, { args: ["nvim_error_event(0)", "message"] });
-          } finally {
-            s.restore();
-          }
+          using s = stub(console, "error");
+          await host.call(
+            "denops#_internal#test#request",
+            "nvim_error_event",
+            [0, "message"],
+          );
+          assertSpyCall(s, 0, { args: ["nvim_error_event(0)", "message"] });
         },
       );
 

--- a/denops/@denops-private/host/vim_test.ts
+++ b/denops/@denops-private/host/vim_test.ts
@@ -41,13 +41,9 @@ Deno.test("Vim", async (t) => {
       );
 
       await t.step("init() calls Service.bind()", async () => {
-        const s = stub(service, "bind");
-        try {
-          await host.init(service);
-          assertSpyCall(s, 0, { args: [host] });
-        } finally {
-          s.restore();
-        }
+        using s = stub(service, "bind");
+        await host.init(service);
+        assertSpyCall(s, 0, { args: [host] });
       });
 
       await t.step("redraw() does nothing", async () => {
@@ -117,17 +113,13 @@ Deno.test("Vim", async (t) => {
       await t.step(
         "'invoke' message calls Service method",
         async () => {
-          const s = stub(service, "reload");
-          try {
-            await host.call(
-              "denops#_internal#test#request",
-              "invoke",
-              ["reload", ["dummy"]],
-            );
-            assertSpyCall(s, 0, { args: ["dummy"] });
-          } finally {
-            s.restore();
-          }
+          using s = stub(service, "reload");
+          await host.call(
+            "denops#_internal#test#request",
+            "invoke",
+            ["reload", ["dummy"]],
+          );
+          assertSpyCall(s, 0, { args: ["dummy"] });
         },
       );
 

--- a/denops/@denops-private/host/vim_test.ts
+++ b/denops/@denops-private/host/vim_test.ts
@@ -96,8 +96,14 @@ Deno.test("Vim", async (t) => {
 
       await t.step("notify() calls the function", () => {
         host.notify("abs", -4);
-        host.notify("@@@@@", -4); // should not throw
       });
+
+      await t.step(
+        "notify() does not throws if calls a non-existent function",
+        () => {
+          host.notify("@@@@@", -4); // should not throw
+        },
+      );
 
       await t.step(
         "'void' message does nothing",

--- a/denops/@denops-private/host_test.ts
+++ b/denops/@denops-private/host_test.ts
@@ -18,101 +18,69 @@ Deno.test("invoke", async (t) => {
 
   await t.step("calls 'load'", async (t) => {
     await t.step("ok", async () => {
-      const s = stub(service, "load");
-      try {
-        await invoke(service, "load", ["dummy", "dummy.ts"]);
-        assertSpyCalls(s, 1);
-        assertSpyCall(s, 0, { args: ["dummy", "dummy.ts"] });
-      } finally {
-        s.restore();
-      }
+      using s = stub(service, "load");
+      await invoke(service, "load", ["dummy", "dummy.ts"]);
+      assertSpyCalls(s, 1);
+      assertSpyCall(s, 0, { args: ["dummy", "dummy.ts"] });
     });
 
     await t.step("invalid args", () => {
-      const s = stub(service, "load");
-      try {
-        assertThrows(() => invoke(service, "load", []), AssertError);
-        assertSpyCalls(s, 0);
-      } finally {
-        s.restore();
-      }
+      using s = stub(service, "load");
+      assertThrows(() => invoke(service, "load", []), AssertError);
+      assertSpyCalls(s, 0);
     });
   });
 
   await t.step("calls 'reload'", async (t) => {
     await t.step("ok", async () => {
-      const s = stub(service, "reload");
-      try {
-        await invoke(service, "reload", ["dummy"]);
-        assertSpyCalls(s, 1);
-        assertSpyCall(s, 0, { args: ["dummy"] });
-      } finally {
-        s.restore();
-      }
+      using s = stub(service, "reload");
+      await invoke(service, "reload", ["dummy"]);
+      assertSpyCalls(s, 1);
+      assertSpyCall(s, 0, { args: ["dummy"] });
     });
 
     await t.step("invalid args", () => {
-      const s = stub(service, "reload");
-      try {
-        assertThrows(() => invoke(service, "reload", []), AssertError);
-        assertSpyCalls(s, 0);
-      } finally {
-        s.restore();
-      }
+      using s = stub(service, "reload");
+      assertThrows(() => invoke(service, "reload", []), AssertError);
+      assertSpyCalls(s, 0);
     });
   });
 
   await t.step("calls 'dispatch'", async (t) => {
     await t.step("ok", async () => {
-      const s = stub(service, "dispatch");
-      try {
-        await invoke(service, "dispatch", ["dummy", "fn", ["args"]]);
-        assertSpyCalls(s, 1);
-        assertSpyCall(s, 0, { args: ["dummy", "fn", ["args"]] });
-      } finally {
-        s.restore();
-      }
+      using s = stub(service, "dispatch");
+      await invoke(service, "dispatch", ["dummy", "fn", ["args"]]);
+      assertSpyCalls(s, 1);
+      assertSpyCall(s, 0, { args: ["dummy", "fn", ["args"]] });
     });
 
     await t.step("invalid args", () => {
-      const s = stub(service, "dispatch");
-      try {
-        assertThrows(() => invoke(service, "dispatch", []), AssertError);
-        assertSpyCalls(s, 0);
-      } finally {
-        s.restore();
-      }
+      using s = stub(service, "dispatch");
+      assertThrows(() => invoke(service, "dispatch", []), AssertError);
+      assertSpyCalls(s, 0);
     });
   });
 
   await t.step("calls 'dispatchAsync'", async (t) => {
     await t.step("ok", async () => {
-      const s = stub(service, "dispatchAsync");
-      try {
-        await invoke(service, "dispatchAsync", [
-          "dummy",
-          "fn",
-          ["args"],
-          "success",
-          "failure",
-        ]);
-        assertSpyCalls(s, 1);
-        assertSpyCall(s, 0, {
-          args: ["dummy", "fn", ["args"], "success", "failure"],
-        });
-      } finally {
-        s.restore();
-      }
+      using s = stub(service, "dispatchAsync");
+      await invoke(service, "dispatchAsync", [
+        "dummy",
+        "fn",
+        ["args"],
+        "success",
+        "failure",
+      ]);
+      assertSpyCalls(s, 1);
+      assertSpyCall(s, 0, {
+        args: ["dummy", "fn", ["args"], "success", "failure"],
+      });
     });
 
     await t.step("invalid args", () => {
-      const s = stub(service, "dispatchAsync");
-      try {
-        assertThrows(() => invoke(service, "dispatchAsync", []), AssertError);
-        assertSpyCalls(s, 0);
-      } finally {
-        s.restore();
-      }
+      using s = stub(service, "dispatchAsync");
+      assertThrows(() => invoke(service, "dispatchAsync", []), AssertError);
+      assertSpyCalls(s, 0);
     });
   });
 

--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -146,7 +146,7 @@ class Plugin {
       await mod.main(this.#denops);
       await emit(this.#denops, `DenopsSystemPluginPost:${this.name}`);
     } catch (e) {
-      console.error(`Failed to load plguin '${this.name}': ${e}`);
+      console.error(`Failed to load plugin '${this.name}': ${e}`);
       await emit(this.#denops, `DenopsSystemPluginFail:${this.name}`);
     }
   }

--- a/denops/@denops-private/service_test.ts
+++ b/denops/@denops-private/service_test.ts
@@ -72,34 +72,30 @@ Deno.test("Service", async (t) => {
   );
 
   await t.step("load() loads plugin and emits autocmd events", async () => {
-    const s = stub(host, "call");
-    try {
-      await service.load("dummy", scriptValid);
-      assertSpyCalls(s, 3);
-      assertSpyCall(s, 0, {
-        args: [
-          "denops#api#cmd",
-          "doautocmd <nomodeline> User DenopsSystemPluginPre:dummy",
-          {},
-        ],
-      });
-      assertSpyCall(s, 1, {
-        args: [
-          "denops#api#cmd",
-          "echo 'Hello, Denops!'",
-          {},
-        ],
-      });
-      assertSpyCall(s, 2, {
-        args: [
-          "denops#api#cmd",
-          "doautocmd <nomodeline> User DenopsSystemPluginPost:dummy",
-          {},
-        ],
-      });
-    } finally {
-      s.restore();
-    }
+    using s = stub(host, "call");
+    await service.load("dummy", scriptValid);
+    assertSpyCalls(s, 3);
+    assertSpyCall(s, 0, {
+      args: [
+        "denops#api#cmd",
+        "doautocmd <nomodeline> User DenopsSystemPluginPre:dummy",
+        {},
+      ],
+    });
+    assertSpyCall(s, 1, {
+      args: [
+        "denops#api#cmd",
+        "echo 'Hello, Denops!'",
+        {},
+      ],
+    });
+    assertSpyCall(s, 2, {
+      args: [
+        "denops#api#cmd",
+        "doautocmd <nomodeline> User DenopsSystemPluginPost:dummy",
+        {},
+      ],
+    });
   });
 
   await t.step(
@@ -112,126 +108,103 @@ Deno.test("Service", async (t) => {
   await t.step(
     "load() loads plugin and emits autocmd events (failure)",
     async () => {
-      const c = stub(console, "error");
-      const s = stub(host, "call");
-      try {
-        await service.load("dummyFail", scriptInvalid);
-        assertSpyCalls(c, 1);
-        assertSpyCall(c, 0, {
-          args: [
-            "Failed to load plugin 'dummyFail': Error: This is dummy error",
-          ],
-        });
-        assertSpyCalls(s, 2);
-        assertSpyCall(s, 0, {
-          args: [
-            "denops#api#cmd",
-            "doautocmd <nomodeline> User DenopsSystemPluginPre:dummyFail",
-            {},
-          ],
-        });
-        assertSpyCall(s, 1, {
-          args: [
-            "denops#api#cmd",
-            "doautocmd <nomodeline> User DenopsSystemPluginFail:dummyFail",
-            {},
-          ],
-        });
-      } finally {
-        s.restore();
-        c.restore();
-      }
-    },
-  );
-
-  await t.step(
-    "load() does nothing when the plugin is already loaded",
-    async () => {
-      const s1 = stub(host, "call");
-      const s2 = stub(console, "log");
-      try {
-        await service.load("dummy", scriptValid);
-        assertSpyCalls(s1, 0);
-        assertSpyCalls(s2, 1);
-        assertSpyCall(s2, 0, {
-          args: [
-            "A denops plugin 'dummy' is already loaded. Skip",
-          ],
-        });
-      } finally {
-        s1.restore();
-        s2.restore();
-      }
-    },
-  );
-
-  await t.step("reload() reloads plugin and emits autocmd events", async () => {
-    const s = stub(host, "call");
-    try {
-      await service.reload("dummy");
-      assertSpyCalls(s, 3);
+      using c = stub(console, "error");
+      using s = stub(host, "call");
+      await service.load("dummyFail", scriptInvalid);
+      assertSpyCalls(c, 1);
+      assertSpyCall(c, 0, {
+        args: [
+          "Failed to load plugin 'dummyFail': Error: This is dummy error",
+        ],
+      });
+      assertSpyCalls(s, 2);
       assertSpyCall(s, 0, {
         args: [
           "denops#api#cmd",
-          "doautocmd <nomodeline> User DenopsSystemPluginPre:dummy",
+          "doautocmd <nomodeline> User DenopsSystemPluginPre:dummyFail",
           {},
         ],
       });
       assertSpyCall(s, 1, {
         args: [
           "denops#api#cmd",
-          "echo 'Hello, Denops!'",
+          "doautocmd <nomodeline> User DenopsSystemPluginFail:dummyFail",
           {},
         ],
       });
-      assertSpyCall(s, 2, {
+    },
+  );
+
+  await t.step(
+    "load() does nothing when the plugin is already loaded",
+    async () => {
+      using s1 = stub(host, "call");
+      using s2 = stub(console, "log");
+      await service.load("dummy", scriptValid);
+      assertSpyCalls(s1, 0);
+      assertSpyCalls(s2, 1);
+      assertSpyCall(s2, 0, {
         args: [
-          "denops#api#cmd",
-          "doautocmd <nomodeline> User DenopsSystemPluginPost:dummy",
-          {},
+          "A denops plugin 'dummy' is already loaded. Skip",
         ],
       });
-    } finally {
-      s.restore();
-    }
+    },
+  );
+
+  await t.step("reload() reloads plugin and emits autocmd events", async () => {
+    using s = stub(host, "call");
+    await service.reload("dummy");
+    assertSpyCalls(s, 3);
+    assertSpyCall(s, 0, {
+      args: [
+        "denops#api#cmd",
+        "doautocmd <nomodeline> User DenopsSystemPluginPre:dummy",
+        {},
+      ],
+    });
+    assertSpyCall(s, 1, {
+      args: [
+        "denops#api#cmd",
+        "echo 'Hello, Denops!'",
+        {},
+      ],
+    });
+    assertSpyCall(s, 2, {
+      args: [
+        "denops#api#cmd",
+        "doautocmd <nomodeline> User DenopsSystemPluginPost:dummy",
+        {},
+      ],
+    });
   });
 
   await t.step(
     "reload() does nothing when the plugin is not loaded yet",
     async () => {
-      const s1 = stub(host, "call");
-      const s2 = stub(console, "log");
-      try {
-        await service.reload("pluginthatisnotloaded");
-        assertSpyCalls(s1, 0);
-        assertSpyCalls(s2, 1);
-        assertSpyCall(s2, 0, {
-          args: [
-            "A denops plugin 'pluginthatisnotloaded' is not loaded yet. Skip",
-          ],
-        });
-      } finally {
-        s1.restore();
-        s2.restore();
-      }
+      using s1 = stub(host, "call");
+      using s2 = stub(console, "log");
+      await service.reload("pluginthatisnotloaded");
+      assertSpyCalls(s1, 0);
+      assertSpyCalls(s2, 1);
+      assertSpyCall(s2, 0, {
+        args: [
+          "A denops plugin 'pluginthatisnotloaded' is not loaded yet. Skip",
+        ],
+      });
     },
   );
 
   await t.step("dispatch() call API of a plugin", async () => {
-    const s = stub(host, "call");
-    try {
-      await service.dispatch("dummy", "test", ["foo"]);
-      assertSpyCalls(s, 1);
-      assertSpyCall(s, 0, {
-        args: [
-          "denops#api#cmd",
-          "echo 'This is test call: [\"foo\"]'",
-          {},
-        ],
-      });
-    } finally {
-      s.restore();
-    }
+    using s = stub(host, "call");
+    await service.dispatch("dummy", "test", ["foo"]);
+    assertSpyCalls(s, 1);
+    assertSpyCall(s, 0, {
+      args: [
+        "denops#api#cmd",
+        "echo 'This is test call: [\"foo\"]'",
+        {},
+      ],
+    });
   });
 
   await t.step(
@@ -248,68 +221,60 @@ Deno.test("Service", async (t) => {
   await t.step(
     "dispatch() rejects when failed to call plugin API",
     async () => {
-      const s = stub(
+      using s = stub(
         host,
         "call",
         () => Promise.reject(new Error("invalid call")),
       );
-      try {
-        const err = await assertRejects(
-          () => service.dispatch("dummy", "test", ["foo"]),
-        );
-        assertSpyCalls(s, 1);
-        assertSpyCall(s, 0, {
-          args: [
-            "denops#api#cmd",
-            "echo 'This is test call: [\"foo\"]'",
-            {},
-          ],
-        });
-        assert(typeof err === "string");
-        assertMatch(err, /invalid call/);
-      } finally {
-        s.restore();
-      }
+      const err = await assertRejects(
+        () => service.dispatch("dummy", "test", ["foo"]),
+      );
+      assertSpyCalls(s, 1);
+      assertSpyCall(s, 0, {
+        args: [
+          "denops#api#cmd",
+          "echo 'This is test call: [\"foo\"]'",
+          {},
+        ],
+      });
+      assert(typeof err === "string");
+      assertMatch(err, /invalid call/);
     },
   );
 
   await t.step(
     "dispatchAsync() call success callback when API call is succeeded",
     async () => {
-      const s = stub(host, "call");
-      try {
-        await service.dispatchAsync(
-          "dummy",
-          "test",
-          ["foo"],
+      using s = stub(host, "call");
+      await service.dispatchAsync(
+        "dummy",
+        "test",
+        ["foo"],
+        "success",
+        "failure",
+      );
+      assertSpyCalls(s, 2);
+      assertSpyCall(s, 0, {
+        args: [
+          "denops#api#cmd",
+          "echo 'This is test call: [\"foo\"]'",
+          {},
+        ],
+      });
+      assertSpyCall(s, 1, {
+        args: [
+          "denops#callback#call",
           "success",
-          "failure",
-        );
-        assertSpyCalls(s, 2);
-        assertSpyCall(s, 0, {
-          args: [
-            "denops#api#cmd",
-            "echo 'This is test call: [\"foo\"]'",
-            {},
-          ],
-        });
-        assertSpyCall(s, 1, {
-          args: [
-            "denops#callback#call",
-            "success",
-            undefined,
-          ],
-        });
-      } finally {
-        s.restore();
-      }
+          undefined,
+        ],
+      });
     },
   );
 
   await t.step(
     "dispatchAsync() call failure callback when API call is failed",
     async () => {
-      const s = stub(
+      using s = stub(
         host,
         "call",
         (method) =>
@@ -317,39 +282,35 @@ Deno.test("Service", async (t) => {
             ? Promise.reject(new Error("invalid call"))
             : Promise.resolve(),
       );
-      try {
-        await service.dispatchAsync(
-          "dummy",
-          "test",
-          ["foo"],
-          "success",
+      await service.dispatchAsync(
+        "dummy",
+        "test",
+        ["foo"],
+        "success",
+        "failure",
+      );
+      assertSpyCalls(s, 2);
+      assertSpyCall(s, 0, {
+        args: [
+          "denops#api#cmd",
+          "echo 'This is test call: [\"foo\"]'",
+          {},
+        ],
+      });
+      assertSpyCall(s, 1, {
+        args: [
+          "denops#callback#call",
           "failure",
-        );
-        assertSpyCalls(s, 2);
-        assertSpyCall(s, 0, {
-          args: [
-            "denops#api#cmd",
-            "echo 'This is test call: [\"foo\"]'",
-            {},
-          ],
-        });
-        assertSpyCall(s, 1, {
-          args: [
-            "denops#callback#call",
-            "failure",
-            s.calls[1].args[2],
-          ],
-        });
-      } finally {
-        s.restore();
-      }
+          s.calls[1].args[2],
+        ],
+      });
     },
   );
 
   await t.step(
     "dispatchAsync() call success callback when API call is succeeded (but fail)",
     async () => {
-      const s1 = stub(
+      using s1 = stub(
         host,
         "call",
         (method) =>
@@ -357,85 +318,75 @@ Deno.test("Service", async (t) => {
             ? Promise.reject(new Error("invalid call"))
             : Promise.resolve(),
       );
-      const s2 = stub(console, "error");
-      try {
-        await service.dispatchAsync(
-          "dummy",
-          "test",
-          ["foo"],
+      using s2 = stub(console, "error");
+      await service.dispatchAsync(
+        "dummy",
+        "test",
+        ["foo"],
+        "success",
+        "failure",
+      );
+      assertSpyCalls(s1, 2);
+      assertSpyCall(s1, 0, {
+        args: [
+          "denops#api#cmd",
+          "echo 'This is test call: [\"foo\"]'",
+          {},
+        ],
+      });
+      assertSpyCall(s1, 1, {
+        args: [
+          "denops#callback#call",
           "success",
-          "failure",
-        );
-        assertSpyCalls(s1, 2);
-        assertSpyCall(s1, 0, {
-          args: [
-            "denops#api#cmd",
-            "echo 'This is test call: [\"foo\"]'",
-            {},
-          ],
-        });
-        assertSpyCall(s1, 1, {
-          args: [
-            "denops#callback#call",
-            "success",
-            undefined,
-          ],
-        });
-        assertSpyCalls(s2, 1);
-        assertSpyCall(s2, 0, {
-          args: [
-            "Failed to call success callback 'success': Error: invalid call",
-          ],
-        });
-      } finally {
-        s1.restore();
-        s2.restore();
-      }
+          undefined,
+        ],
+      });
+      assertSpyCalls(s2, 1);
+      assertSpyCall(s2, 0, {
+        args: [
+          "Failed to call success callback 'success': Error: invalid call",
+        ],
+      });
     },
   );
 
   await t.step(
     "dispatchAsync() call failure callback when API call is failed (but fail)",
     async () => {
-      const s1 = stub(
+      using s1 = stub(
         host,
         "call",
         () => Promise.reject(new Error("invalid call")),
       );
-      const s2 = stub(console, "error");
-      try {
-        await service.dispatchAsync(
-          "dummy",
-          "test",
-          ["foo"],
-          "success",
+      using s2 = stub(console, "error");
+      await service.dispatchAsync(
+        "dummy",
+        "test",
+        ["foo"],
+        "success",
+        "failure",
+      );
+      assertSpyCalls(s1, 2);
+      assertSpyCall(s1, 0, {
+        args: [
+          "denops#api#cmd",
+          "echo 'This is test call: [\"foo\"]'",
+          {},
+        ],
+      });
+      assertSpyCall(s1, 1, {
+        args: [
+          "denops#callback#call",
           "failure",
-        );
-        assertSpyCalls(s1, 2);
-        assertSpyCall(s1, 0, {
-          args: [
-            "denops#api#cmd",
-            "echo 'This is test call: [\"foo\"]'",
-            {},
-          ],
-        });
-        assertSpyCall(s1, 1, {
-          args: [
-            "denops#callback#call",
-            "failure",
-            s1.calls[1].args[2],
-          ],
-        });
-        assertSpyCalls(s2, 1);
-        assertSpyCall(s2, 0, {
-          args: [
-            "Failed to call failure callback 'failure': Error: invalid call",
-          ],
-        });
-      } finally {
-        s1.restore();
-        s2.restore();
-      }
+          s1.calls[1].args[2],
+        ],
+      });
+      assertSpyCalls(s2, 1);
+      assertSpyCall(s2, 0, {
+        args: [
+          "Failed to call failure callback 'failure': Error: invalid call",
+        ],
+      });
     },
   );
 });

--- a/denops/@denops-private/service_test.ts
+++ b/denops/@denops-private/service_test.ts
@@ -112,9 +112,16 @@ Deno.test("Service", async (t) => {
   await t.step(
     "load() loads plugin and emits autocmd events (failure)",
     async () => {
+      const c = stub(console, "error");
       const s = stub(host, "call");
       try {
         await service.load("dummyFail", scriptInvalid);
+        assertSpyCalls(c, 1);
+        assertSpyCall(c, 0, {
+          args: [
+            "Failed to load plugin 'dummyFail': Error: This is dummy error",
+          ],
+        });
         assertSpyCalls(s, 2);
         assertSpyCall(s, 0, {
           args: [
@@ -132,6 +139,7 @@ Deno.test("Service", async (t) => {
         });
       } finally {
         s.restore();
+        c.restore();
       }
     },
   );

--- a/denops/@denops-private/testutil/conf.ts
+++ b/denops/@denops-private/testutil/conf.ts
@@ -9,6 +9,7 @@ export interface Config {
   vimExecutable: string;
   nvimExecutable: string;
   verbose: boolean;
+  timeout?: number;
 }
 
 export function getConfig(): Config {
@@ -18,11 +19,15 @@ export function getConfig(): Config {
   const denopsPath = Deno.env.get("DENOPS_TEST_DENOPS_PATH") ??
     fromFileUrl(new URL("../../..", import.meta.url));
   const verbose = Deno.env.get("DENOPS_TEST_VERBOSE");
+  const timeout = Number.parseFloat(
+    Deno.env.get("DENOPS_TEST_TIMEOUT") ?? "NaN",
+  );
   conf = {
     denopsPath: removeTrailingSep(resolve(denopsPath)),
     vimExecutable: Deno.env.get("DENOPS_TEST_VIM_EXECUTABLE") ?? "vim",
     nvimExecutable: Deno.env.get("DENOPS_TEST_NVIM_EXECUTABLE") ?? "nvim",
     verbose: verbose === "1" || verbose === "true",
+    timeout: timeout >= 0 ? timeout : undefined,
   };
   return conf;
 }

--- a/denops/@denops-private/testutil/shared_server.ts
+++ b/denops/@denops-private/testutil/shared_server.ts
@@ -5,7 +5,7 @@ import { TextLineStream } from "jsr:@std/streams@0.224.0/text-line-stream";
 import { pop } from "jsr:@lambdalisue/streamtools@1.0.0";
 import { getConfig } from "./conf.ts";
 
-const DEFAULT_TIMEOUT = 5000;
+const DEFAULT_TIMEOUT = 30_000;
 
 export interface UseSharedServerOptions {
   /** Print shared-server messages. */

--- a/denops/@denops-private/testutil/shared_server_test.ts
+++ b/denops/@denops-private/testutil/shared_server_test.ts
@@ -3,7 +3,7 @@ import {
   assertMatch,
   assertRejects,
 } from "jsr:@std/assert@0.225.2";
-import { delay } from "jsr:@std/async@^0.224.0/delay";
+import { delay } from "jsr:@std/async@0.224.0/delay";
 import { stub } from "jsr:@std/testing@0.224.0/mock";
 import { useSharedServer } from "./shared_server.ts";
 

--- a/denops/@denops-private/testutil/wait.ts
+++ b/denops/@denops-private/testutil/wait.ts
@@ -1,4 +1,5 @@
 import { AssertionError } from "jsr:@std/assert@0.225.1/assertion-error";
+import { getConfig } from "./conf.ts";
 
 const DEFAULT_TIMEOUT = 30_000;
 const DEFAULT_INTERVAL = 50;
@@ -30,7 +31,7 @@ export async function wait<T>(
     timeout = DEFAULT_TIMEOUT,
     interval = DEFAULT_INTERVAL,
     message,
-  } = options ?? {};
+  } = { ...getConfig(), ...options };
   const TIMEOUT = {};
 
   let timeoutId: number | undefined;

--- a/denops/@denops-private/testutil/wait.ts
+++ b/denops/@denops-private/testutil/wait.ts
@@ -1,5 +1,8 @@
 import { AssertionError } from "jsr:@std/assert@^0.225.1/assertion-error";
 
+const DEFAULT_TIMEOUT = 30_000;
+const DEFAULT_INTERVAL = 50;
+
 export type WaitOptions = {
   /**
    * Timeout period to an exception is thrown.
@@ -23,7 +26,11 @@ export async function wait<T>(
   fn: () => T | Promise<T>,
   options?: WaitOptions,
 ): Promise<T> {
-  const { timeout = 10_000, interval = 50, message } = options ?? {};
+  const {
+    timeout = DEFAULT_TIMEOUT,
+    interval = DEFAULT_INTERVAL,
+    message,
+  } = options ?? {};
   const TIMEOUT = {};
 
   let timeoutId: number | undefined;

--- a/denops/@denops-private/testutil/wait.ts
+++ b/denops/@denops-private/testutil/wait.ts
@@ -1,4 +1,4 @@
-import { AssertionError } from "jsr:@std/assert@^0.225.1/assertion-error";
+import { AssertionError } from "jsr:@std/assert@0.225.1/assertion-error";
 
 const DEFAULT_TIMEOUT = 30_000;
 const DEFAULT_INTERVAL = 50;

--- a/tests/denops/server_test.ts
+++ b/tests/denops/server_test.ts
@@ -22,8 +22,16 @@ testHost({
     await t.step(
       "returns 'starting' when denops#server#start() is called",
       async () => {
-        await host.call("denops#server#start");
-        const actual = await host.call("denops#server#status");
+        // NOTE: The status may transition to `preparing`, so get it within execute.
+        // SEE: https://github.com/vim-denops/denops.vim/issues/354
+        await host.call("execute", [
+          "source plugin/denops.vim",
+          "let g:__test_denops_server_status_when_start_called = denops#server#status()",
+        ]);
+        const actual = await host.call(
+          "eval",
+          "g:__test_denops_server_status_when_start_called",
+        );
         assertEquals(actual, "starting");
       },
     );
@@ -68,16 +76,22 @@ testHost({
   mode: "all",
   verbose: true,
   fn: async (host, t) => {
+    // NOTE: The status may transition to `preparing`, so get it within execute.
+    // SEE: https://github.com/vim-denops/denops.vim/issues/354
     await host.call("execute", [
       "autocmd User DenopsReady let g:denops_ready_fired = 1",
       "autocmd User DenopsClosed let g:denops_closed_fired = 1",
       "source plugin/denops.vim",
+      "let g:__test_denops_server_status_on_sourced = denops#server#status()",
     ], "");
 
     await t.step(
       "'plugin/denops.vim' changes status to 'starting' when sourced",
       async () => {
-        const actual = await host.call("denops#server#status");
+        const actual = await host.call(
+          "eval",
+          "g:__test_denops_server_status_on_sourced",
+        );
         assertEquals(actual, "starting");
       },
     );


### PR DESCRIPTION
- Merge main.
  - Fix error log messge f077ef9bc73a0ee810c9a929d5cdfca271d42ea9.
- Use `using` for `stub`, instead `try ... catch`.
- Fix some flaky tests.
  - Extends timeouts.
  - Fix timing.
  - Optionaly add `DENOPS_TEST_TIMEOUT` environment variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `timeout` field to the configuration settings for better control over test durations.

- **Improvements**
  - Increased default timeout value for shared server operations from 5000ms to 30000ms for enhanced reliability.
  - Improved error messages for better clarity.
  
- **Bug Fixes**
  - Corrected a typo in an error message within the Plugin class.

- **Refactor**
  - Simplified stub usage in test cases for more efficient and cleaner code.
  - Updated import statements and function calls for consistency and better error handling.

- **Tests**
  - Enhanced test cases with new assertion functions and improved error handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->