### PR TITLE
:+1: rejects if the plugin name is invalid

### DIFF
--- a/autoload/denops/_internal/plugin.vim
+++ b/autoload/denops/_internal/plugin.vim
@@ -4,6 +4,7 @@ const s:STATE_LOADED = 'loaded'
 const s:STATE_UNLOADING = 'unloading'
 const s:STATE_FAILED = 'failed'
 
+" NOTE: same as denops/@denops-private/service.ts
 const s:VALID_NAME_PATTERN = '^[-_0-9a-zA-Z]\+$'
 
 let s:plugins = {}

--- a/tests/denops/runtime/functions/denops/notify_test.ts
+++ b/tests/denops/runtime/functions/denops/notify_test.ts
@@ -1,0 +1,61 @@
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert@^1.0.1";
+import { delay } from "jsr:@std/async@^1.0.1/delay";
+import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
+import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
+import { testHost } from "/denops-testutil/host.ts";
+import { wait } from "/denops-testutil/wait.ts";
+
+const ASYNC_DELAY = 100;
+
+const scriptValid = resolveTestDataPath("dummy_valid_plugin.ts");
+
+testHost({
+  name: "denops#notify()",
+  mode: "all",
+  postlude: [
+    "runtime plugin/denops.vim",
+  ],
+  fn: async ({ host, t, stderr }) => {
+    let outputs: string[] = [];
+    stderr.pipeTo(
+      new WritableStream({ write: (s) => void outputs.push(s) }),
+    ).catch(() => {});
+    await wait(() => host.call("eval", "denops#server#status() ==# 'running'"));
+    await host.call("execute", [
+      "let g:__test_denops_events = []",
+      "autocmd User DenopsPlugin* call add(g:__test_denops_events, expand('<amatch>'))",
+    ], "");
+
+    for (const [plugin_name, label] of INVALID_PLUGIN_NAMES) {
+      await t.step(`if the plugin name is invalid (${label})`, async (t) => {
+        await t.step("does not throw an error", async () => {
+          await host.call("denops#notify", plugin_name, "test", ["foo"]);
+        });
+      });
+    }
+
+    await t.step("if the plugin is loaded", async (t) => {
+      // Load plugin and wait.
+      await host.call("execute", [
+        "let g:__test_denops_events = []",
+        `call denops#plugin#load('dummyLoaded', '${scriptValid}')`,
+      ], "");
+      await wait(async () =>
+        (await host.call("eval", "g:__test_denops_events") as string[])
+          .includes("DenopsPluginPost:dummyLoaded")
+      );
+
+      outputs = [];
+      await host.call("denops#notify", "dummyLoaded", "test", ["foo"]);
+
+      await t.step("returns immediately", () => {
+        assertEquals(outputs, []);
+      });
+
+      await t.step("calls dispatcher method", async () => {
+        await delay(ASYNC_DELAY);
+        assertStringIncludes(outputs.join(""), 'This is test call: ["foo"]');
+      });
+    });
+  },
+});

