### PR TITLE
:bug: fix unload feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,10 @@ jobs:
         run: deno task check
 
   test:
+    needs: check
+
     strategy:
+      fail-fast: false
       matrix:
         runner:
           - windows-latest

--- a/autoload/denops/_internal/echo.vim
+++ b/autoload/denops/_internal/echo.vim
@@ -56,5 +56,7 @@ function! s:echomsg_batch() abort
   let s:delayed_timer = 0
   let s:delayed_messages = []
   " Forcibly show the messages to the user
-  call feedkeys(printf("\<Cmd>%dmessages\<CR>", l:counter), 'n')
+  if l:counter > 1 && !g:denops#_test
+    call feedkeys(printf("\<Cmd>%dmessages\<CR>", l:counter), 'n')
+  endif
 endfunction

--- a/autoload/denops/_internal/plugin.vim
+++ b/autoload/denops/_internal/plugin.vim
@@ -21,17 +21,22 @@ function! denops#_internal#plugin#load(name, script) abort
   const l:script = denops#_internal#path#norm(a:script)
   const l:args = [a:name, l:script]
   let l:plugin = denops#_internal#plugin#get(a:name)
+  if l:plugin.state !=# s:STATE_RESERVED && l:plugin.state !=# s:STATE_FAILED
+    call denops#_internal#echo#debug(printf('already loaded. skip: %s', l:args))
+    return
+  endif
   let l:plugin.state = s:STATE_LOADING
   let l:plugin.script = l:script
-  let s:plugins[a:name] = l:plugin
   call denops#_internal#echo#debug(printf('load plugin: %s', l:args))
   call denops#_internal#server#chan#notify('invoke', ['load', l:args])
 endfunction
 
 function! denops#_internal#plugin#unload(name) abort
-  let l:args = [a:name]
+  const l:args = [a:name]
   let l:plugin = denops#_internal#plugin#get(a:name)
-  let l:plugin.state = s:STATE_UNLOADING
+  if l:plugin.state ==# s:STATE_LOADED
+    let l:plugin.state = s:STATE_UNLOADING
+  endif
   call denops#_internal#echo#debug(printf('unload plugin: %s', l:args))
   call denops#_internal#server#chan#notify('invoke', ['unload', l:args])
 endfunction
@@ -39,13 +44,17 @@ endfunction
 function! denops#_internal#plugin#reload(name) abort
   const l:args = [a:name]
   let l:plugin = denops#_internal#plugin#get(a:name)
-  let l:plugin.state = s:STATE_LOADING
+  if l:plugin.state ==# s:STATE_LOADED
+    let l:plugin.state = s:STATE_UNLOADING
+  endif
   call denops#_internal#echo#debug(printf('reload plugin: %s', l:args))
   call denops#_internal#server#chan#notify('invoke', ['reload', l:args])
 endfunction
 
 function! s:DenopsSystemPluginPre() abort
   const l:name = matchstr(expand('<amatch>'), 'DenopsSystemPluginPre:\zs.*')
+  let l:plugin = denops#_internal#plugin#get(l:name)
+  let l:plugin.state = s:STATE_LOADING
   execute printf('doautocmd <nomodeline> User DenopsPluginPre:%s', l:name)
 endfunction
 
@@ -87,7 +96,7 @@ endfunction
 function! s:DenopsSystemPluginUnloadFail() abort
   const l:name = matchstr(expand('<amatch>'), 'DenopsSystemPluginUnloadFail:\zs.*')
   let l:plugin = denops#_internal#plugin#get(l:name)
-  let l:plugin.state = s:STATE_FAILED
+  let l:plugin.state = s:STATE_RESERVED
   let l:plugin.callbacks = []
   execute printf('doautocmd <nomodeline> User DenopsPluginUnloadFail:%s', l:name)
 endfunction

