### PR TITLE
:+1: change restart reconnect behavior

### DIFF
--- a/autoload/denops/_internal/server/chan.vim
+++ b/autoload/denops/_internal/server/chan.vim
@@ -12,52 +12,47 @@ let s:exiting = 0
 " Args:
 "   addr: string
 "   options: {
-"     retry_interval: number
-"     retry_threshold: number
 "     reconnect_on_close: boolean
 "     reconnect_delay: number
 "     reconnect_interval: number
 "     reconnect_threshold: number
+"     on_connect_failure: funcref
 "   }
 " Return:
-"   boolean
+"   v:true - If the connection is successful immediately.
+"   0 - Otherwise, if it fails or waits for reconnection.
 function! denops#_internal#server#chan#connect(addr, options) abort
+  call s:clear_reconnect_delayer()
   if s:chan isnot# v:null
     throw '[denops] Channel already exists'
   endif
-  let l:retry_threshold = a:options.retry_threshold
-  let l:retry_interval = a:options.retry_interval
-  let l:i = 1
-  while v:true
-    call denops#_internal#echo#debug(printf(
-          \ 'Connecting to channel `%s` [%d/%d]',
-          \ a:addr,
-          \ l:i,
-          \ l:retry_threshold,
-          \))
-    try
-      call s:connect(a:addr, a:options)
-      return v:true
-    catch
-      call denops#_internal#echo#debug(printf(
-            \ 'Failed to connect channel `%s` [%d/%d]: %s',
+  try
+    call s:connect(a:addr, a:options)
+    return v:true
+  catch
+    if s:reconnect_guard(a:options)
+      call denops#_internal#echo#error(printf(
+            \ 'Failed to connect channel `%s`: %s',
             \ a:addr,
-            \ l:i,
-            \ l:retry_threshold,
             \ v:exception,
             \))
-      if l:i >= l:retry_threshold
-        call denops#_internal#echo#error(printf(
-              \ 'Failed to connect channel `%s`: %s',
-              \ a:addr,
-              \ v:exception,
-              \))
-        return
+      if a:options->has_key('on_connect_failure')
+        call a:options.on_connect_failure(a:options)
       endif
-    endtry
-    execute printf('sleep %dm', l:retry_interval)
-    let l:i += 1
-  endwhile
+      return
+    endif
+    call denops#_internal#echo#debug(printf(
+          \ 'Failed to connect channel `%s` [%d/%d]: %s',
+          \ a:addr,
+          \ s:reconnect_count,
+          \ a:options.reconnect_threshold,
+          \ v:exception,
+          \))
+    let s:reconnect_delayer = timer_start(
+          \ a:options.reconnect_delay,
+          \ { -> denops#_internal#server#chan#connect(a:addr, a:options) },
+          \)
+  endtry
 endfunction
 
 " Args:
@@ -65,6 +60,9 @@ endfunction
 "     timeout: number (default: 0)
 "   }
 function! denops#_internal#server#chan#close(options) abort
+  if s:clear_reconnect_delayer()
+    return
+  endif
   if s:chan is# v:null
     throw '[denops] Channel does not exist yet'
   endif
@@ -143,28 +141,61 @@ function! s:on_close(options) abort
   if s:chan isnot# v:null || !a:options.reconnect_on_close || s:closed_on_purpose || s:exiting
     return
   endif
-  " Reconnect
+  call s:schedule_reconnect(a:options)
+endfunction
+
+function! s:schedule_reconnect(options)
   if s:reconnect_guard(a:options)
+    call denops#_internal#echo#warn(printf(
+          \ 'Channel closed %d times within %d millisec. Denops is disabled to avoid infinity reconnect loop.',
+          \ a:options.reconnect_threshold + 1,
+          \ a:options.reconnect_interval
+          \))
+    let g:denops#disabled = 1
     return
   endif
   call denops#_internal#echo#warn('Channel closed. Reconnecting...')
-  call timer_start(
+  let s:reconnect_delayer = timer_start(
         \ a:options.reconnect_delay,
-        \ { -> denops#_internal#server#chan#connect(s:addr, a:options) },
+        \ { -> s:reconnect(a:options) },
         \)
+endfunction
+
+function! s:reconnect(options) abort
+  call denops#_internal#echo#debug(printf(
+        \ 'Reconnect channel `%s` [%d/%d]',
+        \ s:addr,
+        \ s:reconnect_count,
+        \ a:options.reconnect_threshold,
+        \))
+  try
+    call s:connect(s:addr, a:options)
+  catch
+    call denops#_internal#echo#debug(printf(
+          \ 'Failed to reconnect channel `%s` [%d/%d]: %s',
+          \ s:addr,
+          \ s:reconnect_count,
+          \ a:options.reconnect_threshold,
+          \ v:exception,
+          \))
+    call s:schedule_reconnect(a:options)
+  endtry
+endfunction
+
+function! s:clear_reconnect_delayer() abort
+  if exists('s:reconnect_delayer')
+    call timer_stop(s:reconnect_delayer)
+    unlet s:reconnect_delayer
+    return v:true
+  endif
 endfunction
 
 function! s:reconnect_guard(options) abort
   let l:reconnect_threshold = a:options.reconnect_threshold
   let l:reconnect_interval = a:options.reconnect_interval
   let s:reconnect_count = get(s:, 'reconnect_count', 0) + 1
