### PR TITLE
:+1: Show a warning message when Deno module cache issue is detected

### DIFF
--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -149,6 +149,24 @@ class Plugin {
       await mod.main(this.#denops);
       await emit(this.#denops, `DenopsSystemPluginPost:${this.name}`);
     } catch (e) {
+      // Show a warning message when Deno module cache issue is detected
+      // https://github.com/vim-denops/denops.vim/issues/358
+      if (
+        e instanceof TypeError &&
+        e.message.startsWith(
+          "Could not find constraint in the list of versions: ",
+        )
+      ) {
+        console.warn("*".repeat(80));
+        console.warn(`Deno module cache issue is detected.`);
+        console.warn(
+          `Execute 'call denops#cache#update(#{reload: v:true})' and restart Vim/Neovim.`,
+        );
+        console.warn(
+          `See https://github.com/vim-denops/denops.vim/issues/358 for more detail.`,
+        );
+        console.warn("*".repeat(80));
+      }
       console.error(`Failed to load plugin '${this.name}': ${e}`);
       await emit(this.#denops, `DenopsSystemPluginFail:${this.name}`);
     }

--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -144,8 +144,8 @@ class Plugin {
 
   async load(suffix = ""): Promise<void> {
     try {
-      const mod = await import(`${this.script}${suffix}`);
       await emit(this.#denops, `DenopsSystemPluginPre:${this.name}`);
+      const mod = await import(`${this.script}${suffix}`);
       await mod.main(this.#denops);
       await emit(this.#denops, `DenopsSystemPluginPost:${this.name}`);
     } catch (e) {

--- a/denops/@denops-private/testdata/dummy_invalid_constraint_plugin.ts
+++ b/denops/@denops-private/testdata/dummy_invalid_constraint_plugin.ts
@@ -1,0 +1,8 @@
+import type { Entrypoint } from "https://deno.land/x/denops_core@v6.1.0/mod.ts";
+
+export const main: Entrypoint = (_denops) => {
+  // Mimic the situation
+  throw new TypeError(
+    "Could not find constraint in the list of versions: @std/encoding@0.224.3",
+  );
+};


### PR DESCRIPTION
After this PR, when `TypeError: Could not find constraint in the list of versions` error is detected, denops will shows the following warning messages to user.

```
********************************************************************************
Deno module cache issue is detected.
Execute 'call denops#cache#update(#{reload: v:true})' and restart Vim/Neovim.
See https://github.com/vim-denops/denops.vim/issues/358 for more detail.
********************************************************************************
```

See #358 for more detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a warning message for Deno module cache issues to improve error handling and user awareness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->