### PR TITLE
:+1: add plugin unload feature

### DIFF
--- a/autoload/denops/plugin.vim
+++ b/autoload/denops/plugin.vim
@@ -53,6 +53,10 @@ function! denops#plugin#load(name, script) abort
   call denops#_internal#plugin#load(a:name, a:script)
 endfunction
 
+function! denops#plugin#unload(name) abort
+  call denops#_internal#plugin#unload(a:name)
+endfunction
+
 function! denops#plugin#reload(name) abort
   call denops#_internal#plugin#reload(a:name)
 endfunction

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,6 +7,12 @@
     "update": "deno run --allow-env --allow-read --allow-write=. --allow-run=git,deno --allow-net=jsr.io,registry.npmjs.org jsr:@molt/cli **/*.ts",
     "update:commit": "deno task -q update --commit --pre-commit=fmt,lint"
   },
+  "test": {
+    "exclude": [
+      // TODO: #349 Update `Entrypoint` in denops-core, and remove this entry.
+      "denops/@denops-private/plugin.ts"
+    ]
+  },
   "exclude": [
     ".coverage/"
   ],

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,7 +3,7 @@
     "check": "deno check **/*.ts",
     "test": "LANG=C deno test -A --parallel --shuffle --doc",
     "test:coverage": "deno task test --coverage=.coverage",
-    "coverage": "deno coverage .coverage",
+    "coverage": "deno coverage --exclude=\"test[.]ts(#.*)?$\" .coverage",
     "update": "deno run --allow-env --allow-read --allow-write=. --allow-run=git,deno --allow-net=jsr.io,registry.npmjs.org jsr:@molt/cli **/*.ts",
     "update:commit": "deno task -q update --commit --pre-commit=fmt,lint"
   },