-  if s:reconnect_count >= l:reconnect_threshold
-    call denops#_internal#echo#warn(printf(
-          \ 'Channel closed %d times within %d millisec. Denops is disabled to avoid infinity reconnect loop.',
-          \ l:reconnect_threshold,
-          \ l:reconnect_interval,
-          \))
-    let g:denops#disabled = 1
+  if s:reconnect_count > l:reconnect_threshold
+    let s:reconnect_count = 0
     return 1
   endif
   if exists('s:reset_reconnect_count_delayer')

--- a/autoload/denops/_internal/server/proc.vim
+++ b/autoload/denops/_internal/server/proc.vim
@@ -12,17 +12,25 @@ let s:exiting = 0
 "     restart_threshold: number
 "   }
 " Return:
-"   boolean
+"   v:true
 function! denops#_internal#server#proc#start(options) abort
+  call s:clear_restart_delayer()
   if s:job isnot# v:null
     throw '[denops] Server already exists'
   endif
-  call denops#_internal#echo#debug('Spawn server')
+  call denops#_internal#echo#debug(printf(
+        \ 'Spawn server [%d/%d]',
+        \ get(s:, 'restart_count', 0),
+        \ a:options.restart_threshold,
+        \))
   call s:start(a:options)
   return v:true
 endfunction
 
 function! denops#_internal#server#proc#stop() abort
+  if s:clear_restart_delayer()
+    return
+  endif
   if s:job is# v:null
     throw '[denops] Server does not exist yet'
   endif
@@ -99,7 +107,7 @@ function! s:on_exit(options, status) abort
         \ 'Server stopped (%d). Restarting...',
         \ a:status,
         \))
-  call timer_start(
+  let s:restart_delayer = timer_start(
         \ a:options.restart_delay,
         \ { -> denops#_internal#server#proc#start(a:options) },
         \)
@@ -109,12 +117,13 @@ function! s:restart_guard(options) abort
   let l:restart_threshold = a:options.restart_threshold
   let l:restart_interval = a:options.restart_interval
   let s:restart_count = get(s:, 'restart_count', 0) + 1
-  if s:restart_count >= l:restart_threshold
+  if s:restart_count > l:restart_threshold
     call denops#_internal#echo#warn(printf(
           \ 'Server stopped %d times within %d millisec. Denops is disabled to avoid infinity restart loop.',
-          \ l:restart_threshold,
+          \ s:restart_count,
           \ l:restart_interval,
           \))
+    let s:restart_count = 0
     let g:denops#disabled = 1
     return 1
   endif
@@ -127,6 +136,14 @@ function! s:restart_guard(options) abort
         \)
 endfunction
 
+function! s:clear_restart_delayer() abort
+  if exists('s:restart_delayer')
+    call timer_stop(s:restart_delayer)
+    unlet s:restart_delayer
+    return v:true
+  endif
+endfunction
+
 augroup denops_internal_server_proc_internal
   autocmd!
   autocmd VimLeave * let s:exiting = 1
@@ -134,3 +151,10 @@ augroup denops_internal_server_proc_internal
   autocmd User DenopsSystemProcessListen:* :
   autocmd User DenopsSystemProcessStopped:* :
 augroup END
+
+function! denops#_internal#server#proc#_get_job_for_test() abort
+  call denops#_internal#echo#warn(
+        \ '_get_job_for_test() should only be used for testing.'
+        \)
+  return s:job
+endfunction

--- a/autoload/denops/_internal/server/proc.vim
+++ b/autoload/denops/_internal/server/proc.vim
@@ -1,7 +1,6 @@
 const s:SCRIPT = denops#_internal#path#script(['@denops-private', 'cli.ts'])
 
 let s:job = v:null
-let s:options = v:null
 let s:stopped_on_purpose = 0
 let s:exiting = 0
 
@@ -60,7 +59,6 @@ function! s:start(options) abort
         \ 'on_stderr': { _job, data, _event -> s:on_stderr(data) },
         \ 'on_exit': { _job, status, _event -> s:on_exit(a:options, status) },
         \})
-  let s:options = a:options
   call denops#_internal#echo#debug(printf('Server started: %s', l:args))
   doautocmd <nomodeline> User DenopsSystemProcessStarted
 endfunction
