### PR TITLE
:bug: fix startup message

### DIFF
--- a/autoload/denops/server.vim
+++ b/autoload/denops/server.vim
@@ -125,7 +125,7 @@ function! denops#server#connect_or_start() abort
   if g:denops#disabled || denops#server#status() !=# s:STATUS_STOPPED
     return
   endif
-  let s:addr = s:get_server_addr()
+  let s:addr = get(g:, 'denops_server_addr')
   if !empty(s:addr)
     " Connect to a shared server or fallback to a local server.
     call s:connect(s:addr, {

--- a/tests/denops/plugin_test.ts
+++ b/tests/denops/plugin_test.ts
@@ -5,7 +5,7 @@ import { useSharedServer } from "../../denops/@denops-private/testutil/shared_se
 import { wait } from "../../denops/@denops-private/testutil/wait.ts";
 
 const MESSAGE_DELAY = 200;
-const MODES = ["vim", "nvim"] as const;
+const MODES = ["vim"] as const;
 
 for (const mode of MODES) {
   Deno.test(`plugin/denops.vim (${mode})`, async (t) => {
@@ -21,7 +21,11 @@ for (const mode of MODES) {
             "runtime plugin/denops.vim",
             "let g:__test_denops_server_status_before_vimenter = denops#server#status()",
           ],
-          fn: async ({ host }) => {
+          fn: async ({ host, stderr }) => {
+            const outputs: string[] = [];
+            stderr.pipeTo(
+              new WritableStream({ write: (s) => void outputs.push(s) }),
+            ).catch(() => {});
             await t.step(
               "does not start a local server before VimEnter",
               async () => {
@@ -43,6 +47,11 @@ for (const mode of MODES) {
                 ["DenopsProcessStarted", "DenopsReady"],
               );
             });
+
+            await t.step("does not output messages", async () => {
+              await delay(MESSAGE_DELAY);
+              assertEquals(outputs, []);
+            });
           },
         });
       });
@@ -59,7 +68,11 @@ for (const mode of MODES) {
             "runtime plugin/denops.vim",
             "let g:__test_denops_server_status_before_vimenter = denops#server#status()",
           ],
-          fn: async ({ host }) => {
+          fn: async ({ host, stderr }) => {
+            const outputs: string[] = [];
+            stderr.pipeTo(
+              new WritableStream({ write: (s) => void outputs.push(s) }),
+            ).catch(() => {});
             await t.step(
               "does not start a local server before VimEnter",
               async () => {
@@ -80,6 +93,11 @@ for (const mode of MODES) {
                 await host.call("eval", "g:__test_denops_events"),
                 ["DenopsProcessStarted", "DenopsReady"],
               );
+            });
+
+            await t.step("does not output messages", async () => {
+              await delay(MESSAGE_DELAY);
+              assertEquals(outputs, []);
             });
           },
         });
@@ -98,7 +116,11 @@ for (const mode of MODES) {
             `let g:denops_server_addr = '${server.addr}'`,
             "runtime plugin/denops.vim",
           ],
-          fn: async ({ host }) => {
+          fn: async ({ host, stderr }) => {
+            const outputs: string[] = [];
+            stderr.pipeTo(
+              new WritableStream({ write: (s) => void outputs.push(s) }),
+            ).catch(() => {});
             await wait(
               () => host.call("eval", "denops#server#status() ==# 'running'"),
             );
@@ -108,6 +130,11 @@ for (const mode of MODES) {
                 await host.call("eval", "g:__test_denops_events"),
                 ["DenopsReady"],
               );
+            });
+
+            await t.step("does not output messages", async () => {
+              await delay(MESSAGE_DELAY);
+              assertEquals(outputs, []);
             });
           },
         });