--- a/denops/@denops-private/host.ts
+++ b/denops/@denops-private/host.ts
@@ -49,6 +49,7 @@ export type CallbackId = string;
 export type Service = {
   bind(host: Host): void;
   load(name: string, script: string): Promise<void>;
+  unload(name: string): Promise<void>;
   reload(name: string): Promise<void>;
   interrupt(reason?: unknown): void;
   dispatch(name: string, fn: string, args: unknown[]): Promise<unknown>;
@@ -72,6 +73,8 @@ export function invoke(
   switch (name) {
     case "load":
       return service.load(...ensure(args, serviceMethodArgs.load));
+    case "unload":
+      return service.unload(...ensure(args, serviceMethodArgs.unload));
     case "reload":
       return service.reload(...ensure(args, serviceMethodArgs.reload));
     case "interrupt":
@@ -92,6 +95,7 @@ export function invoke(
 
 const serviceMethodArgs = {
   load: is.ParametersOf([is.String, is.String] as const),
+  unload: is.ParametersOf([is.String] as const),
   reload: is.ParametersOf([is.String] as const),
   interrupt: is.ParametersOf([is.OptionalOf(is.Unknown)] as const),
   dispatch: is.ParametersOf([is.String, is.String, is.Array] as const),

--- a/denops/@denops-private/host/nvim_test.ts
+++ b/denops/@denops-private/host/nvim_test.ts
@@ -23,6 +23,7 @@ Deno.test("Neovim", async (t) => {
       const service: Service = {
         bind: () => unimplemented(),
         load: () => unimplemented(),
+        unload: () => unimplemented(),
         reload: () => unimplemented(),
         interrupt: () => unimplemented(),
         dispatch: () => unimplemented(),

--- a/denops/@denops-private/host/vim_test.ts
+++ b/denops/@denops-private/host/vim_test.ts
@@ -18,6 +18,7 @@ Deno.test("Vim", async (t) => {
       const service: Service = {
         bind: () => unimplemented(),
         load: () => unimplemented(),
+        unload: () => unimplemented(),
         reload: () => unimplemented(),
         interrupt: () => unimplemented(),
         dispatch: () => unimplemented(),

--- a/denops/@denops-private/host_test.ts
+++ b/denops/@denops-private/host_test.ts
@@ -11,6 +11,7 @@ import { invoke, type Service } from "./host.ts";
 Deno.test("invoke", async (t) => {
   const service: Omit<Service, "bind"> = {
     load: () => unimplemented(),
+    unload: () => unimplemented(),
     reload: () => unimplemented(),
     interrupt: () => unimplemented(),
     dispatch: () => unimplemented(),

--- a/denops/@denops-private/plugin.ts
+++ b/denops/@denops-private/plugin.ts
@@ -1,0 +1,35 @@
+// TODO: #349 Update `Entrypoint` in denops-core, remove this module from `$.test.exclude` in `deno.jsonc`, and remove this module.
+import type { Denops } from "jsr:@denops/core@6.1.0";
+
+/**
+ * Denops's entrypoint definition.
+ *
+ * Use this type to ensure the `main` function is properly implemented like:
+ *
+ * ```ts
+ * import type { Entrypoint } from "jsr:@denops/core";
+ *
+ * export const main: Entrypoint = (denops) => {
+ *   // ...
+ * }
+ * ```
+ *
+ * If an `AsyncDisposable` object is returned, resources can be disposed of
+ * asynchronously when the plugin is unloaded, like:
+ *
+ * ```ts
+ * import type { Entrypoint } from "jsr:@denops/core";
+ *
+ * export const main: Entrypoint = (denops) => {
+ *   // ...
+ *   return {
+ *     [Symbol.asyncDispose]: () => {
+ *       // Dispose resources...
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export type Entrypoint = (
+  denops: Denops,
+) => void | AsyncDisposable | Promise<void | AsyncDisposable>;

--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -73,6 +73,9 @@ export class Service implements HostService, AsyncDisposable {
       }
       return;
     }
+    this.#waiters.get(name)?.promise.finally(() => {
+      this.#waiters.delete(name);
+    });
     this.#plugins.delete(name);
     await plugin.unload();
     return plugin;

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -409,14 +409,37 @@ denops#plugin#discover()
 denops#plugin#load({name}, {script})
 	Loads a denops plugin. Use this function to load denops plugins that
 	are not discovered by |denops#plugin#discover()|.
-	It invokes |User| |DenopsPluginPre|:{plugin} just before denops
-	executes a "main" function of the plugin and |User|
-	|DenopsPluginPost|:{plugin} just after denops executes a "main"
-	function of the plugin.
+
+	Loading a plugin involves the following event steps:
+
+	 - |User| |DenopsPluginPre|:{plugin} is fired.
+	 - The plugin is loaded and the "main" function is executed.
+	 - If it succeeds, |User| |DenopsPluginPost|:{plugin} is fired.
+	 - If it fails, |User| |DenopsPluginFail|:{plugin} is fired.
+
+						*denops#plugin#unload()*
+denops#plugin#unload({name})
+	Unloads a denops plugin. It does nothing when the plugin is not loaded
+	yet.
+
+	Unloading a plugin involves the following event steps:
+
+	 - |User| |DenopsPluginUnloadPre|:{plugin} is fired.
+	 - The plugin's dispose callback is executed, if it exists.
+	 - If it succeeds, |User| |DenopsPluginUnloadPost|:{plugin} is fired.
+	 - If it fails, |User| |DenopsPluginUnloadFail|:{plugin} is fired.
+
+	The above events may not be fired if the connection is forcibly
+	closed or the denops server is forcibly terminated due to timeout
+	or other reasons. Plugins should also use the |DenopsClosed| event.
 
 						*denops#plugin#reload()*
-denops#plugin#reload({name})
-	Reloads a denops plugin.
+denops#plugin#reload({plugin}[, {options}])
+	Reloads a denops plugin. It does nothing when the plugin is not loaded
+	yet.
+
+	It invokes |User| autocommand events. See |denops#plugin#load()| and
+	|denops#plugin#unload()| for details.
 
 						*denops#plugin#check_type()*
 denops#plugin#check_type([{name}])
@@ -482,6 +505,24 @@ DenopsPluginPre:{plugin}				*DenopsPluginPre*
 
 DenopsPluginPost:{plugin}				*DenopsPluginPost*
 	Fired after the "main" function of each plugin is called.
+	{plugin} is the name of the target plugin.
+        Note that if the "main" function throws an error, it will not be fired.
+
+DenopsPluginFail:{plugin}				*DenopsPluginFail*
+	Fired when the "main" function of each plugin throws an error.
+	{plugin} is the name of the target plugin.
+
+DenopsPluginUnloadPre:{plugin}				*DenopsPluginUnloadPre*
+	Fired before each plugin is unloaded.
+	{plugin} is the name of the target plugin.
+
+DenopsPluginUnloadPost:{plugin}				*DenopsPluginUnloadPost*
+	Fired after each plugin is unloaded.
+	{plugin} is the name of the target plugin.
+        Note that if an error is thrown when unloading, it will not be fired.
+
+DenopsPluginUnloadFail:{plugin}				*DenopsPluginUnloadFail*
+	Fired if an error is thrown when unloading each plugin.
 	{plugin} is the name of the target plugin.
 
 DenopsProcessStarted					*DenopsProcessStarted*

--- a/plugin/denops.vim
+++ b/plugin/denops.vim
@@ -22,6 +22,9 @@ augroup denops_plugin_internal
   autocmd User DenopsPluginPre:* :
   autocmd User DenopsPluginPost:* :
   autocmd User DenopsPluginFail:* :
+  autocmd User DenopsPluginUnloadPre:* :
+  autocmd User DenopsPluginUnloadPost:* :
+  autocmd User DenopsPluginUnloadFail:* :
   autocmd User DenopsReady call denops#plugin#discover()
 augroup END
 

--- a/plugin/denops/debug.vim
+++ b/plugin/denops/debug.vim
@@ -9,6 +9,8 @@ augroup denops_debug_plugin_internal
         \  call denops#_internal#echo#debug(expand('<amatch>:t'))
   autocmd User DenopsStarted,DenopsListen:*,DenopsStopped:*
         \  call denops#_internal#echo#debug(expand('<amatch>:t'))
-  autocmd User DenopsPluginPre:*,DenopsPluginPost:*
+  autocmd User DenopsPluginPre:*,DenopsPluginPost:*,DenopsPluginFail:*
+        \  call denops#_internal#echo#debug(expand('<amatch>:t'))
+  autocmd User DenopsPluginUnloadPre:*,DenopsPluginUnloadPost:*,DenopsPluginUnloadFail:*
         \  call denops#_internal#echo#debug(expand('<amatch>:t'))
 augroup END

--- a/tests/denops/testdata/dummy_invalid_dispose_plugin.ts
+++ b/tests/denops/testdata/dummy_invalid_dispose_plugin.ts
@@ -1,0 +1,11 @@
+// TODO: #349 Import `Entrypoint` from denops-core.
+// import type { Entrypoint } from "jsr:@denops/core@7.0.0";
+import type { Entrypoint } from "/denops-private/plugin.ts";
+
+export const main: Entrypoint = (_denops) => {
+  return {
+    [Symbol.asyncDispose]: () => {
+      throw new Error("This is dummy error in async dispose");
+    },
+  };
+};

--- a/tests/denops/testdata/dummy_valid_dispose_plugin.ts
+++ b/tests/denops/testdata/dummy_valid_dispose_plugin.ts
@@ -1,0 +1,11 @@
+// TODO: #349 Import `Entrypoint` from denops-core.
+// import type { Entrypoint } from "jsr:@denops/core@7.0.0";
+import type { Entrypoint } from "/denops-private/plugin.ts";
+
+export const main: Entrypoint = (denops) => {
+  return {
+    [Symbol.asyncDispose]: async () => {
+      await denops.cmd("echo 'Goodbye, Denops!'");
+    },
+  };
+};


### PR DESCRIPTION
Refs #349, https://github.com/vim-denops/deno-denops-core/pull/8

Plugin API:

- `Entrypoint` can now return `AsyncDisposable`.
  - It is called by `denops#plugin#unload()`.
  - It is called when the server closing.
    - When `denops#server#close()` is called.
    - When `denops#server#stop()` is called.
    - When the channel is closed.
    - When the server process trapped `SIGINT`.

Vim API:

- Add new `denops-function`:
  - `denops#plugin#unload({plugin})`
- Add new events:
  - `DenopsPluginUnloadPre:{plugin}`
  - `DenopsPluginUnloadPost:{plugin}`
  - `DenopsPluginUnloadFail:{plugin}`

### Additional

Added tests for script rewrite reload, note that this breaks `deno test --watch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced plugin unloading functionality, enabling better plugin management.
  - Added events for pre and post plugin unloading, enhancing control over plugin lifecycle.
  - Introduced error handling events for plugin operations.
- **Bug Fixes**
  - Improved handling of plugin loading and unloading errors.
- **Documentation**
  - Updated documentation to reflect new plugin unloading and event handling features.
- **Tests**
  - Added comprehensive tests for plugin unloading and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->