### PR TITLE
:package: bump jsr:@std/semver from ^0.224.3 to ^1.0.1

### DIFF
--- a/denops/@denops-private/version.ts
+++ b/denops/@denops-private/version.ts
@@ -1,7 +1,7 @@
 import { dirname } from "jsr:@std/path@^1.0.2/dirname";
 import { fromFileUrl } from "jsr:@std/path@^1.0.2/from-file-url";
-import type { SemVer } from "jsr:@std/semver@^0.224.3/types";
-import { parse } from "jsr:@std/semver@^0.224.3/parse";
+import type { SemVer } from "jsr:@std/semver@^1.0.1/types";
+import { parse } from "jsr:@std/semver@^1.0.1/parse";
 
 const decoder = new TextDecoder();
 

--- a/denops/@denops-private/version_test.ts
+++ b/denops/@denops-private/version_test.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals } from "jsr:@std/assert@^1.0.1";
 import { resolvesNext, stub } from "jsr:@std/testing@^1.0.0/mock";
-import type { SemVer } from "jsr:@std/semver@^0.224.3/types";
+import type { SemVer } from "jsr:@std/semver@^1.0.1/types";
 import type { Predicate } from "jsr:@core/unknownutil@^4.0.0/type";
 import { isArrayOf } from "jsr:@core/unknownutil@^4.0.0/is/array-of";
 import { isNumber } from "jsr:@core/unknownutil@^4.0.0/is/number";


### PR DESCRIPTION
:tada: All modules that denops.vim directly depends on are now at their release versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated to a newer version of the `semver` library, enhancing semantic versioning capabilities.
  
- **Bug Fixes**
	- Potential improvements and bug fixes related to version parsing with the updated library.

- **Documentation**
	- Improved clarity on version handling and its impact on the application's functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->