### PR TITLE
:+1: Gracefully close service

### DIFF
--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -146,7 +146,7 @@ export class Service implements HostService, AsyncDisposable {
       }
       this.#waiters.clear();
       this.#plugins.clear();
-      this.#host = void 0;
+      this.#host = undefined;
       this.#closedWaiter.resolve();
     }
     return this.waitClosed();

--- a/denops/@denops-private/service_test.ts
+++ b/denops/@denops-private/service_test.ts
@@ -192,26 +192,6 @@ Deno.test("Service", async (t) => {
     },
   );
 
-  await t.step("reload() reloads plugin and emits autocmd events", async () => {
-    using s = stub(host, "call");
-    await service.reload("dummy");
-    assertSpyCalls(s, 3);
-    assertSpyCall(s, 1, {
-      args: [
-        "denops#api#cmd",
-        "echo 'Hello, Denops!'",
-        {},
-      ],
-    });
-    assertSpyCall(s, 2, {
-      args: [
-        "denops#api#cmd",
-        "doautocmd <nomodeline> User DenopsSystemPluginPost:dummy",
-        {},
-      ],
-    });
-  });
-
   await t.step(
     "load() does nothing when the plugin is already loaded",
     async () => {

--- a/denops/@denops-private/worker.ts
+++ b/denops/@denops-private/worker.ts
@@ -77,10 +77,11 @@ async function connectHost(): Promise<void> {
 
   // Start service
   using sigintTrap = asyncSignal("SIGINT");
-  using service = new Service(meta);
+  await using service = new Service(meta);
   await host.init(service);
   await host.call("execute", "doautocmd <nomodeline> User DenopsReady", "");
   await Promise.race([
+    service.waitClosed(),
     host.waitClosed(),
     sigintTrap,
   ]);


### PR DESCRIPTION
- The Service is closed when The worker is terminated.
- The worker is teminated when The Service is closed.
- `denops.dispatch()` (but `service.dispatch()`) rejects with a service closed error if the service is closed before the plugin loaded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `Service` class with new asynchronous disposal capabilities.
  - Introduced new methods for service closure management.

- **Tests**
  - Added test cases for new `close()` and `waitClosed()` methods.
  - Updated tests to cover asynchronous disposal and service closure scenarios.

- **Bug Fixes**
  - Improved reliability of service state management and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->