--- a/tests/denops/runtime/functions/denops/request_async_test.ts
+++ b/tests/denops/runtime/functions/denops/request_async_test.ts
@@ -1,0 +1,117 @@
+import {
+  assertEquals,
+  assertObjectMatch,
+  assertStringIncludes,
+} from "jsr:@std/assert@^1.0.1";
+import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
+import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
+import { testHost } from "/denops-testutil/host.ts";
+import { wait } from "/denops-testutil/wait.ts";
+
+const scriptValid = resolveTestDataPath("dummy_valid_plugin.ts");
+
+testHost({
+  name: "denops#request_async()",
+  mode: "all",
+  postlude: [
+    "runtime plugin/denops.vim",
+  ],
+  fn: async ({ host, t, stderr, mode }) => {
+    let outputs: string[] = [];
+    stderr.pipeTo(
+      new WritableStream({ write: (s) => void outputs.push(s) }),
+    ).catch(() => {});
+    await wait(() => host.call("eval", "denops#server#status() ==# 'running'"));
+    await host.call("execute", [
+      "let g:__test_denops_events = []",
+      "autocmd User DenopsPlugin* call add(g:__test_denops_events, expand('<amatch>'))",
+      "function TestDenopsRequestAsyncSuccess(...)",
+      "  call add(g:__test_denops_events, ['TestDenopsRequestAsyncSuccess', a:000])",
+      "endfunction",
+      "function TestDenopsRequestAsyncFailure(...)",
+      "  call add(g:__test_denops_events, ['TestDenopsRequestAsyncFailure', a:000])",
+      "endfunction",
+    ], "");
+
+    for (const [plugin_name, label] of INVALID_PLUGIN_NAMES) {
+      await t.step(`if the plugin name is invalid (${label})`, async (t) => {
+        await host.call("execute", [
+          "let g:__test_denops_events = []",
+        ], "");
+
+        await t.step("does not throw an error", async () => {
+          await host.call(
+            "denops#request_async",
+            plugin_name,
+            "test",
+            ["foo"],
+            "TestDenopsRequestAsyncSuccess",
+            "TestDenopsRequestAsyncFailure",
+          );
+        });
+
+        await t.step("calls failure callback", async () => {
+          await wait(() => host.call("eval", "len(g:__test_denops_events)"));
+          assertObjectMatch(
+            await host.call("eval", "g:__test_denops_events") as [],
+            {
+              0: [
+                "TestDenopsRequestAsyncFailure",
+                [
+                  {
+                    message: `Invalid plugin name: ${plugin_name}`,
+                    name: "TypeError",
+                  },
+                ],
+              ],
+            },
+          );
+        });
+      });
+    }
+
+    await t.step("if the plugin is loaded", async (t) => {
+      // Load plugin and wait.
+      await host.call("execute", [
+        "let g:__test_denops_events = []",
+        `call denops#plugin#load('dummyLoaded', '${scriptValid}')`,
+      ], "");
+      await wait(async () =>
+        (await host.call("eval", "g:__test_denops_events") as string[])
+          .includes("DenopsPluginPost:dummyLoaded")
+      );
+      await host.call("execute", [
+        "let g:__test_denops_events = []",
+      ], "");
+
+      outputs = [];
+      await host.call(
+        "denops#request_async",
+        "dummyLoaded",
+        "test",
+        ["foo"],
+        "TestDenopsRequestAsyncSuccess",
+        "TestDenopsRequestAsyncFailure",
+      );
+
+      await t.step("returns immediately", () => {
+        assertEquals(outputs, []);
+      });
+
+      await t.step("calls success callback", async () => {
+        await wait(() => host.call("eval", "len(g:__test_denops_events)"));
+        const returnValue = mode === "vim" ? null : 0;
+        assertObjectMatch(
+          await host.call("eval", "g:__test_denops_events") as [],
+          {
+            0: ["TestDenopsRequestAsyncSuccess", [returnValue]],
+          },
+        );
+      });
+
+      await t.step("calls dispatcher method", () => {
+        assertStringIncludes(outputs.join(""), 'This is test call: ["foo"]');
+      });
+    });
+  },
+});

--- a/tests/denops/runtime/functions/denops/request_test.ts
+++ b/tests/denops/runtime/functions/denops/request_test.ts
@@ -1,0 +1,57 @@
+import { assertRejects, assertStringIncludes } from "jsr:@std/assert@^1.0.1";
+import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
+import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
+import { testHost } from "/denops-testutil/host.ts";
+import { wait } from "/denops-testutil/wait.ts";
+
+const scriptValid = resolveTestDataPath("dummy_valid_plugin.ts");
+
+testHost({
+  name: "denops#request()",
+  mode: "all",
+  postlude: [
+    "runtime plugin/denops.vim",
+  ],
+  fn: async ({ host, t, stderr }) => {
+    let outputs: string[] = [];
+    stderr.pipeTo(
+      new WritableStream({ write: (s) => void outputs.push(s) }),
+    ).catch(() => {});
+    await wait(() => host.call("eval", "denops#server#status() ==# 'running'"));
+    await host.call("execute", [
+      "let g:__test_denops_events = []",
+      "autocmd User DenopsPlugin* call add(g:__test_denops_events, expand('<amatch>'))",
+    ], "");
+
+    for (const [plugin_name, label] of INVALID_PLUGIN_NAMES) {
+      await t.step(`if the plugin name is invalid (${label})`, async (t) => {
+        await t.step("throws an error", async () => {
+          await assertRejects(
+            () => host.call("denops#request", plugin_name, "test", ["foo"]),
+            Error,
+            `Invalid plugin name: ${plugin_name}`,
+          );
+        });
+      });
+    }
+
+    await t.step("if the plugin is loaded", async (t) => {
+      // Load plugin and wait.
+      await host.call("execute", [
+        "let g:__test_denops_events = []",
+        `call denops#plugin#load('dummyLoaded', '${scriptValid}')`,
+      ], "");
+      await wait(async () =>
+        (await host.call("eval", "g:__test_denops_events") as string[])
+          .includes("DenopsPluginPost:dummyLoaded")
+      );
+
+      await t.step("calls dispatcher method", async () => {
+        outputs = [];
+        await host.call("denops#request", "dummyLoaded", "test", ["foo"]);
+
+        assertStringIncludes(outputs.join(""), 'This is test call: ["foo"]');
+      });
+    });
+  },
+});

--- a/tests/denops/runtime/functions/plugin/check_type_test.ts
+++ b/tests/denops/runtime/functions/plugin/check_type_test.ts
@@ -3,6 +3,7 @@ import {
   assertNotMatch,
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
+import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
 import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
@@ -76,16 +77,17 @@ testHost({
       });
     });
 
