### PR TITLE
:package: :herb: update deps for testing

### DIFF
--- a/denops/@denops-private/cli_test.ts
+++ b/denops/@denops-private/cli_test.ts
@@ -16,8 +16,8 @@ import {
   spy,
   type Stub,
   stub,
-} from "jsr:@std/testing@^1.0.0-rc.5/mock";
-import { FakeTime } from "jsr:@std/testing@^1.0.0-rc.5/time";
+} from "jsr:@std/testing@^1.0.0/mock";
+import { FakeTime } from "jsr:@std/testing@^1.0.0/time";
 import { delay } from "jsr:@std/async@^1.0.1/delay";
 import { promiseState } from "jsr:@lambdalisue/async@^2.1.1";
 import {

--- a/denops/@denops-private/denops_test.ts
+++ b/denops/@denops-private/denops_test.ts
@@ -11,7 +11,7 @@ import {
   assertSpyCalls,
   resolvesNext,
   stub,
-} from "jsr:@std/testing@^1.0.0-rc.5/mock";
+} from "jsr:@std/testing@^1.0.0/mock";
 import { promiseState } from "jsr:@lambdalisue/async@^2.1.1";
 import { DenopsImpl, type Host, type Service } from "./denops.ts";
 

--- a/denops/@denops-private/host/nvim_test.ts
+++ b/denops/@denops-private/host/nvim_test.ts
@@ -9,7 +9,7 @@ import {
   assertSpyCalls,
   resolvesNext,
   stub,
-} from "jsr:@std/testing@^1.0.0-rc.5/mock";
+} from "jsr:@std/testing@^1.0.0/mock";
 import { delay } from "jsr:@std/async@^1.0.1/delay";
 import { promiseState } from "jsr:@lambdalisue/async@^2.1.1";
 import { unimplemented } from "jsr:@lambdalisue/errorutil@^1.1.0";

--- a/denops/@denops-private/host/vim_test.ts
+++ b/denops/@denops-private/host/vim_test.ts
@@ -8,7 +8,7 @@ import {
   assertSpyCalls,
   resolvesNext,
   stub,
-} from "jsr:@std/testing@^1.0.0-rc.5/mock";
+} from "jsr:@std/testing@^1.0.0/mock";
 import { delay } from "jsr:@std/async@^1.0.1/delay";
 import { promiseState } from "jsr:@lambdalisue/async@^2.1.1";
 import { unimplemented } from "jsr:@lambdalisue/errorutil@^1.1.0";

--- a/denops/@denops-private/host_test.ts
+++ b/denops/@denops-private/host_test.ts
@@ -3,7 +3,7 @@ import {
   assertSpyCall,
   assertSpyCalls,
   stub,
-} from "jsr:@std/testing@^1.0.0-rc.5/mock";
+} from "jsr:@std/testing@^1.0.0/mock";
 import { AssertError } from "jsr:@core/unknownutil@^4.0.0/assert";
 import { unimplemented } from "jsr:@lambdalisue/errorutil@^1.1.0";
 import { invoke, type Service } from "./host.ts";

--- a/denops/@denops-private/service_test.ts
+++ b/denops/@denops-private/service_test.ts
@@ -16,7 +16,7 @@ import {
   resolvesNext,
   spy,
   stub,
-} from "jsr:@std/testing@^1.0.0-rc.5/mock";
+} from "jsr:@std/testing@^1.0.0/mock";
 import type { Meta } from "jsr:@denops/core@^7.0.0";
 import { promiseState } from "jsr:@lambdalisue/async@^2.1.1";
 import { unimplemented } from "jsr:@lambdalisue/errorutil@^1.1.0";

--- a/denops/@denops-private/version_test.ts
+++ b/denops/@denops-private/version_test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals } from "jsr:@std/assert@^1.0.1";
-import { resolvesNext, stub } from "jsr:@std/testing@^1.0.0-rc.5/mock";
+import { resolvesNext, stub } from "jsr:@std/testing@^1.0.0/mock";
 import type { SemVer } from "jsr:@std/semver@^0.224.3/types";
 import type { Predicate } from "jsr:@core/unknownutil@^4.0.0/type";
 import { isArrayOf } from "jsr:@core/unknownutil@^4.0.0/is/array-of";

