### PR TITLE
:herb: use core/asyncutil instead lambdalisue/async

### DIFF
--- a/denops/@denops-private/cli_test.ts
+++ b/denops/@denops-private/cli_test.ts
@@ -19,7 +19,7 @@ import {
 } from "jsr:@std/testing@^1.0.0/mock";
 import { FakeTime } from "jsr:@std/testing@^1.0.0/time";
 import { delay } from "jsr:@std/async@^1.0.1/delay";
-import { promiseState } from "jsr:@lambdalisue/async@^2.1.1";
+import { flushPromises, peekPromiseState } from "jsr:@core/asyncutil@^1.1.1";
 import {
   createFakeTcpConn,
   createFakeTcpListener,
@@ -263,7 +263,7 @@ Deno.test("main()", async (t) => {
         });
 
         await t.step("pendings main() Promise", async () => {
-          assertEquals(await promiseState(p), "pending");
+          assertEquals(await peekPromiseState(p), "pending");
         });
       });
 
@@ -276,7 +276,7 @@ Deno.test("main()", async (t) => {
         });
 
         await t.step("pendings main() Promise", async () => {
-          assertEquals(await promiseState(p), "pending");
+          assertEquals(await peekPromiseState(p), "pending");
         });
 
         await t.step(
@@ -296,7 +296,7 @@ Deno.test("main()", async (t) => {
           });
 
           await t.step("resolves main() Promise", async () => {
-            assertEquals(await promiseState(p), "fulfilled");
+            assertEquals(await peekPromiseState(p), "fulfilled");
           });
         });
 
@@ -384,14 +384,15 @@ Deno.test("main()", async (t) => {
         });
 
         await t.step("pendings main() Promise", async () => {
-          assertEquals(await promiseState(p), "pending");
+          assertEquals(await peekPromiseState(p), "pending");
         });
 
         await t.step("and the listner is closed", async (t) => {
           fakeTcpListener.close();
+          await flushPromises();
 
           await t.step("resolves main() Promise", async () => {
-            assertEquals(await promiseState(p), "fulfilled");
+            assertEquals(await peekPromiseState(p), "fulfilled");
           });
         });
       });
@@ -460,7 +461,7 @@ Deno.test("main()", async (t) => {
         });
 
         await t.step("resolves main() Promise", async () => {
-          assertEquals(await promiseState(p), "fulfilled");
+          assertEquals(await peekPromiseState(p), "fulfilled");
         });
 
         await t.step("does not outputs error logs", () => {
@@ -604,7 +605,7 @@ Deno.test("main()", async (t) => {
       });
 
       await t.step("resolves main() Promise", async () => {
-        assertEquals(await promiseState(mainPromise), "fulfilled");
+        assertEquals(await peekPromiseState(mainPromise), "fulfilled");
       });
     });
   });

--- a/denops/@denops-private/denops_test.ts
+++ b/denops/@denops-private/denops_test.ts
@@ -12,7 +12,7 @@ import {
   resolvesNext,
   stub,
 } from "jsr:@std/testing@^1.0.0/mock";
-import { promiseState } from "jsr:@lambdalisue/async@^2.1.1";
+import { flushPromises, peekPromiseState } from "jsr:@core/asyncutil@^1.1.1";
 import { DenopsImpl, type Host, type Service } from "./denops.ts";
 
 type BatchReturn = [results: unknown[], errmsg: string];
@@ -360,11 +360,14 @@ Deno.test("DenopsImpl", async (t) => {
 
         const dispatchPromise = denops.dispatch("dummy", "fn", "args");
 
-        assertEquals(await promiseState(dispatchPromise), "pending");
+        assertEquals(await peekPromiseState(dispatchPromise), "pending");
         assertSpyCalls(service_waitLoaded, 1);
         assertSpyCalls(service_dispatch, 0);
+
         waiter.resolve();
-        assertEquals(await promiseState(dispatchPromise), "fulfilled");
+        await flushPromises();
+
+        assertEquals(await peekPromiseState(dispatchPromise), "fulfilled");
         assertSpyCalls(service_waitLoaded, 1);
         assertSpyCalls(service_dispatch, 1);
       });

--- a/denops/@denops-private/host/nvim_test.ts
+++ b/denops/@denops-private/host/nvim_test.ts
@@ -11,7 +11,7 @@ import {
   stub,
 } from "jsr:@std/testing@^1.0.0/mock";
 import { delay } from "jsr:@std/async@^1.0.1/delay";
