### PR TITLE
:herb: add module that resolves testdata path or URL

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -17,6 +17,7 @@
   // NOTE: Import maps should only be used from test modules.
   "imports": {
     "/denops-private/": "./denops/@denops-private/",
+    "/denops-testdata/": "./tests/denops/testdata/",
     "/denops-testutil/": "./tests/denops/testutil/"
   }
 }

--- a/denops/@denops-private/service_test.ts
+++ b/denops/@denops-private/service_test.ts
@@ -17,21 +17,28 @@ import {
   spy,
   stub,
 } from "jsr:@std/testing@^1.0.0/mock";
+import { toFileUrl } from "jsr:@std/path@^1.0.2/to-file-url";
 import type { Meta } from "jsr:@denops/core@^7.0.0";
 import { promiseState } from "jsr:@lambdalisue/async@^2.1.1";
 import { unimplemented } from "jsr:@lambdalisue/errorutil@^1.1.0";
+import { resolveTestDataURL } from "/denops-testdata/resolve.ts";
 import type { Host } from "./denops.ts";
 import { Service } from "./service.ts";
-import { toFileUrl } from "jsr:@std/path@^1.0.2/to-file-url";
 
 const NOOP = () => {};
 
-const scriptValid = resolve("dummy_valid_plugin.ts");
-const scriptInvalid = resolve("dummy_invalid_plugin.ts");
-const scriptValidDispose = resolve("dummy_valid_dispose_plugin.ts");
-const scriptInvalidDispose = resolve("dummy_invalid_dispose_plugin.ts");
-const scriptInvalidConstraint = resolve("dummy_invalid_constraint_plugin.ts");
-const scriptInvalidConstraint2 = resolve("dummy_invalid_constraint_plugin2.ts");
+const scriptValid = resolveTestDataURL("dummy_valid_plugin.ts");
+const scriptInvalid = resolveTestDataURL("dummy_invalid_plugin.ts");
+const scriptValidDispose = resolveTestDataURL("dummy_valid_dispose_plugin.ts");
+const scriptInvalidDispose = resolveTestDataURL(
+  "dummy_invalid_dispose_plugin.ts",
+);
+const scriptInvalidConstraint = resolveTestDataURL(
+  "dummy_invalid_constraint_plugin.ts",
+);
+const scriptInvalidConstraint2 = resolveTestDataURL(
+  "dummy_invalid_constraint_plugin2.ts",
+);
 
 Deno.test("Service", async (t) => {
   const meta: Meta = {
@@ -1620,11 +1627,6 @@ Deno.test("Service", async (t) => {
     });
   });
 });
-
-/** Resolve testdata script URL. */
-function resolve(path: string): string {
-  return new URL(`../../tests/denops/testdata/${path}`, import.meta.url).href;
-}
 
 async function useTempFile(options?: Deno.MakeTempOptions) {
   const path = await Deno.makeTempFile(options);

--- a/tests/denops/runtime/functions/plugin/check_type_test.ts
+++ b/tests/denops/runtime/functions/plugin/check_type_test.ts
@@ -3,11 +3,11 @@ import {
   assertNotMatch,
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
-import { join } from "jsr:@std/path@^1.0.2/join";
+import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
 
-const scriptValid = resolve("dummy_valid_plugin.ts");
+const scriptValid = resolveTestDataPath("dummy_valid_plugin.ts");
 
 testHost({
   name: "denops#plugin#check_type()",
@@ -211,8 +211,3 @@ testHost({
     });
   },
 });
-
-/** Resolve testdata script path. */
-function resolve(path: string): string {
-  return join(import.meta.dirname!, `../../../testdata/${path}`);
-}

--- a/tests/denops/runtime/functions/plugin/discover_test.ts
+++ b/tests/denops/runtime/functions/plugin/discover_test.ts
@@ -4,13 +4,13 @@ import {
   assertMatch,
 } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1";
-import { join } from "jsr:@std/path@^1.0.2/join";
+import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
 
 const MESSAGE_DELAY = 200; // msc
 
-const runtimepathPlugin = resolve("dummy_plugins");
+const runtimepathPlugin = resolveTestDataPath("dummy_plugins");
 
 testHost({
   name: "denops#plugin#discover()",
@@ -83,8 +83,3 @@ testHost({
     });
   },
 });
-
-/** Resolve testdata script path. */
-function resolve(path: string): string {
-  return join(import.meta.dirname!, `../../../testdata/${path}`);
-}

--- a/tests/denops/runtime/functions/plugin/is_loaded_test.ts
+++ b/tests/denops/runtime/functions/plugin/is_loaded_test.ts
@@ -1,14 +1,16 @@
 import { assertEquals, assertRejects } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1";
-import { join } from "jsr:@std/path@^1.0.2/join";
+import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
 
 const MESSAGE_DELAY = 200; // msc
 
