### PR TITLE
:bug: fix delay in resolving `waitLoaded()`

### DIFF
--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -92,12 +92,16 @@ export class Service implements HostService, AsyncDisposable {
     }
   }
 
-  async waitLoaded(name: string): Promise<void> {
-    if (this.#closed) {
-      throw new Error("Service closed");
+  waitLoaded(name: string): Promise<void> {
+    try {
+      if (this.#closed) {
+        throw new Error("Service closed");
+      }
+      assertValidPluginName(name);
+    } catch (e) {
+      return Promise.reject(e);
     }
-    assertValidPluginName(name);
-    await this.#getWaiter(name).promise;
+    return this.#getWaiter(name).promise;
   }
 
   interrupt(reason?: unknown): void {

--- a/denops/@denops-private/service_test.ts
+++ b/denops/@denops-private/service_test.ts
@@ -1235,7 +1235,7 @@ Deno.test("Service", async (t) => {
   });
 
   await t.step(".interrupt()", async (t) => {
-    await t.step("sends signal to `interrupted` attribute", () => {
+    await t.step("sends signal to `interrupted` property", () => {
       const service = new Service(meta);
       const signal = service.interrupted;
 
@@ -1244,7 +1244,7 @@ Deno.test("Service", async (t) => {
       assert(signal.aborted);
     });
 
-    await t.step("sends signal to `interrupted` attribute with reason", () => {
+    await t.step("sends signal to `interrupted` property with reason", () => {
       const service = new Service(meta);
       const signal = service.interrupted;
 

--- a/denops/@denops-private/service_test.ts
+++ b/denops/@denops-private/service_test.ts
@@ -10,7 +10,6 @@ import {
   assertRejects,
   assertStrictEquals,
   assertStringIncludes,
-  assertThrows,
 } from "jsr:@std/assert@^1.0.1";
 import {
   assertSpyCall,
@@ -1242,7 +1241,7 @@ Deno.test("Service", async (t) => {
 
       service.interrupt();
 
-      assertThrows(() => signal.throwIfAborted());
+      assert(signal.aborted);
     });
 
     await t.step("sends signal to `interrupted` attribute with reason", () => {
@@ -1251,7 +1250,8 @@ Deno.test("Service", async (t) => {
 
       service.interrupt("test");
 
-      assertThrows(() => signal.throwIfAborted(), "test");
+      assert(signal.aborted);
+      assertEquals(signal.reason, "test");
     });
   });
 


### PR DESCRIPTION
Fixed delay in resolving `waitLoaded()`.
This is a regression due to #418 and discovered by #419.

And fixed tests for `interrupt()`, it was a mistake in using `assertThrows`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the service's loading method, enhancing resilience and clarity in asynchronous contexts.
  
- **New Features**
	- Introduced a new Denops plugin that responds to interruption signals, improving interactivity and user experience.
  
- **Tests**
	- Updated test cases to focus on the state of the signal object instead of relying on thrown exceptions, leading to clearer and more maintainable tests.
	- Added comprehensive tests for the `denops#interrupt()` function, ensuring correct behavior under various server and plugin states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->