--- a/autoload/denops/_internal/plugin.vim
+++ b/autoload/denops/_internal/plugin.vim
@@ -89,7 +89,6 @@ function! s:DenopsSystemPluginUnloadPost() abort
   const l:name = matchstr(expand('<amatch>'), 'DenopsSystemPluginUnloadPost:\zs.*')
   let l:plugin = denops#_internal#plugin#get(l:name)
   let l:plugin.state = s:STATE_RESERVED
-  let l:plugin.callbacks = []
   execute printf('doautocmd <nomodeline> User DenopsPluginUnloadPost:%s', l:name)
 endfunction
 

--- a/doc/denops.txt
+++ b/doc/denops.txt
@@ -345,17 +345,23 @@ denops#server#wait_async({callback})
 
 						*denops#plugin#is_loaded()*
 denops#plugin#is_loaded({name})
-	Returns 1 if a {name} plugin is already loaded. Otherwise, returns
-	0.
+	Returns 1 if a {name} plugin is already loaded or failed to load.
+	Returns 0 otherwise, even if |denops#plugin#unload()| or
+	|denops#plugin#reload()| are called.
 
 						*denops#plugin#wait()*
 denops#plugin#wait({name}[, {options}])
-	Waits synchronously until a {name} plugin is loaded. It returns
-	immediately when the {name} plugin is already loaded.
-	It returns -1 if it times out, -2 if the server is not yet ready or
-	interrupted, or -3 if the plugin initialization failed.
-	Developers need to consider this return value to decide whether to
-	continue with the subsequent process.
+	Waits synchronously until a {name} plugin is loaded or failed to load.
+	It returns immediately when the {name} plugin is already loaded.
+
+	Developers need to consider the following return value to decide
+	whether to continue with the subsequent process:
+
+	 0	The {name} plugin is loaded successfully.
+	-1	"timeout" expired.
+	-2	The server is not yet ready or interrupted.
+	-3	The {name} plugin failed to load.
+
 	The following attributes are available on {options}.
 
         "interval"	Interval in milliseconds for |:sleep| in internal
@@ -408,26 +414,28 @@ denops#plugin#discover()
 						*denops#plugin#load()*
 denops#plugin#load({name}, {script})
 	Loads a denops plugin. Use this function to load denops plugins that
-	are not discovered by |denops#plugin#discover()|.
+	are not discovered by |denops#plugin#discover()|. If the {name} plugin
+	is already loaded, it does nothing.
 
 	Loading a plugin involves the following event steps:
 
-	 - |User| |DenopsPluginPre|:{plugin} is fired.
+	 - |User| |DenopsPluginPre|:{name} is fired.
 	 - The plugin is loaded and the "main" function is executed.
-	 - If it succeeds, |User| |DenopsPluginPost|:{plugin} is fired.
-	 - If it fails, |User| |DenopsPluginFail|:{plugin} is fired.
+	 - If it succeeds, |User| |DenopsPluginPost|:{name} is fired.
+	 - If it fails, |User| |DenopsPluginFail|:{name} is fired.
 
 						*denops#plugin#unload()*
 denops#plugin#unload({name})
-	Unloads a denops plugin. It does nothing when the plugin is not loaded
-	yet.
+	Unloads a denops plugin. If the {name} plugin is currently loading, it
+	will be unloaded after it has been successfully loaded. If the {name}
+	plugin does not exist or fails to load, it does nothing.
 
 	Unloading a plugin involves the following event steps:
 
-	 - |User| |DenopsPluginUnloadPre|:{plugin} is fired.
+	 - |User| |DenopsPluginUnloadPre|:{name} is fired.
 	 - The plugin's dispose callback is executed, if it exists.
-	 - If it succeeds, |User| |DenopsPluginUnloadPost|:{plugin} is fired.
-	 - If it fails, |User| |DenopsPluginUnloadFail|:{plugin} is fired.
+	 - If it succeeds, |User| |DenopsPluginUnloadPost|:{name} is fired.
+	 - If it fails, |User| |DenopsPluginUnloadFail|:{name} is fired.
 
 	The above events may not be fired if the connection is forcibly
 	closed or the denops server is forcibly terminated due to timeout