--- a/denops/@denops-private/worker_test.ts
+++ b/denops/@denops-private/worker_test.ts
@@ -11,7 +11,7 @@ import {
   resolvesNext,
   spy,
   stub,
-} from "jsr:@std/testing@^1.0.0-rc.5/mock";
+} from "jsr:@std/testing@^1.0.0/mock";
 import { delay } from "jsr:@std/async@^1.0.1/delay";
 import { DisposableStack } from "jsr:@nick/dispose@^1.1.0/disposable-stack";
 import * as nvimCodec from "jsr:@lambdalisue/messagepack@^1.0.1";

--- a/tests/denops/runtime/functions/plugin/discover_test.ts
+++ b/tests/denops/runtime/functions/plugin/discover_test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertMatch,
 } from "jsr:@std/assert@^1.0.1";
-import { delay } from "jsr:@std/async@^0.224.0";
+import { delay } from "jsr:@std/async@^1.0.1";
 import { join } from "jsr:@std/path@^1.0.2/join";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";

--- a/tests/denops/runtime/functions/plugin/is_loaded_test.ts
+++ b/tests/denops/runtime/functions/plugin/is_loaded_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertRejects } from "jsr:@std/assert@^1.0.1";
-import { delay } from "jsr:@std/async@^0.224.0";
+import { delay } from "jsr:@std/async@^1.0.1";
 import { join } from "jsr:@std/path@^1.0.2/join";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";