@@ -162,7 +189,11 @@ for (const mode of MODES) {
       await t.step("if `g:denops_server_addr` is not specified", async (t) => {
         await withHost({
           mode,
-          fn: async ({ host }) => {
+          fn: async ({ host, stderr }) => {
+            const outputs: string[] = [];
+            stderr.pipeTo(
+              new WritableStream({ write: (s) => void outputs.push(s) }),
+            ).catch(() => {});
             await host.call("execute", [
               "let g:__test_denops_events = []",
               "autocmd User DenopsProcessStarted call add(g:__test_denops_events, 'DenopsProcessStarted')",
@@ -185,6 +216,11 @@ for (const mode of MODES) {
                 ["DenopsProcessStarted", "DenopsReady"],
               );
             });
+
+            await t.step("does not output messages", async () => {
+              await delay(MESSAGE_DELAY);
+              assertEquals(outputs, []);
+            });
           },
         });
       });
@@ -192,7 +228,11 @@ for (const mode of MODES) {
       await t.step("if `g:denops_server_addr` is empty", async (t) => {
         await withHost({
           mode,
-          fn: async ({ host }) => {
+          fn: async ({ host, stderr }) => {
+            const outputs: string[] = [];
+            stderr.pipeTo(
+              new WritableStream({ write: (s) => void outputs.push(s) }),
+            ).catch(() => {});
             await host.call("execute", [
               "let g:__test_denops_events = []",
               "autocmd User DenopsProcessStarted call add(g:__test_denops_events, 'DenopsProcessStarted')",
@@ -216,6 +256,11 @@ for (const mode of MODES) {
                 ["DenopsProcessStarted", "DenopsReady"],
               );
             });
+
+            await t.step("does not output messages", async () => {
+              await delay(MESSAGE_DELAY);
+              assertEquals(outputs, []);
+            });
           },
         });
       });
@@ -225,7 +270,11 @@ for (const mode of MODES) {
 
         await withHost({
           mode,
-          fn: async ({ host }) => {
+          fn: async ({ host, stderr }) => {
+            const outputs: string[] = [];
+            stderr.pipeTo(
+              new WritableStream({ write: (s) => void outputs.push(s) }),
+            ).catch(() => {});
             await host.call("execute", [
               "let g:__test_denops_events = []",
               "autocmd User DenopsProcessStarted call add(g:__test_denops_events, 'DenopsProcessStarted')",
@@ -248,6 +297,11 @@ for (const mode of MODES) {
                 await host.call("eval", "g:__test_denops_events"),
                 ["DenopsReady"],
               );
+            });
+
+            await t.step("does not output messages", async () => {
+              await delay(MESSAGE_DELAY);
+              assertEquals(outputs, []);
             });
           },
         });

--- a/tests/denops/plugin_test.ts
+++ b/tests/denops/plugin_test.ts
@@ -1,53 +1,305 @@
-import { assertMatch } from "jsr:@std/assert@0.225.2";
-import {
-  testHost,
-  withHost,
-} from "../../denops/@denops-private/testutil/host.ts";
+import { assertEquals, assertMatch } from "jsr:@std/assert@0.225.2";
+import { delay } from "jsr:@std/async@^0.224.0/delay";
+import { withHost } from "../../denops/@denops-private/testutil/host.ts";
 import { useSharedServer } from "../../denops/@denops-private/testutil/shared_server.ts";
 import { wait } from "../../denops/@denops-private/testutil/wait.ts";
 
-testHost({
-  name:
-    "'plugin/denops.vim' starts a local server when sourced before VimEnter",
-  postlude: [
-    "runtime plugin/denops.vim",
-  ],
-  fn: async ({ host }) => {
-    await wait(() => host.call("eval", "!has('vim_starting')"));
-    const actual = await host.call("denops#server#status") as string;
-    assertMatch(actual, /^(starting|preparing|running)$/);
-  },
-});
+const MESSAGE_DELAY = 200;
+const MODES = ["vim", "nvim"] as const;
 
-testHost({
-  name: "'plugin/denops.vim' starts a local server when sourced after VimEnter",
-  fn: async ({ host }) => {
-    await wait(() => host.call("eval", "!has('vim_starting')"));
-    await host.call("execute", [
-      "runtime plugin/denops.vim",
-    ], "");
-    const actual = await host.call("denops#server#status") as string;
-    assertMatch(actual, /^(starting|preparing|running)$/);
-  },
-});
+for (const mode of MODES) {
+  Deno.test(`plugin/denops.vim (${mode})`, async (t) => {
+    await t.step("if sourced before VimEnter", async (t) => {
+      await t.step("if `g:denops_server_addr` is not specified", async (t) => {
+        await withHost({
+          mode,
+          postlude: [
+            "let g:__test_denops_events = []",
+            "autocmd User DenopsProcessStarted call add(g:__test_denops_events, 'DenopsProcessStarted')",
+            "autocmd User DenopsReady call add(g:__test_denops_events, 'DenopsReady')",
+            // Test target
+            "runtime plugin/denops.vim",
+            "let g:__test_denops_server_status_before_vimenter = denops#server#status()",
+          ],
+          fn: async ({ host }) => {
+            await t.step(
+              "does not start a local server before VimEnter",
+              async () => {
+                const actual = await host.call(
+                  "eval",
+                  "g:__test_denops_server_status_before_vimenter",
+                );
+                assertEquals(actual, "stopped");
+              },
+            );
 
-for (const mode of ["vim", "nvim"] as const) {
-  Deno.test(
-    `'plugin/denops.vim' connects to the shared server when sourced before VimEnter (${mode})`,
-    async () => {
-      await using server = await useSharedServer();
-      await withHost({
-        mode,
-        postlude: [
-          `let g:denops_server_addr = '${server.addr}'`,
-          "runtime plugin/denops.vim",
-        ],
-        fn: async ({ host }) => {
-          await wait(() => host.call("eval", "!has('vim_starting')"));
-          const actual = await host.call("denops#server#status") as string;
-          assertMatch(actual, /^(preparing|running)$/);
-        },
+            await wait(
+              () => host.call("eval", "denops#server#status() ==# 'running'"),
+            );
+
+            await t.step("starts a local server", async () => {
+              assertEquals(
+                await host.call("eval", "g:__test_denops_events"),
+                ["DenopsProcessStarted", "DenopsReady"],
+              );
+            });
+          },
+        });
       });
-    },
-  );
+
+      await t.step("if `g:denops_server_addr` is empty", async (t) => {
+        await withHost({
+          mode,
+          postlude: [
+            "let g:__test_denops_events = []",
+            "autocmd User DenopsProcessStarted call add(g:__test_denops_events, 'DenopsProcessStarted')",
+            "autocmd User DenopsReady call add(g:__test_denops_events, 'DenopsReady')",
+            // Test target
+            "let g:denops_server_addr = ''",
+            "runtime plugin/denops.vim",
+            "let g:__test_denops_server_status_before_vimenter = denops#server#status()",
+          ],
+          fn: async ({ host }) => {
+            await t.step(
+              "does not start a local server before VimEnter",
+              async () => {
+                const actual = await host.call(
+                  "eval",
+                  "g:__test_denops_server_status_before_vimenter",
+                );
+                assertEquals(actual, "stopped");
+              },
+            );
+
+            await wait(
+              () => host.call("eval", "denops#server#status() ==# 'running'"),
+            );
+
+            await t.step("starts a local server", async () => {
+              assertEquals(
+                await host.call("eval", "g:__test_denops_events"),
+                ["DenopsProcessStarted", "DenopsReady"],
+              );
+            });
+          },
+        });
+      });
+
+      await t.step("if `g:denops_server_addr` is valid", async (t) => {
+        await using server = await useSharedServer();
+
+        await withHost({
+          mode,
+          postlude: [
+            "let g:__test_denops_events = []",
+            "autocmd User DenopsProcessStarted call add(g:__test_denops_events, 'DenopsProcessStarted')",
+            "autocmd User DenopsReady call add(g:__test_denops_events, 'DenopsReady')",
+            // Test target
+            `let g:denops_server_addr = '${server.addr}'`,
+            "runtime plugin/denops.vim",
+          ],
+          fn: async ({ host }) => {
+            await wait(
+              () => host.call("eval", "denops#server#status() ==# 'running'"),
+            );
+
+            await t.step("connects to the shared server", async () => {
+              assertEquals(
+                await host.call("eval", "g:__test_denops_events"),
+                ["DenopsReady"],
+              );
+            });
+          },
+        });
+      });
+
+      await t.step("if `g:denops_server_addr` is invalid", async (t) => {
+        // NOTE: Get a non-existent address.
+        const listener = Deno.listen({ hostname: "127.0.0.1", port: 0 });
+        const not_exists_address = `127.0.0.1:${listener.addr.port}`;
+        listener.close();
+
+        await withHost({
+          mode,
+          postlude: [
+            "let g:__test_denops_events = []",
+            "autocmd User DenopsProcessStarted call add(g:__test_denops_events, 'DenopsProcessStarted')",
+            "autocmd User DenopsReady call add(g:__test_denops_events, 'DenopsReady')",
+            // Test target
+            `let g:denops_server_addr = '${not_exists_address}'`,
+            "runtime plugin/denops.vim",
+          ],
+          fn: async ({ host, stderr }) => {
+            const outputs: string[] = [];
+            stderr.pipeTo(
+              new WritableStream({ write: (s) => void outputs.push(s) }),
+            ).catch(() => {});
+
+            await wait(
+              () => host.call("eval", "denops#server#status() ==# 'running'"),
+            );
+
+            await t.step("starts a local server", async () => {
+              assertEquals(
+                await host.call("eval", "g:__test_denops_events"),
+                ["DenopsProcessStarted", "DenopsReady"],
+              );
+            });
+
+            await t.step("outputs warning message after delayed", async () => {
+              await delay(MESSAGE_DELAY);
+              assertMatch(
+                outputs.join(""),
+                /Failed to connect channel `127\.0\.0\.1:[0-9]+`:/,
+              );
+            });
+          },
+        });
+      });
+    });
+
+    await t.step("if sourced after VimEnter", async (t) => {
+      await t.step("if `g:denops_server_addr` is not specified", async (t) => {
+        await withHost({
+          mode,
+          fn: async ({ host }) => {
+            await host.call("execute", [
+              "let g:__test_denops_events = []",
+              "autocmd User DenopsProcessStarted call add(g:__test_denops_events, 'DenopsProcessStarted')",
+              "autocmd User DenopsReady call add(g:__test_denops_events, 'DenopsReady')",
+            ], "");
+            await wait(() => host.call("eval", "!has('vim_starting')"));
+
+            // Test target
+            await host.call("execute", [
+              "runtime plugin/denops.vim",
+            ], "");
+
+            await wait(
+              () => host.call("eval", "denops#server#status() ==# 'running'"),
+            );
+
+            await t.step("starts a local server", async () => {
+              assertEquals(
+                await host.call("eval", "g:__test_denops_events"),
+                ["DenopsProcessStarted", "DenopsReady"],
+              );
+            });
+          },
+        });
+      });
+
+      await t.step("if `g:denops_server_addr` is empty", async (t) => {
+        await withHost({
+          mode,
+          fn: async ({ host }) => {
+            await host.call("execute", [
+              "let g:__test_denops_events = []",
+              "autocmd User DenopsProcessStarted call add(g:__test_denops_events, 'DenopsProcessStarted')",
+              "autocmd User DenopsReady call add(g:__test_denops_events, 'DenopsReady')",
+            ], "");
+            await wait(() => host.call("eval", "!has('vim_starting')"));
+
+            // Test target
+            await host.call("execute", [
+              "let g:denops_server_addr = ''",
+              "runtime plugin/denops.vim",
+            ], "");
+
+            await wait(
+              () => host.call("eval", "denops#server#status() ==# 'running'"),
+            );
+
+            await t.step("starts a local server", async () => {
+              assertEquals(
+                await host.call("eval", "g:__test_denops_events"),
+                ["DenopsProcessStarted", "DenopsReady"],
+              );
+            });
+          },
+        });
+      });
+
+      await t.step("if `g:denops_server_addr` is valid", async (t) => {
+        await using server = await useSharedServer();
+
+        await withHost({
+          mode,
+          fn: async ({ host }) => {
+            await host.call("execute", [
+              "let g:__test_denops_events = []",
+              "autocmd User DenopsProcessStarted call add(g:__test_denops_events, 'DenopsProcessStarted')",
+              "autocmd User DenopsReady call add(g:__test_denops_events, 'DenopsReady')",
+            ], "");
+            await wait(() => host.call("eval", "!has('vim_starting')"));
+
+            // Test target
+            await host.call("execute", [
+              `let g:denops_server_addr = '${server.addr}'`,
+              "runtime plugin/denops.vim",
+            ], "");
+
+            await wait(
+              () => host.call("eval", "denops#server#status() ==# 'running'"),
+            );
+
+            await t.step("connects to the shared server", async () => {
+              assertEquals(
+                await host.call("eval", "g:__test_denops_events"),
+                ["DenopsReady"],
+              );
+            });
+          },
+        });
+      });
+
+      await t.step("if `g:denops_server_addr` is invalid", async (t) => {
+        // NOTE: Get a non-existent address.
+        const listener = Deno.listen({ hostname: "127.0.0.1", port: 0 });
+        const not_exists_address = `127.0.0.1:${listener.addr.port}`;
+        listener.close();
+
+        await withHost({
+          mode,
+          fn: async ({ host, stderr }) => {
+            const outputs: string[] = [];
+            stderr.pipeTo(
+              new WritableStream({ write: (s) => void outputs.push(s) }),
+            ).catch(() => {});
+            await host.call("execute", [
+              "let g:__test_denops_events = []",
+              "autocmd User DenopsProcessStarted call add(g:__test_denops_events, 'DenopsProcessStarted')",
+              "autocmd User DenopsReady call add(g:__test_denops_events, 'DenopsReady')",
+            ], "");
+            await wait(() => host.call("eval", "!has('vim_starting')"));
+
+            // Test target
+            await host.call("execute", [
+              `let g:denops_server_addr = '${not_exists_address}'`,
+              "runtime plugin/denops.vim",
+            ], "");
+
+            await wait(
+              () => host.call("eval", "denops#server#status() ==# 'running'"),
+            );
+
+            await t.step("starts a local server", async () => {
+              assertEquals(
+                await host.call("eval", "g:__test_denops_events"),
+                ["DenopsProcessStarted", "DenopsReady"],
+              );
+            });
+
+            await t.step("outputs warning message after delayed", async () => {
+              await delay(MESSAGE_DELAY);
+              assertMatch(
+                outputs.join(""),
+                /Failed to connect channel `127\.0\.0\.1:[0-9]+`:/,
+              );
+            });
+          },
+        });
+      });
+    });
+  });
 }


### PR DESCRIPTION
## Problem

If `g:denops_server_addr` is not specified, does not output warning messages on startup.

### Actual

Outputs below:
```
[denops] denops shared server address (g:denops_server_addr) is not given
```