### PR TITLE
:+1: Forcibly show info/warn/error messages block to the user (RFC)

### DIFF
--- a/autoload/denops/_internal/echo.vim
+++ b/autoload/denops/_internal/echo.vim
@@ -56,5 +56,5 @@ function! s:echomsg_batch() abort
   let s:delayed_timer = 0
   let s:delayed_messages = []
   " Forcibly show the messages to the user
-  call feedkeys(printf(":\<C-u>%dmessages\<CR>", l:counter), 'nt')
+  call feedkeys(printf("\<Cmd>%dmessages\<CR>", l:counter), 'n')
 endfunction


### PR DESCRIPTION
Users may not realize that there are info/warn/error messages in the message history. This commit forcibly shows the messages to the user when the messages are posted with `console.info/warn/error` functions in Denops side.

With this change, for example Denops plugin loading issue is shown on the Vim start-up like below (tested with https://github.com/vim-denops/denops-issue358.vim)

https://github.com/vim-denops/denops.vim/assets/546312/f1c82de7-73f6-4546-9914-4a8fb1ec798d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced delayed message handling for better user experience.
- **Refactor**
  - Enhanced echo functions to utilize the new delayed message mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->