-import { promiseState } from "jsr:@lambdalisue/async@^2.1.1";
+import { peekPromiseState } from "jsr:@core/asyncutil@^1.1.1";
 import { unimplemented } from "jsr:@lambdalisue/errorutil@^1.1.0";
 import { Client } from "jsr:@lambdalisue/messagepack-rpc@^2.4.0";
 import { withNeovim } from "/denops-testutil/with.ts";
@@ -400,14 +400,14 @@ Deno.test("Neovim", async (t) => {
         const waitClosedPromise = host.waitClosed();
 
         await t.step("pendings before the session closes", async () => {
-          assertEquals(await promiseState(waitClosedPromise), "pending");
+          assertEquals(await peekPromiseState(waitClosedPromise), "pending");
         });
 
         // NOTE: Close the session of the host.
         await host[Symbol.asyncDispose]();
 
         await t.step("fulfilled when the session closes", async () => {
-          assertEquals(await promiseState(waitClosedPromise), "fulfilled");
+          assertEquals(await peekPromiseState(waitClosedPromise), "fulfilled");
         });
       });
     },

--- a/denops/@denops-private/host/vim_test.ts
+++ b/denops/@denops-private/host/vim_test.ts
@@ -10,7 +10,7 @@ import {
   stub,
 } from "jsr:@std/testing@^1.0.0/mock";
 import { delay } from "jsr:@std/async@^1.0.1/delay";
-import { promiseState } from "jsr:@lambdalisue/async@^2.1.1";
+import { peekPromiseState } from "jsr:@core/asyncutil@^1.1.1";
 import { unimplemented } from "jsr:@lambdalisue/errorutil@^1.1.0";
 import { Client, Session } from "jsr:@denops/vim-channel-command@^4.0.2";
 import { withVim } from "/denops-testutil/with.ts";
@@ -378,14 +378,14 @@ Deno.test("Vim", async (t) => {
         const waitClosedPromise = host.waitClosed();
 
         await t.step("pendings before the session closes", async () => {
-          assertEquals(await promiseState(waitClosedPromise), "pending");
+          assertEquals(await peekPromiseState(waitClosedPromise), "pending");
         });
 
         // NOTE: Close the session of the host.
         await host[Symbol.asyncDispose]();
 
         await t.step("fulfilled when the session closes", async () => {
-          assertEquals(await promiseState(waitClosedPromise), "fulfilled");
+          assertEquals(await peekPromiseState(waitClosedPromise), "fulfilled");
         });
       });
     },

--- a/denops/@denops-private/service_test.ts
+++ b/denops/@denops-private/service_test.ts
@@ -19,7 +19,7 @@ import {
 } from "jsr:@std/testing@^1.0.0/mock";
 import { toFileUrl } from "jsr:@std/path@^1.0.2/to-file-url";
 import type { Meta } from "jsr:@denops/core@^7.0.0";
-import { promiseState } from "jsr:@lambdalisue/async@^2.1.1";
+import { flushPromises, peekPromiseState } from "jsr:@core/asyncutil@^1.1.1";
 import { unimplemented } from "jsr:@lambdalisue/errorutil@^1.1.0";
 import { resolveTestDataURL } from "/denops-testdata/resolve.ts";
 import type { Host } from "./denops.ts";