-const scriptValid = resolve("dummy_valid_plugin.ts");
-const scriptInvalid = resolve("dummy_invalid_plugin.ts");
-const scriptInvalidDispose = resolve("dummy_invalid_dispose_plugin.ts");
+const scriptValid = resolveTestDataPath("dummy_valid_plugin.ts");
+const scriptInvalid = resolveTestDataPath("dummy_invalid_plugin.ts");
+const scriptInvalidDispose = resolveTestDataPath(
+  "dummy_invalid_dispose_plugin.ts",
+);
 
 testHost({
   name: "denops#plugin#is_loaded()",
@@ -309,8 +311,3 @@ testHost({
     });
   },
 });
-
-/** Resolve testdata script path. */
-function resolve(path: string): string {
-  return join(import.meta.dirname!, `../../../testdata/${path}`);
-}

--- a/tests/denops/runtime/functions/plugin/load_test.ts
+++ b/tests/denops/runtime/functions/plugin/load_test.ts
@@ -4,15 +4,15 @@ import {
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1";
-import { join } from "jsr:@std/path@^1.0.2/join";
+import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
 
 const MESSAGE_DELAY = 200; // msc
 
-const scriptValid = resolve("dummy_valid_plugin.ts");
-const scriptInvalid = resolve("dummy_invalid_plugin.ts");
-const scriptValidDispose = resolve("dummy_valid_dispose_plugin.ts");
+const scriptValid = resolveTestDataPath("dummy_valid_plugin.ts");
+const scriptInvalid = resolveTestDataPath("dummy_invalid_plugin.ts");
+const scriptValidDispose = resolveTestDataPath("dummy_valid_dispose_plugin.ts");
 
 testHost({
   name: "denops#plugin#load()",
@@ -387,8 +387,3 @@ testHost({
     });
   },
 });
-
-/** Resolve testdata script path. */
-function resolve(path: string): string {
-  return join(import.meta.dirname!, `../../../testdata/${path}`);
-}

--- a/tests/denops/runtime/functions/plugin/reload_test.ts
+++ b/tests/denops/runtime/functions/plugin/reload_test.ts
@@ -4,14 +4,16 @@ import {
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1";
-import { join } from "jsr:@std/path@^1.0.2/join";
+import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
 
 const MESSAGE_DELAY = 200; // msc
 
-const scriptValid = resolve("dummy_valid_plugin.ts");
-const scriptInvalidDispose = resolve("dummy_invalid_dispose_plugin.ts");
+const scriptValid = resolveTestDataPath("dummy_valid_plugin.ts");
+const scriptInvalidDispose = resolveTestDataPath(
+  "dummy_invalid_dispose_plugin.ts",
+);
 
 testHost({
   name: "denops#plugin#reload()",
@@ -360,8 +362,3 @@ testHost({
     });
   },
 });
-
-/** Resolve testdata script path. */
-function resolve(path: string): string {
-  return join(import.meta.dirname!, `../../../testdata/${path}`);
-}

--- a/tests/denops/runtime/functions/plugin/unload_test.ts
+++ b/tests/denops/runtime/functions/plugin/unload_test.ts
@@ -4,14 +4,16 @@ import {
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1";
-import { join } from "jsr:@std/path@^1.0.2/join";
+import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
 
 const MESSAGE_DELAY = 200; // msc
 
-const scriptValidDispose = resolve("dummy_valid_dispose_plugin.ts");
-const scriptInvalidDispose = resolve("dummy_invalid_dispose_plugin.ts");
+const scriptValidDispose = resolveTestDataPath("dummy_valid_dispose_plugin.ts");
+const scriptInvalidDispose = resolveTestDataPath(
+  "dummy_invalid_dispose_plugin.ts",
+);
 
 testHost({
   name: "denops#plugin#unload()",
@@ -358,8 +360,3 @@ testHost({
     });
   },
 });
-
-/** Resolve testdata script path. */
-function resolve(path: string): string {
-  return join(import.meta.dirname!, `../../../testdata/${path}`);
-}

--- a/tests/denops/runtime/functions/plugin/wait_async_test.ts
+++ b/tests/denops/runtime/functions/plugin/wait_async_test.ts
@@ -5,16 +5,16 @@ import {
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1";
-import { join } from "jsr:@std/path@^1.0.2/join";
+import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
 
 const MESSAGE_DELAY = 200; // msc
 
-const scriptValid = resolve("dummy_valid_plugin.ts");
-const scriptInvalid = resolve("dummy_invalid_plugin.ts");
-const scriptValidWait = resolve("dummy_valid_wait_plugin.ts");
-const scriptInvalidWait = resolve("dummy_invalid_wait_plugin.ts");
+const scriptValid = resolveTestDataPath("dummy_valid_plugin.ts");
+const scriptInvalid = resolveTestDataPath("dummy_invalid_plugin.ts");
+const scriptValidWait = resolveTestDataPath("dummy_valid_wait_plugin.ts");
+const scriptInvalidWait = resolveTestDataPath("dummy_invalid_wait_plugin.ts");
 
 testHost({
   name: "denops#plugin#wait_async()",
@@ -308,8 +308,3 @@ testHost({
     });
   },
 });