-    await t.step("if the plugin name is invalid", async (t) => {
-      await t.step("throws an error", async () => {
-        // NOTE: '.' is not allowed in plugin name.
-        await assertRejects(
-          () => host.call("denops#plugin#check_type", "dummy.invalid"),
-          Error,
-          "Invalid plugin name: dummy.invalid",
-        );
+    for (const [plugin_name, label] of INVALID_PLUGIN_NAMES) {
+      await t.step(`if the plugin name is invalid (${label})`, async (t) => {
+        await t.step("throws an error", async () => {
+          await assertRejects(
+            () => host.call("denops#plugin#check_type", plugin_name),
+            Error,
+            `Invalid plugin name: ${plugin_name}`,
+          );
+        });
       });
-    });
+    }
 
     await t.step("if the plugin is not yet loaded", async (t) => {
       outputs = [];

--- a/tests/denops/runtime/functions/plugin/is_loaded_test.ts
+++ b/tests/denops/runtime/functions/plugin/is_loaded_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertRejects } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1";
+import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
 import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
@@ -30,16 +31,17 @@ testHost({
       "augroup END",
     ], "");
 
-    await t.step("if the plugin name is invalid", async (t) => {
-      await t.step("throws an error", async () => {
-        // NOTE: '.' is not allowed in plugin name.
-        await assertRejects(
-          () => host.call("denops#plugin#is_loaded", "dummy.invalid"),
-          Error,
-          "Invalid plugin name: dummy.invalid",
-        );
+    for (const [plugin_name, label] of INVALID_PLUGIN_NAMES) {
+      await t.step(`if the plugin name is invalid (${label})`, async (t) => {
+        await t.step("throws an error", async () => {
+          await assertRejects(
+            () => host.call("denops#plugin#is_loaded", plugin_name),
+            Error,
+            `Invalid plugin name: ${plugin_name}`,
+          );
+        });
       });
-    });
+    }
 
     await t.step("if the plugin is not yet loaded", async (t) => {
       await t.step("returns 0", async () => {

--- a/tests/denops/runtime/functions/plugin/load_test.ts
+++ b/tests/denops/runtime/functions/plugin/load_test.ts
@@ -4,6 +4,7 @@ import {
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1";
+import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
 import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
@@ -31,16 +32,17 @@ testHost({
       "autocmd User DenopsPlugin* call add(g:__test_denops_events, expand('<amatch>'))",
     ], "");
 
-    await t.step("if the plugin name is invalid", async (t) => {
-      await t.step("throws an error", async () => {
-        // NOTE: '.' is not allowed in plugin name.
-        await assertRejects(
-          () => host.call("denops#plugin#load", "dummy.invalid", scriptValid),
-          Error,
-          "Invalid plugin name: dummy.invalid",
-        );
+    for (const [plugin_name, label] of INVALID_PLUGIN_NAMES) {
+      await t.step(`if the plugin name is invalid (${label})`, async (t) => {
+        await t.step("throws an error", async () => {
+          await assertRejects(
+            () => host.call("denops#plugin#load", plugin_name, scriptValid),
+            Error,
+            `Invalid plugin name: ${plugin_name}`,
+          );
+        });
       });
-    });
+    }
 
     await t.step("if the plugin is not yet loaded", async (t) => {
       outputs = [];

--- a/tests/denops/runtime/functions/plugin/reload_test.ts
+++ b/tests/denops/runtime/functions/plugin/reload_test.ts
@@ -4,6 +4,7 @@ import {
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1";
+import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
 import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
@@ -32,16 +33,17 @@ testHost({
       "autocmd User DenopsPlugin* call add(g:__test_denops_events, expand('<amatch>'))",
     ], "");
 
-    await t.step("if the plugin name is invalid", async (t) => {
-      await t.step("throws an error", async () => {
-        // NOTE: '.' is not allowed in plugin name.
-        await assertRejects(
-          () => host.call("denops#plugin#reload", "dummy.invalid"),
-          Error,
-          "Invalid plugin name: dummy.invalid",
-        );
+    for (const [plugin_name, label] of INVALID_PLUGIN_NAMES) {
+      await t.step(`if the plugin name is invalid (${label})`, async (t) => {
+        await t.step("throws an error", async () => {
+          await assertRejects(
+            () => host.call("denops#plugin#reload", plugin_name),
+            Error,
+            `Invalid plugin name: ${plugin_name}`,
+          );
+        });
       });
-    });
+    }
 
     await t.step("if the plugin is not yet loaded", async (t) => {
       outputs = [];

--- a/tests/denops/runtime/functions/plugin/unload_test.ts
+++ b/tests/denops/runtime/functions/plugin/unload_test.ts
@@ -4,6 +4,7 @@ import {
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1";
+import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
 import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
@@ -32,16 +33,17 @@ testHost({
       "autocmd User DenopsPlugin* call add(g:__test_denops_events, expand('<amatch>'))",
     ], "");
 
-    await t.step("if the plugin name is invalid", async (t) => {
-      await t.step("throws an error", async () => {
-        // NOTE: '.' is not allowed in plugin name.
-        await assertRejects(
-          () => host.call("denops#plugin#unload", "dummy.invalid"),
-          Error,
-          "Invalid plugin name: dummy.invalid",
-        );
+    for (const [plugin_name, label] of INVALID_PLUGIN_NAMES) {
+      await t.step(`if the plugin name is invalid (${label})`, async (t) => {
+        await t.step("throws an error", async () => {
+          await assertRejects(
+            () => host.call("denops#plugin#unload", plugin_name),
+            Error,
+            `Invalid plugin name: ${plugin_name}`,
+          );
+        });
       });
-    });
+    }
 
     await t.step("if the plugin is not yet loaded", async (t) => {
       outputs = [];

--- a/tests/denops/runtime/functions/plugin/wait_async_test.ts
+++ b/tests/denops/runtime/functions/plugin/wait_async_test.ts
@@ -5,6 +5,7 @@ import {
   assertRejects,
 } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1";
+import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
 import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
@@ -29,19 +30,20 @@ testHost({
       "autocmd User DenopsPlugin* call add(g:__test_denops_events, expand('<amatch>'))",
     ], "");
 
-    await t.step("if the plugin name is invalid", async (t) => {
-      await t.step("throws an error", async () => {
-        // NOTE: '.' is not allowed in plugin name.
-        await assertRejects(
-          () =>
-            host.call("execute", [
-              "call denops#plugin#wait_async('dummy.invalid', { -> 0 })",
-            ], ""),
-          Error,
-          "Invalid plugin name: dummy.invalid",
-        );
+    for (const [plugin_name, label] of INVALID_PLUGIN_NAMES) {
+      await t.step(`if the plugin name is invalid (${label})`, async (t) => {
+        await t.step("throws an error", async () => {
+          await assertRejects(
+            () =>
+              host.call("execute", [
+                `call denops#plugin#wait_async('${plugin_name}', { -> 0 })`,
+              ], ""),
+            Error,
+            `Invalid plugin name: ${plugin_name}`,
+          );
+        });
       });
-    });
+    }
 
     await t.step("if the plugin is load asynchronously", async (t) => {
       // Load plugin asynchronously.

--- a/tests/denops/runtime/functions/plugin/wait_test.ts
+++ b/tests/denops/runtime/functions/plugin/wait_test.ts
@@ -7,6 +7,7 @@ import {
   assertStringIncludes,
 } from "jsr:@std/assert@^1.0.1";
 import { delay } from "jsr:@std/async@^1.0.1";
+import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
 import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
@@ -35,16 +36,17 @@ testHost({
       "autocmd User DenopsPlugin* call add(g:__test_denops_events, expand('<amatch>'))",
     ], "");
 
-    await t.step("if the plugin name is invalid", async (t) => {
-      await t.step("throws an error", async () => {
-        // NOTE: '.' is not allowed in plugin name.
-        await assertRejects(
-          () => host.call("denops#plugin#wait", "dummy.invalid"),
-          Error,
-          "Invalid plugin name: dummy.invalid",
-        );
+    for (const [plugin_name, label] of INVALID_PLUGIN_NAMES) {
+      await t.step(`if the plugin name is invalid (${label})`, async (t) => {
+        await t.step("throws an error", async () => {
+          await assertRejects(
+            () => host.call("denops#plugin#wait", plugin_name),
+            Error,
+            `Invalid plugin name: ${plugin_name}`,
+          );
+        });
       });
-    });
+    }
 
     await t.step("if the plugin is loading", async (t) => {
       await host.call("execute", [

--- a/tests/denops/testdata/invalid_plugin_names.ts
+++ b/tests/denops/testdata/invalid_plugin_names.ts
@@ -1,0 +1,6 @@
+export const INVALID_PLUGIN_NAMES:
+  readonly (readonly [plugin_name: string, label: string])[] = [
+    ["", "empty"],
+    ["dummy.invalid", "'.'"],
+    ["dummy invalid", "' '"],
+  ];


### PR DESCRIPTION
Fixes part of #415.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced validation for plugin names, ensuring only valid names are processed, enhancing overall system robustness.
	- Added a constant for invalid plugin names to improve validation and error handling.

- **Bug Fixes**
	- Improved error handling for various plugin operations when invalid names are used.

- **Tests**
	- Expanded test coverage for handling invalid plugin names across multiple functions, ensuring robust error detection and handling.

- **Documentation**
	- Added comments to clarify relationships between constants and improve code understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->