### PR TITLE
:+1: Remove `args` from error messages of `call/batch`

### DIFF
--- a/denops/@denops-private/host.ts
+++ b/denops/@denops-private/host.ts
@@ -91,7 +91,3 @@ export function invoke(
       throw new Error(`Service does not have a method '${name}'`);
   }
 }
-
-export function formatCall(fn: string, ...args: unknown[]): string {
-  return `${fn}(${args.map((v) => JSON.stringify(v)).join(", ")})`;
-}

--- a/denops/@denops-private/host/nvim.ts
+++ b/denops/@denops-private/host/nvim.ts
@@ -5,7 +5,7 @@ import {
 } from "https://deno.land/x/messagepack_rpc@v2.0.3/mod.ts";
 import { errorDeserializer, errorSerializer } from "../error.ts";
 import { getVersionOr } from "../version.ts";
-import { formatCall, Host, invoke, Service } from "../host.ts";
+import { Host, invoke, Service } from "../host.ts";
 
 export class Neovim implements Host {
   #session: Session;
@@ -63,9 +63,7 @@ export class Neovim implements Host {
       if (isNvimErrorObject(err)) {
         const [code, message] = err;
         throw new Error(
-          `Failed to call ${
-            formatCall(fn, ...args)
-          }: ${message} (code: ${code})`,
+          `Failed to call '${fn}' in Neovim: ${message} (code: ${code})`,
         );
       }
       throw err;
@@ -82,11 +80,10 @@ export class Neovim implements Host {
     const [ret, err] = ensure(result, isNvimCallAtomicReturn);
     if (err) {
       const [index, code, message] = err;
+      const fn = calls[index][0];
       return [
         ret,
-        `Failed to call ${
-          formatCall(...calls[index])
-        }: ${message} (code: ${code})`,
+        `Failed to call '${fn}' in Neovim: ${message} (code: ${code})`,
       ];
     }
     return [ret, ""];

--- a/denops/@denops-private/host/nvim_test.ts
+++ b/denops/@denops-private/host/nvim_test.ts
@@ -67,7 +67,7 @@ Deno.test("Neovim", async (t) => {
           await assertRejects(
             () => host.call("@@@@@", -4),
             Error,
-            "Failed to call @@@@@(-4): Vim:E117: Unknown function: @@@@@ (code: 0)",
+            "Failed to call '@@@@@' in Neovim: Vim:E117: Unknown function: @@@@@ (code: 0)",
           );
         },
       );
@@ -93,7 +93,7 @@ Deno.test("Neovim", async (t) => {
           assertEquals(ret, [4, 10]);
           assertMatch(
             err,
-            /Failed to call @@@@@\(-9\): Vim:E117: Unknown function: @@@@@/,
+            /Failed to call '@@@@@' in Neovim: Vim:E117: Unknown function: @@@@@/,
           );
         },
       );

--- a/denops/@denops-private/host/vim.ts
+++ b/denops/@denops-private/host/vim.ts
@@ -4,7 +4,7 @@ import {
   Message,
   Session,
 } from "https://deno.land/x/vim_channel_command@v3.0.0/mod.ts";
-import { formatCall, Host, invoke, Service } from "../host.ts";
+import { Host, invoke, Service } from "../host.ts";
 
 export class Vim implements Host {
   #session: Session;
@@ -53,7 +53,7 @@ export class Vim implements Host {
     }
     const [ret, err] = ensure(result, isCallReturn);
     if (err !== "") {
-      throw new Error(`Failed to call ${formatCall(fn, ...args)}: ${err}`);
+      throw new Error(`Failed to call '${fn}' in Vim: ${err}`);
     }
     return ret;
   }
@@ -72,9 +72,10 @@ export class Vim implements Host {
     const [ret, err] = ensure(result, isBatchReturn) as [unknown[], string];
     if (err) {
       const index = ret.length;
+      const fn = calls[index][0];
       return [
         ret,
-        `Failed to call ${formatCall(...calls[index])}: ${err}`,
+        `Failed to call '${fn}' in Vim: ${err}`,
       ];
     }
     return [ret, ""];

--- a/denops/@denops-private/host/vim_test.ts
+++ b/denops/@denops-private/host/vim_test.ts
@@ -70,7 +70,7 @@ Deno.test("Vim", async (t) => {
           await assertRejects(
             () => host.call("@@@@@", -4),
             Error,
-            "Failed to call @@@@@(-4): Vim(let):E117: Unknown function: @@@@@",
+            "Failed to call '@@@@@' in Vim: Vim(let):E117: Unknown function: @@@@@",
           );
         },
       );
@@ -96,7 +96,7 @@ Deno.test("Vim", async (t) => {
           assertEquals(ret, [4, 10]);
           assertMatch(
             err,
-            /Failed to call @@@@@\(-9\): Vim\(.*\):E117: Unknown function: @@@@@/,
+            /Failed to call '@@@@@' in Vim: Vim\(.*\):E117: Unknown function: @@@@@/,
           );
         },
       );


### PR DESCRIPTION
`args` may contains some sensitive information or massive data.

It follows the decision in #374 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved error message formatting in Neovim and Vim integrations to provide clearer context during function call failures.

- **Tests**
  - Updated test error messages for Neovim and Vim to reflect the new error format for better readability and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->