@@ -435,8 +443,8 @@ denops#plugin#unload({name})
 
 						*denops#plugin#reload()*
 denops#plugin#reload({plugin}[, {options}])
-	Reloads a denops plugin. It does nothing when the plugin is not loaded
-	yet.
+	Reloads a denops plugin. If the {name} plugin does not exist or fails
+	to load, it does nothing.
 
 	It invokes |User| autocommand events. See |denops#plugin#load()| and
 	|denops#plugin#unload()| for details.

--- a/tests/denops/runtime/functions/plugin_test.ts
+++ b/tests/denops/runtime/functions/plugin_test.ts
@@ -1056,7 +1056,36 @@ testHost({
         await delay(MESSAGE_DELAY); // Wait outputs of denops#plugin#load()
       });
 
-      // FIXME: Implement "if the plugin dispose method throws"
+      await t.step("if the plugin dispose method throws", async (t) => {
+        // Load plugin and wait.
+        await host.call("execute", [
+          "let g:__test_denops_events = []",
+          `call denops#plugin#load('dummyIsLoadedInvalidDispose', '${scriptInvalidDispose}')`,
+        ], "");
+        await wait(async () =>
+          (await host.call("eval", "g:__test_denops_events") as string[])
+            .includes("DenopsPluginPost:dummyIsLoadedInvalidDispose")
+        );
+        // Unload plugin and wait failure.
+        await host.call("execute", [
+          "let g:__test_denops_events = []",
+          `call denops#plugin#unload('dummyIsLoadedInvalidDispose')`,
+        ], "");
+        await wait(async () =>
+          (await host.call("eval", "g:__test_denops_events") as string[])
+            .includes("DenopsPluginUnloadFail:dummyIsLoadedInvalidDispose")
+        );
+
+        await t.step("returns 0", async () => {
+          const actual = await host.call(
+            "denops#plugin#is_loaded",
+            "dummyIsLoadedInvalidDispose",
+          );
+          assertEquals(actual, 0);
+        });
+
+        await delay(MESSAGE_DELAY); // Wait outputs of denops#plugin#unload()
+      });
 
       await t.step("if the plugin is loading", async (t) => {
         await host.call("execute", [
@@ -1311,7 +1340,13 @@ testHost({
           assertEquals(actual, 0);
         });
 
-        // FIXME: Implement "returns 0 when DenopsPluginUnloadFail"
+        await t.step("returns 0 when DenopsPluginUnloadFail", async () => {
+          const actual = await host.call(
+            "eval",
+            "g:__test_denops_is_loaded['DenopsPluginUnloadFail:dummyIsLoadedEventInvalidDispose']",
+          );
+          assertEquals(actual, 0);
+        });
       });
     });
 

--- a/tests/denops/testdata/dummy_invalid_wait_plugin.ts
+++ b/tests/denops/testdata/dummy_invalid_wait_plugin.ts
@@ -1,0 +1,7 @@
+import type { Entrypoint } from "jsr:@denops/core@7.0.0-pre1";
+import { delay } from "jsr:@std/async@0.224.0/delay";
+
+export const main: Entrypoint = async (_denops) => {
+  await delay(1000);
+  throw new Error("This is dummy error");
+};

--- a/tests/denops/testdata/dummy_valid_wait_plugin.ts
+++ b/tests/denops/testdata/dummy_valid_wait_plugin.ts
@@ -1,0 +1,6 @@
+import type { Entrypoint } from "jsr:@denops/core@7.0.0-pre1";
+import { delay } from "jsr:@std/async@0.224.0/delay";
+
+export const main: Entrypoint = async (_denops) => {
+  await delay(1000);
+};

