### PR TITLE
:+1: no package json

### DIFF
--- a/autoload/denops/_internal/server/proc.vim
+++ b/autoload/denops/_internal/server/proc.vim
@@ -55,6 +55,7 @@ function! s:start(options) abort
   let l:env = {
         \   'NO_COLOR': 1,
         \   'DENO_NO_PROMPT': 1,
+        \   'DENO_NO_PACKAGE_JSON': 1,
         \ }
   if g:denops#deno_dir isnot# v:null
     let l:env['DENO_DIR'] = g:denops#deno_dir


### PR DESCRIPTION
Do not use the *package.json* file.
Do not create the *node_modules* directory.

For example, some Vim plugins have the *package.json* file and directories are merged by the Vim package manager.
If the *package.json* file is exists, then `deno run` use it and create the *node_modules* directory automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable, `DENO_NO_PACKAGE_JSON`, enhancing configuration options for the Deno runtime environment. This allows for more control over package resolution and initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->