--- a/tests/denops/runtime/functions/plugin/load_test.ts
+++ b/tests/denops/runtime/functions/plugin/load_test.ts
@@ -3,7 +3,7 @@ import {
   assertMatch,
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
-import { delay } from "jsr:@std/async@^0.224.0";
+import { delay } from "jsr:@std/async@^1.0.1";
 import { join } from "jsr:@std/path@^1.0.2/join";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";

--- a/tests/denops/runtime/functions/plugin/reload_test.ts
+++ b/tests/denops/runtime/functions/plugin/reload_test.ts
@@ -3,7 +3,7 @@ import {
   assertMatch,
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
-import { delay } from "jsr:@std/async@^0.224.0";
+import { delay } from "jsr:@std/async@^1.0.1";
 import { join } from "jsr:@std/path@^1.0.2/join";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";

--- a/tests/denops/runtime/functions/plugin/unload_test.ts
+++ b/tests/denops/runtime/functions/plugin/unload_test.ts
@@ -3,7 +3,7 @@ import {
   assertMatch,
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
-import { delay } from "jsr:@std/async@^0.224.0";
+import { delay } from "jsr:@std/async@^1.0.1";
 import { join } from "jsr:@std/path@^1.0.2/join";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";

--- a/tests/denops/runtime/functions/plugin/wait_async_test.ts
+++ b/tests/denops/runtime/functions/plugin/wait_async_test.ts
@@ -4,7 +4,7 @@ import {
   assertLess,
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
-import { delay } from "jsr:@std/async@^0.224.0";
+import { delay } from "jsr:@std/async@^1.0.1";
 import { join } from "jsr:@std/path@^1.0.2/join";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";

--- a/tests/denops/runtime/functions/plugin/wait_test.ts
+++ b/tests/denops/runtime/functions/plugin/wait_test.ts
@@ -6,7 +6,7 @@ import {
   assertRejects,
   assertStringIncludes,
 } from "jsr:@std/assert@^1.0.1";
-import { delay } from "jsr:@std/async@^0.224.0";
+import { delay } from "jsr:@std/async@^1.0.1";
 import { join } from "jsr:@std/path@^1.0.2/join";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";

--- a/tests/denops/runtime/functions/server/close_test.ts
+++ b/tests/denops/runtime/functions/server/close_test.ts
@@ -4,7 +4,7 @@ import {
   assertMatch,
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
-import { delay } from "jsr:@std/async@^0.224.0/delay";
+import { delay } from "jsr:@std/async@^1.0.1/delay";
 import { AsyncDisposableStack } from "jsr:@nick/dispose@^1.1.0/async-disposable-stack";
 import { testHost } from "/denops-testutil/host.ts";
 import { useSharedServer } from "/denops-testutil/shared_server.ts";

--- a/tests/denops/runtime/functions/server/connect_test.ts
+++ b/tests/denops/runtime/functions/server/connect_test.ts
@@ -5,7 +5,7 @@ import {
   assertMatch,
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
-import { delay } from "jsr:@std/async@^0.224.0/delay";
+import { delay } from "jsr:@std/async@^1.0.1/delay";
 import { AsyncDisposableStack } from "jsr:@nick/dispose@^1.1.0/async-disposable-stack";
 import { testHost } from "/denops-testutil/host.ts";
 import { useSharedServer } from "/denops-testutil/shared_server.ts";

--- a/tests/denops/runtime/functions/server/start_test.ts
+++ b/tests/denops/runtime/functions/server/start_test.ts
@@ -6,7 +6,7 @@ import {
   assertNotMatch,
   assertStringIncludes,
 } from "jsr:@std/assert@^1.0.1";
-import { delay } from "jsr:@std/async@^0.224.0/delay";
+import { delay } from "jsr:@std/async@^1.0.1/delay";
 import { AsyncDisposableStack } from "jsr:@nick/dispose@^1.1.0/async-disposable-stack";
 import { testHost } from "/denops-testutil/host.ts";
 import { useSharedServer } from "/denops-testutil/shared_server.ts";

--- a/tests/denops/runtime/plugin_test.ts
+++ b/tests/denops/runtime/plugin_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertMatch } from "jsr:@std/assert@^1.0.1";
-import { delay } from "jsr:@std/async@^0.224.0/delay";
+import { delay } from "jsr:@std/async@^1.0.1/delay";
 import { withHost } from "/denops-testutil/host.ts";
 import { useSharedServer } from "/denops-testutil/shared_server.ts";
 import { wait } from "/denops-testutil/wait.ts";

--- a/tests/denops/testutil/mock_test.ts
+++ b/tests/denops/testutil/mock_test.ts
@@ -17,7 +17,7 @@ import {
   resolvesNext,
   spy,
   stub,
-} from "jsr:@std/testing@^1.0.0-rc.5/mock";
+} from "jsr:@std/testing@^1.0.0/mock";
 
 // deno-lint-ignore no-explicit-any
 type AnyFn = (...args: any[]) => unknown;

--- a/tests/denops/testutil/mock_test.ts
+++ b/tests/denops/testutil/mock_test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertInstanceOf,
   assertRejects,
-} from "jsr:@std/assert@^0.225.2";
+} from "jsr:@std/assert@^1.0.1";
 import { promiseState } from "jsr:@lambdalisue/async@^2.1.1";
 import {
   createFakeTcpConn,
@@ -11,7 +11,7 @@ import {
   createFakeWorker,
   pendingPromise,
 } from "./mock.ts";
-import { assertThrows } from "jsr:@std/assert@^0.225.1/assert-throws";
+import { assertThrows } from "jsr:@std/assert@^1.0.1/throws";
 import {
   assertSpyCalls,
   resolvesNext,

--- a/tests/denops/testutil/wait_test.ts
+++ b/tests/denops/testutil/wait_test.ts
@@ -4,8 +4,8 @@ import {
   resolvesNext,
   returnsNext,
   spy,
-} from "jsr:@std/testing@^1.0.0-rc.5/mock";
-import { FakeTime } from "jsr:@std/testing@^1.0.0-rc.5/time";
+} from "jsr:@std/testing@^1.0.0/mock";
+import { FakeTime } from "jsr:@std/testing@^1.0.0/time";
 import { wait } from "./wait.ts";
 
 Deno.test("wait()", async (t) => {


### PR DESCRIPTION
- `@std/async` update to same as production code.
- `@std/assert`, `@std/testing` update to v1 major release.

These are only for test codes.
`@std/semver` is still below v1, but since this is a change to the production code, I will make this a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated testing libraries to stable versions, enhancing reliability and functionality in test execution.
- **Bug Fixes**
	- Adjusted versioning for the `delay` function, which may include bug fixes or performance improvements.
- **Documentation**
	- Improved clarity of import statements across test files to reflect the transition to stable versions of libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->