--- a/tests/denops/testutil/shared_server_test.ts
+++ b/tests/denops/testutil/shared_server_test.ts
@@ -10,48 +10,54 @@ import { join } from "jsr:@std/path@0.225.0/join";
 import { useSharedServer } from "./shared_server.ts";
 
 Deno.test("useSharedServer()", async (t) => {
-  await t.step("if `verbose` is not specified", async (t) => {
-    await t.step("returns `result.addr`", async (t) => {
-      await using server = await useSharedServer({ verbose: true });
-      const { addr } = server;
+  const HAS_DENOPS_TEST_VERBOSE = Deno.env.has("DENOPS_TEST_VERBOSE");
 
-      await t.step("`addr.host` is string", () => {
-        assertEquals(addr.host, "127.0.0.1");
-      });
-      await t.step("`addr.port` is number", () => {
-        assertEquals(typeof addr.port, "number");
-      });
-      await t.step("`addr.toString()` returns the address", () => {
-        assertMatch(addr.toString(), /^127\.0\.0\.1:\d+$/);
-      });
-    });
+  await t.step({
+    name: "if `verbose` is not specified",
+    ignore: HAS_DENOPS_TEST_VERBOSE,
+    fn: async (t) => {
+      await t.step("returns `result.addr`", async (t) => {
+        await using server = await useSharedServer();
+        const { addr } = server;
 
-    await t.step("returns `result.stdout`", async () => {
-      await using server = await useSharedServer();
-      assertInstanceOf(server.stdout, ReadableStream);
-      const outputs: string[] = [];
-      server.stdout.pipeTo(
-        new WritableStream({ write: (line) => void outputs.push(line) }),
-      ).catch(() => {});
-      await delay(100);
-      assertMatch(outputs.join("\n"), /Listen denops clients on/);
-    });
+        await t.step("`addr.host` is string", () => {
+          assertEquals(addr.host, "127.0.0.1");
+        });
+        await t.step("`addr.port` is number", () => {
+          assertEquals(typeof addr.port, "number");
+        });
+        await t.step("`addr.toString()` returns the address", () => {
+          assertMatch(addr.toString(), /^127\.0\.0\.1:\d+$/);
+        });
+      });
 
-    await t.step("does not output stdout", async () => {
-      const proc = new Deno.Command(Deno.execPath(), {
-        args: [
-          "run",
-          "--allow-env",
-          "--allow-read",
-          "--allow-run",
-          resolve("shared_server_test_no_verbose.ts"),
-        ],
-        stdout: "piped",
-      }).spawn();
-      const output = await proc.output();
-      const stdout = new TextDecoder().decode(output.stdout);
-      assertNotMatch(stdout, /Listen denops clients on/);
-    });
+      await t.step("returns `result.stdout`", async () => {
+        await using server = await useSharedServer();
+        assertInstanceOf(server.stdout, ReadableStream);
+        const outputs: string[] = [];
+        server.stdout.pipeTo(
+          new WritableStream({ write: (line) => void outputs.push(line) }),
+        ).catch(() => {});
+        await delay(100);
+        assertMatch(outputs.join("\n"), /Listen denops clients on/);
+      });
+
+      await t.step("does not output stdout", async () => {
+        const proc = new Deno.Command(Deno.execPath(), {
+          args: [
+            "run",
+            "--allow-env",
+            "--allow-read",
+            "--allow-run",
+            resolve("shared_server_test_no_verbose.ts"),
+          ],
+          stdout: "piped",
+        }).spawn();
+        const output = await proc.output();
+        const stdout = new TextDecoder().decode(output.stdout);
+        assertNotMatch(stdout, /Listen denops clients on/);
+      });
+    },
   });
 
   await t.step("if `verbose` is true", async (t) => {


### PR DESCRIPTION
Include fixes #387.

Workflow changed.
- `test` job depends `check` (If `check` failed, `test` does not start.)
- disable `strategy.fail-fast` (If a job failed, do not stop another jobs.)