### PR TITLE
:+1: Gracefully terminate worker

### DIFF
--- a/denops/@denops-private/cli.ts
+++ b/denops/@denops-private/cli.ts
@@ -2,24 +2,18 @@ import {
   readableStreamFromWorker,
   writableStreamFromWorker,
 } from "jsr:@lambdalisue/workerio@4.0.0";
+import { deadline } from "jsr:@std/async@0.224.0/deadline";
 import { parseArgs } from "jsr:@std/cli@0.224.3/parse-args";
+import { asyncSignal } from "jsr:@milly/async-signal@^1.0.0";
 
 // Disable "Native acceleration" feature of `msgpackr` as an workaround of Deno panic.
 // https://github.com/denoland/deno/issues/23792
 Deno.env.set("MSGPACKR_NATIVE_ACCELERATION_DISABLED", "true");
 
 const WORKER_SCRIPT = import.meta.resolve("./worker.ts");
+const WORKER_CLOSE_TIMEOUT_MS = 5000;
 
-async function handleConn(
-  conn: Deno.TcpConn,
-  { quiet }: { quiet?: boolean },
-): Promise<void> {
-  const remoteAddr = conn.remoteAddr;
-  const name = `${remoteAddr.hostname}:${remoteAddr.port}`;
-  if (!quiet) {
-    console.info(`${name} is connected`);
-  }
-
+async function processWorker(name: string, conn: Deno.Conn): Promise<void> {
   const worker = new Worker(WORKER_SCRIPT, {
     name,
     type: "module",
@@ -29,10 +23,16 @@ async function handleConn(
 
   try {
     await Promise.race([
-      reader.pipeTo(conn.writable),
+      reader.pipeTo(conn.writable, { preventCancel: true }),
       conn.readable.pipeTo(writer),
     ]);
   } finally {
+    try {
+      const closeWaiter = reader.pipeTo(new WritableStream());
+      await deadline(closeWaiter, WORKER_CLOSE_TIMEOUT_MS);
+    } catch {
+      // `reader` already closed or deadline has passed, do nothing
+    }
     // Terminate worker to avoid leak
     worker.terminate();
   }
@@ -61,14 +61,48 @@ export async function main(args: string[]): Promise<void> {
     );
   }
 
-  for await (const conn of listener) {
-    handleConn(conn, { quiet }).catch((err) =>
+  const handleConn = async (conn: Deno.Conn<Deno.NetAddr>): Promise<void> => {
+    const { remoteAddr } = conn;
+    const name = `${remoteAddr.hostname}:${remoteAddr.port}`;
+    if (!quiet) {
+      console.info(`${name} is connected`);
+    }
+    try {
+      await processWorker(name, conn);
+    } catch (err) {
       console.error(
         "Internal error occurred and Host/Denops connection is dropped",
         err,
-      )
-    );
+      );
+    } finally {
+      try {
+        conn.close();
+      } catch {
+        // Already closed, do nothing
+      }
+      if (!quiet) {
+        console.info(`${name} is closed`);
+      }
+    }
+  };
+
+  const connections = new Set<Promise<void>>();
+
+  {
+    using sigintTrap = asyncSignal("SIGINT");
+    sigintTrap.catch(() => {
+      listener.close();
+    });
+
+    for await (const conn of listener) {
+      const handler = handleConn(conn)
+        .finally(() => connections.delete(handler));
+      connections.add(handler);
+    }
   }
+
+  // The listener is closed and waits for existing connections to terminate.
+  await Promise.allSettled([...connections]);
 }
 
 if (import.meta.main) {

--- a/tests/denops/server_test.ts
+++ b/tests/denops/server_test.ts
@@ -74,7 +74,6 @@ testHost({
 testHost({
   name: "Denops server",
   mode: "all",
-  verbose: true,
   fn: async (host, t) => {
     // NOTE: The status may transition to `preparing`, so get it within execute.
     // SEE: https://github.com/vim-denops/denops.vim/issues/354


### PR DESCRIPTION
When the cli process traps `SIGINT`, it will do the following:
- Close the port listen.
- Perform termination processing in each worker.
- Terminate the cli process after all workers have terminated.
(Previously: All workers and the cli process terminated immediately.)

When the connection is disconnected, it will do the following:
- Perform termination processing in the worker.
- Wait for the worker to terminate. If the timeout expires, it will terminate the worker.
(Previously: Terminate the worker immediately.)

This PR alone does not include any new features. This is because the termination processing of the worker has not been implemented.
This will allow we to implement the termination processing of the worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved connection management and error handling for worker processes.
	- Updated connection handling mechanism to manage active connections efficiently.

- **Tests**
	- Enhanced test coverage with additional stubs and assertions.
	- Refined test logic for signal handling and worker stream closure.

- **Chores**
	- Removed verbose setting in server test to streamline test output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->