@@ -621,7 +621,7 @@ Deno.test("Service", async (t) => {
       });
 
       await t.step("previous `load()` was resolved", async () => {
-        assertEquals(await promiseState(prevLoadPromise), "fulfilled");
+        assertEquals(await peekPromiseState(prevLoadPromise), "fulfilled");
       });
 
       await t.step("emits `load()` and `unload()` events", () => {
@@ -668,7 +668,7 @@ Deno.test("Service", async (t) => {
       });
 
       await t.step("previous `load()` was resolved", async () => {
-        assertEquals(await promiseState(prevLoadPromise), "fulfilled");
+        assertEquals(await peekPromiseState(prevLoadPromise), "fulfilled");
       });
 
       await t.step("outputs an error message", () => {
@@ -712,7 +712,7 @@ Deno.test("Service", async (t) => {
       });
 
       await t.step("previous `unload()` was resolved", async () => {
-        assertEquals(await promiseState(prevUnloadPromise), "fulfilled");
+        assertEquals(await peekPromiseState(prevUnloadPromise), "fulfilled");
       });
 
       await t.step("emits `unload()` events", () => {
@@ -887,7 +887,7 @@ Deno.test("Service", async (t) => {
       });
 
       await t.step("previous `load()` was resolved", async () => {
-        assertEquals(await promiseState(prevLoadPromise), "fulfilled");
+        assertEquals(await peekPromiseState(prevLoadPromise), "fulfilled");
       });
 
       await t.step("emits `load()` and `reload()` events", () => {
@@ -950,7 +950,7 @@ Deno.test("Service", async (t) => {
       });
 
       await t.step("previous `unload()` was resolved", async () => {
-        assertEquals(await promiseState(prevUnloadPromise), "fulfilled");
+        assertEquals(await peekPromiseState(prevUnloadPromise), "fulfilled");
       });
 
       await t.step("emits `reload()` events", () => {
@@ -1069,7 +1069,7 @@ Deno.test("Service", async (t) => {
 
       const actual = service.waitLoaded("dummy");
 
-      assertEquals(await promiseState(actual), "pending");
+      assertEquals(await peekPromiseState(actual), "pending");
     });
 
     await t.step("pendings if the plugin is already unloaded", async () => {
@@ -1081,7 +1081,7 @@ Deno.test("Service", async (t) => {
 
       const actual = service.waitLoaded("dummy");
 
-      assertEquals(await promiseState(actual), "pending");
+      assertEquals(await peekPromiseState(actual), "pending");
     });
 
     await t.step("resolves if the plugin is already loaded", async () => {
@@ -1092,7 +1092,7 @@ Deno.test("Service", async (t) => {
 
       const actual = service.waitLoaded("dummy");
 
-      assertEquals(await promiseState(actual), "fulfilled");
+      assertEquals(await peekPromiseState(actual), "fulfilled");
     });
 
     await t.step("resolves when the plugin is loaded", async () => {
@@ -1103,7 +1103,7 @@ Deno.test("Service", async (t) => {
       const actual = service.waitLoaded("dummy");
       await service.load("dummy", scriptValid);
 
-      assertEquals(await promiseState(actual), "fulfilled");
+      assertEquals(await peekPromiseState(actual), "fulfilled");
     });
 
     await t.step(
@@ -1118,7 +1118,7 @@ Deno.test("Service", async (t) => {
         const unloadPromise = service.unload("dummy");
         await Promise.all([loadPromise, unloadPromise]);
 
-        assertEquals(await promiseState(actual), "fulfilled");
+        assertEquals(await peekPromiseState(actual), "fulfilled");
       },
     );
 
@@ -1131,7 +1131,7 @@ Deno.test("Service", async (t) => {
       const actual = service.waitLoaded("dummy");
       actual.catch(NOOP);
 
-      assertEquals(await promiseState(actual), "rejected");
+      assertEquals(await peekPromiseState(actual), "rejected");
       await assertRejects(
         () => actual,
         Error,
@@ -1147,7 +1147,7 @@ Deno.test("Service", async (t) => {
       const actual = service.waitLoaded("dummy");
       await service.close();
 
-      assertEquals(await promiseState(actual), "rejected");
+      assertEquals(await peekPromiseState(actual), "rejected");
       await assertRejects(
         () => actual,
         Error,
@@ -1586,7 +1586,7 @@ Deno.test("Service", async (t) => {
 
       const actual = service.waitClosed();
 
-      assertEquals(await promiseState(actual), "pending");
+      assertEquals(await peekPromiseState(actual), "pending");
     });
 
     await t.step("resolves if the service is already closed", async () => {
@@ -1594,10 +1594,11 @@ Deno.test("Service", async (t) => {
       const service = new Service(meta);
       service.bind(host);
       service.close();
+      await flushPromises();
 
       const actual = service.waitClosed();
 
-      assertEquals(await promiseState(actual), "fulfilled");
+      assertEquals(await peekPromiseState(actual), "fulfilled");
     });
 
     await t.step("resolves when the service is closed", async () => {
@@ -1607,8 +1608,9 @@ Deno.test("Service", async (t) => {
 
       const actual = service.waitClosed();
       service.close();
+      await flushPromises();
 
-      assertEquals(await promiseState(actual), "fulfilled");
+      assertEquals(await peekPromiseState(actual), "fulfilled");
     });
   });
 


### PR DESCRIPTION
This allows we to test promise states more accurately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of promise states in asynchronous tests, enhancing reliability and accuracy.
  
- **New Features**
	- Introduced `flushPromises` and `peekPromiseState` for better promise state management in tests. 

- **Refactor**
	- Replaced instances of `promiseState` with `peekPromiseState` across multiple test files to streamline promise state checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->