-
-/** Resolve testdata script path. */
-function resolve(path: string): string {
-  return join(import.meta.dirname!, `../../../testdata/${path}`);
-}

--- a/tests/denops/runtime/functions/plugin/wait_test.ts
+++ b/tests/denops/runtime/functions/plugin/wait_test.ts
@@ -7,16 +7,16 @@ import {
   assertStringIncludes,
 } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1";
-import { join } from "jsr:@std/path@^1.0.2/join";
+import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
 
 const MESSAGE_DELAY = 200; // msc
 
-const scriptValid = resolve("dummy_valid_plugin.ts");
-const scriptInvalid = resolve("dummy_invalid_plugin.ts");
-const scriptValidWait = resolve("dummy_valid_wait_plugin.ts");
-const scriptInvalidWait = resolve("dummy_invalid_wait_plugin.ts");
+const scriptValid = resolveTestDataPath("dummy_valid_plugin.ts");
+const scriptInvalid = resolveTestDataPath("dummy_invalid_plugin.ts");
+const scriptValidWait = resolveTestDataPath("dummy_valid_wait_plugin.ts");
+const scriptInvalidWait = resolveTestDataPath("dummy_invalid_wait_plugin.ts");
 
 testHost({
   name: "denops#plugin#wait()",
@@ -426,8 +426,3 @@ testHost({
     });
   },
 });
-
-/** Resolve testdata script path. */
-function resolve(path: string): string {
-  return join(import.meta.dirname!, `../../../testdata/${path}`);
-}

--- a/tests/denops/runtime/functions/server/start_test.ts
+++ b/tests/denops/runtime/functions/server/start_test.ts
@@ -8,6 +8,7 @@ import {
 } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1/delay";
 import { AsyncDisposableStack } from "jsr:@nick/dispose@^1.1.0/async-disposable-stack";
+import { resolveTestDataURL } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { useSharedServer } from "/denops-testutil/shared_server.ts";
 import { wait } from "/denops-testutil/wait.ts";
@@ -404,7 +405,7 @@ testHost({
         await host.call("execute", [
           "silent! unlet g:__test_denops_process_stopped_fired",
           `let g:denops#server#deno_args = ['${
-            resolve("no_check/cli_constraint_error_on_issue_401.ts")
+            resolveTestDataURL("no_check/cli_constraint_error_on_issue_401.ts")
           }']`,
           "let g:denops#server#restart_delay = 1000",
           "let g:denops#server#restart_interval = 10000",
@@ -440,8 +441,3 @@ testHost({
     );
   },
 });
-
-/** Resolve testdata script URL. */
-function resolve(path: string): string {
-  return new URL(`../../../testdata/${path}`, import.meta.url).href;
-}

--- a/tests/denops/testdata/resolve.ts
+++ b/tests/denops/testdata/resolve.ts
@@ -1,0 +1,11 @@
+import { join } from "jsr:@std/path@^1.0.2/join";
+
+/** Resolve testdata script path. */
+export function resolveTestDataPath(path: string): string {
+  return join(import.meta.dirname!, path);
+}
+
+/** Resolve testdata script URL. */
+export function resolveTestDataURL(path: string): string {
+  return new URL(path, import.meta.url).href;
+}

--- a/tests/denops/testutil/shared_server_test.ts
+++ b/tests/denops/testutil/shared_server_test.ts
@@ -6,7 +6,7 @@ import {
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1/delay";
-import { join } from "jsr:@std/path@^1.0.2/join";
+import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { useSharedServer } from "./shared_server.ts";
 
 Deno.test("useSharedServer()", async (t) => {
@@ -49,7 +49,7 @@ Deno.test("useSharedServer()", async (t) => {
             "--allow-env",
             "--allow-read",
             "--allow-run",
-            resolve("shared_server_test_no_verbose.ts"),
+            resolveTestDataPath("shared_server_test_no_verbose.ts"),
           ],
           stdout: "piped",
         }).spawn();
@@ -94,7 +94,7 @@ Deno.test("useSharedServer()", async (t) => {
           "--allow-env",
           "--allow-read",
           "--allow-run",
-          resolve("shared_server_test_verbose_true.ts"),
+          resolveTestDataPath("shared_server_test_verbose_true.ts"),
         ],
         stdout: "piped",
       }).spawn();
@@ -114,8 +114,3 @@ Deno.test("useSharedServer()", async (t) => {
     );
   });
 });
-
-/** Resolve testdata script path. */
-function resolve(path: string): string {
-  return join(import.meta.dirname!, `../testdata/${path}`);
-}


### PR DESCRIPTION
Changes only for tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new import mapping for `/denops-testdata/` to enhance test data organization.
	- Added functions for resolving test data paths and URLs, improving access to test resources.

- **Bug Fixes**
	- Replaced local `resolve` functions with centralized utility functions for better maintainability across various test files.

- **Refactor**
	- Removed redundant `resolve` functions from multiple test files, streamlining the codebase and enhancing clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->