@@ -103,7 +101,7 @@ function! s:on_exit(options, status) abort
         \))
   call timer_start(
         \ a:options.restart_delay,
-        \ { -> denops#_internal#server#proc#start(s:options) },
+        \ { -> denops#_internal#server#proc#start(a:options) },
         \)
 endfunction
 

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -5,13 +5,16 @@ const s:STATUS_RUNNING = 'running'
 const s:STATUS_CLOSING = 'closing'
 const s:STATUS_CLOSED = 'closed'
 
+" Common variables
 let s:is_ready = v:false
 let s:ready_callbacks = []
 
+" Local server variables
 let s:stopping = v:false
 let s:restart_once = v:false
 let s:local_addr = ""
 
+" Shared server variables
 let s:is_closed = v:false
 let s:closing = v:false
 let s:reconnect_once = v:false
@@ -118,6 +121,22 @@ function! s:get_server_addr() abort
 endfunction
 
 " Common
+function! denops#server#connect_or_start() abort
+  if g:denops#disabled || denops#server#status() !=# s:STATUS_STOPPED
+    return
+  endif
+  let s:addr = s:get_server_addr()
+  if !empty(s:addr)
+    " Connect to a shared server or fallback to a local server.
+    call s:connect(s:addr, {
+          \ 'reconnect_on_close': v:true,
+          \ 'on_connect_failure': { -> denops#server#start() },
+          \})
+  else
+    call denops#server#start()
+  endif
+endfunction
+
 function! denops#server#status() abort
   if s:closing
     return s:STATUS_CLOSING
@@ -176,8 +195,6 @@ endfunction
 function! s:connect(addr, ...) abort
   let s:is_closed = v:false
   let l:options = extend({
-        \ 'retry_interval': g:denops#server#retry_interval,
-        \ 'retry_threshold': g:denops#server#retry_threshold,
         \ 'reconnect_delay': g:denops#server#reconnect_delay,
         \ 'reconnect_interval': g:denops#server#reconnect_interval,
         \ 'reconnect_threshold': g:denops#server#reconnect_threshold,
@@ -277,9 +294,6 @@ call denops#_internal#conf#define('denops#server#deno_args', [
       \ '--no-lock',
       \ '-A',
       \])
-
-call denops#_internal#conf#define('denops#server#retry_interval', 500)
-call denops#_internal#conf#define('denops#server#retry_threshold', 3)
 
 call denops#_internal#conf#define('denops#server#restart_delay', 100)
 call denops#_internal#conf#define('denops#server#restart_interval', 10000)

--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -138,7 +138,7 @@ function! denops#server#wait(...) abort
         \ 'silent': 0,
         \}, a:0 ? a:1 : {},
         \)
-  if denops#server#status() ==# 'stopped'
+  if denops#server#status() ==# s:STATUS_STOPPED
     if !l:options.silent
       call denops#_internal#echo#error(
             \ 'Failed to wait `DenopsReady` autocmd. Denops server itself is not started.',

--- a/denops/@denops-private/testutil/host.ts
+++ b/denops/@denops-private/testutil/host.ts
@@ -4,6 +4,7 @@ import { Vim } from "../host/vim.ts";
 import { withNeovim, WithOptions, withVim } from "./with.ts";
 
 export type HostFn<T> = (helper: {
+  mode: "vim" | "nvim";
   host: Host;
   stdout: ReadableStream<string>;
   stderr: ReadableStream<string>;
@@ -23,7 +24,7 @@ export function withHost<T>(
     return withVim({
       fn: async ({ reader, writer, stdout, stderr }) => {
         await using host = new Vim(reader, writer);
-        return await fn({ host, stdout, stderr });
+        return await fn({ mode, host, stdout, stderr });
       },
       ...withOptions,
     });
@@ -32,7 +33,7 @@ export function withHost<T>(
     return withNeovim({
       fn: async ({ reader, writer, stdout, stderr }) => {
         await using host = new Neovim(reader, writer);
-        return await fn({ host, stdout, stderr });
+        return await fn({ mode, host, stdout, stderr });
       },
       ...withOptions,
     });
@@ -41,6 +42,7 @@ export function withHost<T>(
 }
 
 export type TestFn = (helper: {
+  mode: "vim" | "nvim";
   host: Host;
   t: Deno.TestContext;
   stdout: ReadableStream<string>;
@@ -74,7 +76,7 @@ export function testHost(
       fn: async (t) => {
         await withHost<void | Promise<void>>({
           mode,
-          fn: ({ host, stdout, stderr }) => fn({ host, t, stdout, stderr }),
+          fn: (helper) => fn({ ...helper, t }),
           ...hostOptions,
         });
       },

--- a/denops/@denops-private/testutil/shared_server_test.ts
+++ b/denops/@denops-private/testutil/shared_server_test.ts
@@ -1,4 +1,5 @@
 import {
+  assertEquals,
   assertInstanceOf,
   assertMatch,
   assertNotMatch,
@@ -10,9 +11,19 @@ import { useSharedServer } from "./shared_server.ts";
 
 Deno.test("useSharedServer()", async (t) => {
   await t.step("if `verbose` is not specified", async (t) => {
-    await t.step("returns `result.addr`", async () => {
-      await using server = await useSharedServer();
-      assertMatch(server.addr, /^127\.0\.0\.1:\d+$/);
+    await t.step("returns `result.addr`", async (t) => {
+      await using server = await useSharedServer({ verbose: true });
+      const { addr } = server;
+
+      await t.step("`addr.host` is string", () => {
+        assertEquals(addr.host, "127.0.0.1");
+      });
+      await t.step("`addr.port` is number", () => {
+        assertEquals(typeof addr.port, "number");
+      });
+      await t.step("`addr.toString()` returns the address", () => {
+        assertMatch(addr.toString(), /^127\.0\.0\.1:\d+$/);
+      });
     });
 
     await t.step("returns `result.stdout`", async () => {
@@ -44,9 +55,19 @@ Deno.test("useSharedServer()", async (t) => {
   });
 
   await t.step("if `verbose` is true", async (t) => {
-    await t.step("returns `result.addr`", async () => {
+    await t.step("returns `result.addr`", async (t) => {
       await using server = await useSharedServer({ verbose: true });
-      assertMatch(server.addr, /^127\.0\.0\.1:\d+$/);
+      const { addr } = server;
+
+      await t.step("`addr.host` is string", () => {
+        assertEquals(addr.host, "127.0.0.1");
+      });
+      await t.step("`addr.port` is number", () => {
+        assertEquals(typeof addr.port, "number");
+      });
+      await t.step("`addr.toString()` returns the address", () => {
+        assertMatch(addr.toString(), /^127\.0\.0\.1:\d+$/);
+      });
     });
 
     await t.step("returns `result.stdout`", async () => {

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -147,12 +147,19 @@ VARIABLE						*denops-variable*
 	|g:denops#server#restart_interval|.
 	Default: 3
 
-*g:denops#server#reconnect_interval*
-	Interval in milliseconds before retrying connection to the server.
+*g:denops#server#reconnect_delay*
+	The delay in milliseconds before reconnecting to the server.
 	Default: 100
 
+*g:denops#server#reconnect_interval*
+	Interval in milliseconds to avoid infinite errors. Denops will reset
+	internal counter when the channel keeps connecting more than this
+	interval.
+	Default: 1000
+
 *g:denops#server#reconnect_threshold*
-	The number of reconnect counts on connection failure.
+	The number of reconnect counts on connection failure within
+	|g:denops#server#reconnect_interval|.
 	Default: 3
 
 *g:denops#server#close_timeout*

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -132,8 +132,8 @@ VARIABLE						*denops-variable*
 	Default: ['-q', '--no-lock', '-A']
 
 *g:denops#server#restart_delay*
-	Restart delay in milliseconds to avoid #136.
-	https://github.com/vim-denops/denops.vim/issues/136
+	The delay in milliseconds before restarting the server.
+	This avoid #136. https://github.com/vim-denops/denops.vim/issues/136
 	Default: 100
 
 *g:denops#server#restart_interval*
@@ -143,7 +143,8 @@ VARIABLE						*denops-variable*
 	Default: 10000
 
 *g:denops#server#restart_threshold*
-        The number of restart counts within |g:denops#server#restart_interval|.
+        The number of restart counts on unexpected process terminattion within
+	|g:denops#server#restart_interval|.
 	Default: 3
 
 *g:denops#server#reconnect_interval*

--- a/plugin/denops.vim
+++ b/plugin/denops.vim
@@ -25,21 +25,11 @@ augroup denops_plugin_internal
   autocmd User DenopsReady call denops#plugin#discover()
 augroup END
 
-function! s:init() abort
-  if !empty(get(g:, 'denops_server_addr'))
-    if denops#server#connect()
-      return
-    endif
-    " Fallback to a local denops server
-  endif
-  call denops#server#start()
-endfunction
-
 if has('vim_starting')
   augroup denops_plugin_internal_startup
     autocmd!
-    autocmd VimEnter * call s:init()
+    autocmd VimEnter * call denops#server#connect_or_start()
   augroup END
 else
-  call s:init()
+  call denops#server#connect_or_start()
 endif

--- a/tests/denops/server_test.ts
+++ b/tests/denops/server_test.ts
@@ -124,16 +124,57 @@ testHost({
     // NOTE: Disable startup on VimEnter.
     "autocmd! denops_plugin_internal_startup VimEnter",
   ],
-  fn: async ({ host, t, stderr }) => {
+  fn: async ({ mode, host, t, stderr }) => {
     let outputs: string[] = [];
     stderr.pipeTo(
       new WritableStream({ write: (s) => void outputs.push(s) }),
     ).catch(() => {});
 
+    async function forceShutdownServer() {
+      const serverPid = await host.call(
+        "eval",
+        mode === "vim"
+          ? "job_info(denops#_internal#server#proc#_get_job_for_test()).process"
+          : "jobpid(denops#_internal#server#proc#_get_job_for_test())",
+      ) as number;
+      Deno.kill(serverPid, "SIGKILL");
+    }
+
     await host.call("execute", [
       "autocmd User DenopsReady let g:__test_denops_ready_fired = 1",
+      "autocmd User DenopsClosed let g:__test_denops_closed_fired = 1",
+      "autocmd User DenopsProcessStarted let g:__test_denops_process_started_fired = 1",
       "autocmd User DenopsProcessStopped:* let g:__test_denops_process_stopped_fired = expand('<amatch>')",
     ], "");
+
+    await t.step("if denops disabled", async (t) => {
+      await using stack = new AsyncDisposableStack();
+      stack.defer(async () => {
+        await host.call("execute", [
+          "let g:denops#disabled = 0",
+        ], "");
+      });
+
+      await host.call("execute", [
+        "let g:denops#disabled = 1",
+        "let g:__test_denops_server_start_result = denops#server#start()",
+        "let g:__test_denops_server_status_when_start_called = denops#server#status()",
+      ], "");
+
+      await t.step("returns falsy", async () => {
+        assertFalse(
+          await host.call("eval", "g:__test_denops_server_start_result"),
+        );
+      });
+
+      await t.step("does not change status from 'stopped'", async () => {
+        const actual = await host.call(
+          "eval",
+          "g:__test_denops_server_status_when_start_called",
+        );
+        assertEquals(actual, "stopped");
+      });
+    });
 
     await t.step("if not yet started", async (t) => {
       await using stack = new AsyncDisposableStack();
@@ -146,6 +187,7 @@ testHost({
 
       await host.call("execute", [
         "silent! unlet g:__test_denops_ready_fired",
+        "silent! unlet g:__test_denops_process_started_fired",
         "let g:__test_denops_server_start_result = denops#server#start()",
         "let g:__test_denops_server_status_when_start_called = denops#server#status()",
       ], "");
@@ -160,6 +202,12 @@ testHost({
           "g:__test_denops_server_status_when_start_called",
         );
         assertEquals(actual, "starting");
+      });
+
+      await t.step("fires DenopsProcessStarted", async () => {
+        await wait(() =>
+          host.call("exists", "g:__test_denops_process_started_fired")
+        );
       });
 
       await t.step("fires DenopsReady", async () => {
@@ -270,9 +318,14 @@ testHost({
       await using stack = new AsyncDisposableStack();
       const saved_deno_path = await host.call("eval", "g:denops#server#deno");
       stack.defer(async () => {
+        await host.call("denops#server#stop");
+        await wait(
+          () => host.call("eval", "denops#server#status() ==# 'stopped'"),
+        );
         await host.call("execute", [
           `let g:denops#server#deno = '${saved_deno_path}'`,
-        ]);
+          `let g:denops#disabled = 0`,
+        ], "");
       });
 
       await host.call("execute", [
@@ -305,6 +358,134 @@ testHost({
       await t.step("changes status to 'stopped' asynchronously", async () => {
         const actual = await host.call("denops#server#status");
         assertEquals(actual, "stopped");
+      });
+
+      await t.step("outputs warning message", async () => {
+        await delay(MESSAGE_DELAY);
+        assertMatch(
+          outputs.join(""),
+          /Server stopped 1 times .* Denops is disabled/,
+        );
+      });
+
+      await t.step("changes `g:denops#disabled` to truthy", async () => {
+        assert(await host.call("eval", "g:denops#disabled"));
+      });
+    });
+
+    await t.step("if the server is stopped unexpectedly", async (t) => {
+      await using stack = new AsyncDisposableStack();
+      stack.defer(async () => {
+        await host.call("denops#server#stop");
+        await wait(
+          () => host.call("eval", "denops#server#status() ==# 'stopped'"),
+        );
+      });
+
+      await host.call("execute", [
+        "let g:denops#server#restart_delay = 1000",
+        "let g:denops#server#restart_interval = 1000",
+        "let g:denops#server#restart_threshold = 1",
+        "call denops#server#start()",
+      ], "");
+      await wait(
+        () => host.call("eval", "denops#server#status() ==# 'running'"),
+      );
+      await host.call("execute", [
+        "silent! unlet g:__test_denops_ready_fired",
+        "silent! unlet g:__test_denops_closed_fired",
+        "silent! unlet g:__test_denops_process_started_fired",
+        "silent! unlet g:__test_denops_process_stopped_fired",
+      ], "");
+      outputs = [];
+
+      await forceShutdownServer();
+
+      await t.step("fires DenopsClosed", async () => {
+        await wait(() => host.call("exists", "g:__test_denops_closed_fired"));
+      });
+
+      await t.step("fires DenopsProcessStopped", async () => {
+        await wait(() =>
+          host.call("exists", "g:__test_denops_process_stopped_fired")
+        );
+      });
+
+      await t.step("changes status to 'stopped' asynchronously", async () => {
+        assertEquals(await host.call("denops#server#status"), "stopped");
+      });
+
+      await t.step("restart the server", async (t) => {
+        await t.step("fires DenopsProcessStarted", async () => {
+          await wait(() =>
+            host.call("exists", "g:__test_denops_process_started_fired")
+          );
+        });
+
+        await t.step("fires DenopsReady", async () => {
+          await wait(() => host.call("exists", "g:__test_denops_ready_fired"));
+        });
+
+        await t.step("changes status to 'running' asynchronously", async () => {
+          assertEquals(await host.call("denops#server#status"), "running");
+        });
+
+        await t.step("outputs warning message", () => {
+          assertMatch(
+            outputs.join(""),
+            /Server stopped \(-?[0-9]+\)\. Restarting\.\.\./,
+          );
+        });
+      });
+    });
+
+    await t.step("if restart count exceed", async (t) => {
+      await using stack = new AsyncDisposableStack();
+      stack.defer(async () => {
+        await host.call("denops#server#stop");
+        await wait(
+          () => host.call("eval", "denops#server#status() ==# 'stopped'"),
+        );
+        await host.call("execute", [
+          `let g:denops#disabled = 0`,
+        ], "");
+      });
+
+      await host.call("execute", [
+        "silent! unlet g:__test_denops_process_started_fired",
+        "let g:denops#server#restart_delay = 10",
+        "let g:denops#server#restart_interval = 30000",
+        "let g:denops#server#restart_threshold = 3",
+        "call denops#server#start()",
+      ], "");
+      outputs = [];
+
+      for (let i = 0; i < 4; i++) {
+        await wait(() =>
+          host.call("exists", "g:__test_denops_process_started_fired")
+        );
+        await host.call("execute", [
+          "unlet g:__test_denops_process_started_fired",
+        ], "");
+        await forceShutdownServer();
+      }
+
+      await t.step("changes `g:denops#disabled` to truthy", async () => {
+        await wait(() => host.call("eval", "g:denops#disabled"));
+      });
+
+      await t.step("changes status to 'stopped'", async () => {
+        await wait(() =>
+          host.call("eval", "denops#server#status() ==# 'stopped'")
+        );
+      });
+
+      await t.step("outputs warning message after delayed", async () => {
+        await delay(MESSAGE_DELAY);
+        assertMatch(
+          outputs.join(""),
+          /Server stopped 4 times within 30000 millisec/,
+        );
       });
     });
   },

--- a/tests/denops/server_test.ts
+++ b/tests/denops/server_test.ts
@@ -638,7 +638,37 @@ testHost({
 
     await host.call("execute", [
       "autocmd User DenopsReady let g:__test_denops_ready_fired = 1",
+      "autocmd User DenopsClosed let g:__test_denops_closed_fired = 1",
     ], "");
+
+    await t.step("if denops disabled", async (t) => {
+      await using stack = new AsyncDisposableStack();
+      stack.defer(async () => {
+        await host.call("execute", [
+          "let g:denops#disabled = 0",
+        ], "");
+      });
+
+      await host.call("execute", [
+        "let g:denops#disabled = 1",
+        "let g:__test_denops_server_connect_result = denops#server#connect()",
+        "let g:__test_denops_server_status_when_connect_called = denops#server#status()",
+      ], "");
+
+      await t.step("returns falsy", async () => {
+        assertFalse(
+          await host.call("eval", "g:__test_denops_server_connect_result"),
+        );
+      });
+
+      await t.step("does not change status from 'stopped'", async () => {
+        const actual = await host.call(
+          "eval",
+          "g:__test_denops_server_status_when_connect_called",
+        );
+        assertEquals(actual, "stopped");
+      });
+    });
 
     await t.step("if not yet connected", async (t) => {
       await t.step("if `g:denops_server_addr` is empty", async (t) => {
@@ -684,6 +714,13 @@ testHost({
             "Timeout",
           );
         });
+
+        await t.step(
+          "does not change `g:denops#disabled` from falsy",
+          async () => {
+            assertFalse(await host.call("eval", "g:denops#disabled"));
+          },
+        );
       });
 
       await t.step("if `g:denops_server_addr` is invalid", async (t) => {
@@ -696,8 +733,9 @@ testHost({
 
         await host.call("execute", [
           `let g:denops_server_addr = '${not_exists_address}'`,
-          "let g:denops#server#retry_interval = 10",
-          "let g:denops#server#retry_threshold = 1",
+          "let g:denops#server#reconnect_delay = 10",
+          "let g:denops#server#reconnect_interval = 30000",
+          "let g:denops#server#reconnect_threshold = 3",
           "silent! unlet g:__test_denops_ready_fired",
           "let g:__test_denops_server_connect_result = denops#server#connect()",
           "let g:__test_denops_server_status_when_connect_called = denops#server#status()",
@@ -736,6 +774,13 @@ testHost({
             "Timeout",
           );
         });
+
+        await t.step(
+          "does not change `g:denops#disabled` from falsy",
+          async () => {
+            assertFalse(await host.call("eval", "g:denops#disabled"));
+          },
+        );
       });
 
       await t.step("if `g:denops_server_addr` is valid", async (t) => {
@@ -881,6 +926,116 @@ testHost({
             ),
           Error,
           "Timeout",
+        );
+      });
+    });
+
+    await t.step("if the channel is closed unexpectedly", async (t) => {
+      await using stack = new AsyncDisposableStack();
+      const server = stack.use(await useSharedServer());
+      stack.defer(async () => {
+        await host.call("denops#server#close");
+        await wait(
+          () => host.call("eval", "denops#server#status() ==# 'stopped'"),
+        );
+      });
+
+      await host.call("execute", [
+        `let g:denops_server_addr = '${server.addr}'`,
+        "let g:denops#server#reconnect_delay = 1000",
+        "let g:denops#server#reconnect_interval = 1000",
+        "let g:denops#server#reconnect_threshold = 1",
+        "call denops#server#connect()",
+      ], "");
+      await wait(
+        () => host.call("eval", "denops#server#status() ==# 'running'"),
+      );
+      await host.call("execute", [
+        "silent! unlet g:__test_denops_closed_fired",
+      ], "");
+      outputs = [];
+
+      // Close the channel by stop the shared-server.
+      await server[Symbol.asyncDispose]();
+
+      await t.step("fires DenopsClosed", async () => {
+        await wait(() => host.call("exists", "g:__test_denops_closed_fired"));
+      });
+
+      await t.step("changes status to 'stopped' asynchronously", async () => {
+        assertEquals(await host.call("denops#server#status"), "stopped");
+      });
+
+      await t.step("reconnect to the server", async (t) => {
+        await host.call("execute", [
+          "silent! unlet g:__test_denops_ready_fired",
+        ], "");
+
+        // Start the shared-server with the same port number.
+        stack.use(await useSharedServer({ port: server.addr.port }));
+
+        await t.step("fires DenopsReady", async () => {
+          await wait(() => host.call("exists", "g:__test_denops_ready_fired"));
+        });
+
+        await t.step("changes status to 'running' asynchronously", async () => {
+          assertEquals(await host.call("denops#server#status"), "running");
+        });
+
+        await t.step("outputs warning message after delayed", async () => {
+          await delay(MESSAGE_DELAY);
+          assertMatch(
+            outputs.join(""),
+            /Channel closed\. Reconnecting\.\.\./,
+          );
+        });
+      });
+    });
+
+    await t.step("if reconnect count exceed", async (t) => {
+      await using stack = new AsyncDisposableStack();
+      const listener = stack.use(
+        Deno.listen({ hostname: "127.0.0.1", port: 0 }),
+      );
+      stack.defer(async () => {
+        await host.call("denops#server#close");
+        await wait(
+          () => host.call("eval", "denops#server#status() ==# 'stopped'"),
+        );
+        await host.call("execute", [
+          "let g:denops#disabled = 0",
+        ], "");
+      });
+
+      await host.call("execute", [
+        `let g:denops_server_addr = '127.0.0.1:${listener.addr.port}'`,
+        "let g:denops#server#reconnect_delay = 10",
+        "let g:denops#server#reconnect_interval = 30000",
+        "let g:denops#server#reconnect_threshold = 3",
+        "call denops#server#connect()",
+      ], "");
+      outputs = [];
+
+      // Close the channel from server side.
+      (async () => {
+        for await (const conn of listener) {
+          conn.close();
+        }
+      })();
+
+      await t.step("changes `g:denops#disabled` to truthy", async () => {
+        await wait(() => host.call("eval", "g:denops#disabled"));
+      });
+
+      await t.step("changes status to 'stopped'", async () => {
+        assertEquals(await host.call("denops#server#status"), "stopped");
+      });
+
+      await t.step("outputs warning message after delayed", async () => {
+        await delay(MESSAGE_DELAY);
+        assertMatch(
+          outputs.join(""),
+          /Channel closed 4 times within 30000 millisec/,
         );
       });
     });

--- a/tests/denops/server_test.ts
+++ b/tests/denops/server_test.ts
@@ -360,7 +360,7 @@ testHost({
         assertEquals(actual, "stopped");
       });
 
-      await t.step("outputs warning message", async () => {
+      await t.step("outputs warning message after delay", async () => {
         await delay(MESSAGE_DELAY);
         assertMatch(
           outputs.join(""),
@@ -430,7 +430,8 @@ testHost({
           assertEquals(await host.call("denops#server#status"), "running");
         });
 
-        await t.step("outputs warning message", () => {
+        await t.step("outputs warning message after delayed", async () => {
+          await delay(MESSAGE_DELAY);
           assertMatch(
             outputs.join(""),
             /Server stopped \(-?[0-9]+\)\. Restarting\.\.\./,
@@ -695,14 +696,6 @@ testHost({
           assertEquals(actual, "stopped");
         });
 
-        await t.step("outputs error message after delayed", async () => {
-          await delay(MESSAGE_DELAY);
-          assertMatch(
-            outputs.join(""),
-            /denops shared server address \(g:denops_server_addr\) is not given/,
-          );
-        });
-
         await t.step("does not fire DenopsReady", async () => {
           await assertRejects(
             () =>
@@ -721,6 +714,14 @@ testHost({
             assertFalse(await host.call("eval", "g:denops#disabled"));
           },
         );
+
+        await t.step("outputs error message after delayed", async () => {
+          await delay(MESSAGE_DELAY);
+          assertMatch(
+            outputs.join(""),
+            /denops shared server address \(g:denops_server_addr\) is not given/,
+          );
+        });
       });
 
       await t.step("if `g:denops_server_addr` is invalid", async (t) => {
@@ -755,14 +756,6 @@ testHost({
           assertEquals(actual, "stopped");
         });
 
-        await t.step("outputs warning message after delayed", async () => {
-          await delay(MESSAGE_DELAY);
-          assertMatch(
-            outputs.join(""),
-            /Failed to connect channel `127\.0\.0\.1:[0-9]+`:/,
-          );
-        });
-
         await t.step("does not fire DenopsReady", async () => {
           await assertRejects(
             () =>
@@ -781,6 +774,14 @@ testHost({
             assertFalse(await host.call("eval", "g:denops#disabled"));
           },
         );
+
+        await t.step("outputs warning message after delayed", async () => {
+          await delay(MESSAGE_DELAY);
+          assertMatch(
+            outputs.join(""),
+            /Failed to connect channel `127\.0\.0\.1:[0-9]+`:/,
+          );
+        });
       });
 
       await t.step("if `g:denops_server_addr` is valid", async (t) => {


### PR DESCRIPTION
## Problem

The behavior of restart and reconnection is inconsistent with the documentation.
There are `g:denops#server#retry_*`, `g:denops#server#restart_*` and `g:denops#server#reconnect_*` variables which can be confusing. 

- The `g:denops#server#retry_*` variables have never been documented.
- When `g:denops#server#restart_threshold=3` is set:
  - Expected: Restart will be attempted 3 times.
  - Actual: It will fail after 3 terminations (the first startup and 2 restarts).
- When `g:denops#server#reconnect_threshold=3` is set:
  - Expected: Reconnection will be attempted 3 times.
  - Actual: It will fail after 3 disconnections (the first startup and 2 reconnections). Then the connection will be attempted up to `retry_threshold` times, i.e. at most `(reconnect_threshold - 1) * retry_threshold` times.
- Missing document for `g:denops#server#reconnect_delay`.

## Fixes

- The `g:denops#server#retry_*` variables have been completely removed.
  - No longer used in `denops#server#start()` on #378.
  - Similarly, no longer used in `denops#server#connect()` on This PR.
- The `g:denops#server#restart_*` variables are used on first starting or restart.
  - If the initial starting fails threthold times in interval, `g:denops#disable=1` is set.
  - If the restart fails threthold times in interval, `g:denops#disable=1` is set.
- The `g:denops#server#reconnect_*` variables are used on first connecting or reconnect.
  - If the initial connecting fails threthold times in interval, does **NOT** set `g:denops#disable=1`.
  - If the reconnect fails threthold times in interval, `g:denops#disable=1` is set.
  - `denops#server#connect()` will asynchronously retry the initial connection. Do not block Vim startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `denops#server#connect_or_start()` to handle server connections and startups.
  - Introduced `mode` property to `HostFn` and `TestFn` types for better configuration in test utilities.
  - Enhanced `useSharedServer` function to support `port` configuration.
  - Added new function `forceShutdownServer()` for robust server handling in tests.

- **Improvements**
  - Enhanced error handling and reconnect logic for server connections.
  - Refined descriptions and configurations for server-related variables in documentation.
  - Improved initialization logic for the `denops.vim` plugin.
  - Refined server shutdown and restart logic in tests.

- **Bug Fixes**
  - Fixed issues with server restart and reconnect behaviors to ensure robust performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->