### PR TITLE
:+1: Check `deno` executable and show executable path in `checkhealth`

### DIFF
--- a/autoload/health/denops.vim
+++ b/autoload/health/denops.vim
@@ -164,6 +164,7 @@ function! health#denops#check() abort
         \ 'Supported Neovim version: `%s`',
         \ l:supported_versions.neovim,
         \))
+  call s:check_deno_executable()
   call s:check_deno_version(l:supported_versions.deno)
   if !has('nvim')
     call s:check_vim_version(l:supported_versions.vim)

--- a/autoload/health/denops.vim
+++ b/autoload/health/denops.vim
@@ -51,8 +51,9 @@ endfunction
 function! s:check_deno_version(supported_version) abort
   const l:deno_version = s:get_deno_version(g:denops#deno)
   call s:report_info(printf(
-        \ 'Detected Deno version: `%s`',
+        \ 'Detected Deno version: `%s` (%s)',
         \ l:deno_version,
+        \ exepath(g:denops#deno),
         \))
   if empty(l:deno_version)
     call s:report_error('Unable to detect version of deno, make sure your deno runtime is correct.')


### PR DESCRIPTION
To avoid misconfiguration like #400 

![CleanShot 2024-08-06 at 09 04 31](https://github.com/user-attachments/assets/1c6b95c4-34cc-4861-80cf-2ed6d8ca7b3b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved Deno version reporting by including the executable path for clarity.
	- Added a prerequisite check for the Deno executable before version validation, enhancing the health check process.
  
- **Bug Fixes**
	- Enhanced robustness of the health checking mechanism for Deno, reducing potential errors related to Deno installation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->