### PR TITLE
:herb: add/improve tests for interrupt

### DIFF
--- a/tests/denops/runtime/functions/denops/interrupt_test.ts
+++ b/tests/denops/runtime/functions/denops/interrupt_test.ts
@@ -43,12 +43,15 @@ testHost({
         (await host.call("eval", "g:__test_denops_events") as string[])
           .includes("DenopsPluginPost:dummy")
       );
-      await host.call("execute", [
-        "let g:__test_denops_events = []",
-      ], "");
 
       await t.step("returns immediately", async () => {
+        await host.call("execute", [
+          "let g:__test_denops_events = []",
+        ], "");
+
         await host.call("denops#interrupt");
+
+        assertEquals(await host.call("eval", "g:__test_denops_events"), []);
       });
 
       await t.step("sends signal to the plugin", async () => {

--- a/tests/denops/runtime/functions/denops/interrupt_test.ts
+++ b/tests/denops/runtime/functions/denops/interrupt_test.ts
@@ -51,6 +51,7 @@ testHost({
 
         await host.call("denops#interrupt");
 
+        // It should passed because of delay(MIMIC_ABORT_DELAY) in dummy_interrupt_plugin.ts
         assertEquals(await host.call("eval", "g:__test_denops_events"), []);
       });
 
@@ -70,6 +71,7 @@ testHost({
         );
       });
 
+      // Reset interrupt event handler.
       await host.call("denops#request", "dummy", "reset", []);
 
       await t.step("sends signal to the plugin with reason", async () => {

--- a/tests/denops/runtime/functions/denops/interrupt_test.ts
+++ b/tests/denops/runtime/functions/denops/interrupt_test.ts
@@ -1,0 +1,86 @@
+import { assert, assertEquals } from "jsr:@std/assert@^1.0.1";
+import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
+import { testHost } from "/denops-testutil/host.ts";
+import { wait } from "/denops-testutil/wait.ts";
+
+const scriptInterrupt = resolveTestDataPath("dummy_interrupt_plugin.ts");
+
+testHost({
+  name: "denops#interrupt()",
+  mode: "all",
+  postlude: [
+    "let g:__test_denops_events = []",
+    "autocmd User DenopsPlugin* call add(g:__test_denops_events, expand('<amatch>'))",
+    "autocmd User DummyInterruptPlugin:* call add(g:__test_denops_events, expand('<amatch>'))",
+    "runtime plugin/denops.vim",
+    // NOTE: Disable startup on VimEnter.
+    "autocmd! denops_plugin_internal_startup VimEnter",
+  ],
+  fn: async ({ host, t }) => {
+    await t.step("if the server is not yet running", async (t) => {
+      await t.step("returns immediately", async () => {
+        await host.call("denops#interrupt");
+      });
+    });
+
+    // Start the server and wait.
+    await host.call("denops#server#start");
+    await wait(() => host.call("eval", "denops#server#status() ==# 'running'"));
+
+    await t.step("if the plugin is not yet loaded", async (t) => {
+      await t.step("returns immediately", async () => {
+        await host.call("denops#interrupt");
+      });
+    });
+
+    await t.step("if the plugin is loaded", async (t) => {
+      // Load plugin and wait.
+      await host.call("execute", [
+        "let g:__test_denops_events = []",
+        `call denops#plugin#load('dummy', '${scriptInterrupt}')`,
+      ], "");
+      await wait(async () =>
+        (await host.call("eval", "g:__test_denops_events") as string[])
+          .includes("DenopsPluginPost:dummy")
+      );
+      await host.call("execute", [
+        "let g:__test_denops_events = []",
+      ], "");
+
+      await t.step("returns immediately", async () => {
+        await host.call("denops#interrupt");
+      });
+
+      await t.step("sends signal to the plugin", async () => {
+        await wait(() => host.call("eval", "len(g:__test_denops_events)"));
+        const events = await host.call(
+          "eval",
+          "g:__test_denops_events",
+        ) as string[];
+        assert(
+          events.some((event) =>
+            event.startsWith("DummyInterruptPlugin:Interrupted:")
+          ),
+          `Expected event 'DummyInterruptPlugin:Interrupted:*', but: ${
+            JSON.stringify(events)
+          }`,
+        );
+      });
+
+      await host.call("denops#request", "dummy", "reset", []);
+
+      await t.step("sends signal to the plugin with reason", async () => {
+        await host.call("execute", [
+          "let g:__test_denops_events = []",
+        ], "");
+
+        await host.call("denops#interrupt", "test");
+
+        await wait(() => host.call("eval", "len(g:__test_denops_events)"));
+        assertEquals(await host.call("eval", "g:__test_denops_events"), [
+          "DummyInterruptPlugin:Interrupted:test",
+        ]);
+      });
+    });
+  },
+});

--- a/tests/denops/runtime/functions/denops/notify_test.ts
+++ b/tests/denops/runtime/functions/denops/notify_test.ts
@@ -5,7 +5,6 @@ import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
 
-const ASYNC_DELAY = 100;
 const MESSAGE_DELAY = 200;
 
 const scriptDispatcher = resolveTestDataPath("dummy_dispatcher_plugin.ts");
@@ -58,7 +57,7 @@ testHost({
       });
 
       await t.step("calls dispatcher method", async () => {
-        await delay(100 + ASYNC_DELAY);
+        await wait(() => host.call("eval", "len(g:__test_denops_events)"));
         assertEquals(await host.call("eval", "g:__test_denops_events"), [
           'DummyDispatcherPlugin:TestCalled:["foo"]',
         ]);

--- a/tests/denops/runtime/functions/denops/request_async_test.ts
+++ b/tests/denops/runtime/functions/denops/request_async_test.ts
@@ -122,18 +122,14 @@ testHost({
         await t.step("returns immediately", async () => {
           await host.call("execute", [
             "let g:__test_denops_events = []",
+            "call denops#request_async('dummy', 'not_exist_method', ['foo'], 'TestDenopsRequestAsyncSuccess', 'TestDenopsRequestAsyncFailure')",
+            "let g:__test_denops_events_after_called = g:__test_denops_events->copy()",
           ], "");
 
-          await host.call(
-            "denops#request_async",
-            "dummy",
-            "not_exist_method",
-            ["foo"],
-            "TestDenopsRequestAsyncSuccess",
-            "TestDenopsRequestAsyncFailure",
+          assertEquals(
+            await host.call("eval", "g:__test_denops_events_after_called"),
+            [],
           );
-
-          assertEquals(await host.call("eval", "g:__test_denops_events"), []);
         });
 
         await t.step("calls failure callback", async () => {

--- a/tests/denops/runtime/functions/denops/request_async_test.ts
+++ b/tests/denops/runtime/functions/denops/request_async_test.ts
@@ -3,13 +3,10 @@ import {
   assertEquals,
   assertObjectMatch,
 } from "jsr:@std/assert@^1.0.1";
-import { delay } from "jsr:@std/async@^1.0.1/delay";
 import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
 import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
-
-const ASYNC_DELAY = 100;
 
 const scriptDispatcher = resolveTestDataPath("dummy_dispatcher_plugin.ts");
 
@@ -99,7 +96,7 @@ testHost({
       });
 
       await t.step("calls dispatcher method", async () => {
-        await delay(100 + ASYNC_DELAY);
+        await wait(() => host.call("eval", "len(g:__test_denops_events)"));
         assertArrayIncludes(
           await host.call("eval", "g:__test_denops_events") as unknown[],
           ['DummyDispatcherPlugin:TestCalled:["foo"]'],

--- a/tests/denops/runtime/functions/denops/request_test.ts
+++ b/tests/denops/runtime/functions/denops/request_test.ts
@@ -1,10 +1,10 @@
-import { assertRejects, assertStringIncludes } from "jsr:@std/assert@^1.0.1";
+import { assertEquals, assertRejects } from "jsr:@std/assert@^1.0.1";
 import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
 import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
 import { wait } from "/denops-testutil/wait.ts";
 
-const scriptValid = resolveTestDataPath("dummy_valid_plugin.ts");
+const scriptDispatcher = resolveTestDataPath("dummy_dispatcher_plugin.ts");
 
 testHost({
   name: "denops#request()",
@@ -12,15 +12,12 @@ testHost({
   postlude: [
     "runtime plugin/denops.vim",
   ],
-  fn: async ({ host, t, stderr }) => {
-    let outputs: string[] = [];
-    stderr.pipeTo(
-      new WritableStream({ write: (s) => void outputs.push(s) }),
-    ).catch(() => {});
+  fn: async ({ host, t }) => {
     await wait(() => host.call("eval", "denops#server#status() ==# 'running'"));
     await host.call("execute", [
       "let g:__test_denops_events = []",
       "autocmd User DenopsPlugin* call add(g:__test_denops_events, expand('<amatch>'))",
+      "autocmd User DummyDispatcherPlugin:* call add(g:__test_denops_events, expand('<amatch>'))",
     ], "");
 
     for (const [plugin_name, label] of INVALID_PLUGIN_NAMES) {
@@ -39,18 +36,50 @@ testHost({
       // Load plugin and wait.
       await host.call("execute", [
         "let g:__test_denops_events = []",
-        `call denops#plugin#load('dummyLoaded', '${scriptValid}')`,
+        `call denops#plugin#load('dummy', '${scriptDispatcher}')`,
       ], "");
       await wait(async () =>
         (await host.call("eval", "g:__test_denops_events") as string[])
-          .includes("DenopsPluginPost:dummyLoaded")
+          .includes("DenopsPluginPost:dummy")
       );
 
       await t.step("calls dispatcher method", async () => {
-        outputs = [];
-        await host.call("denops#request", "dummyLoaded", "test", ["foo"]);
+        await host.call("execute", [
+          "let g:__test_denops_events = []",
+        ], "");
 
-        assertStringIncludes(outputs.join(""), 'This is test call: ["foo"]');
+        await host.call("denops#request", "dummy", "test", ["foo"]);
+
+        assertEquals(await host.call("eval", "g:__test_denops_events"), [
+          'DummyDispatcherPlugin:TestCalled:["foo"]',
+        ]);
+      });
+
+      await t.step("returns dispatcher method return value", async () => {
+        const result = await host.call(
+          "denops#request",
+          "dummy",
+          "test",
+          ["foo"],
+        );
+
+        assertEquals(result, { result: "OK", args: ["foo"] });
+      });
+
+      await t.step("if the dispatcher method is not exist", async (t) => {
+        await t.step("throws an error", async () => {
+          await assertRejects(
+            () =>
+              host.call(
+                "denops#request",
+                "dummy",
+                "not_exist_method",
+                ["foo"],
+              ),
+            Error,
+            "Failed to call 'not_exist_method' API in 'dummy'",
+          );
+        });
       });
     });
   },

--- a/tests/denops/testdata/dummy_dispatcher_plugin.ts
+++ b/tests/denops/testdata/dummy_dispatcher_plugin.ts
@@ -1,10 +1,12 @@
 import { delay } from "jsr:@std/async@^1.0.1/delay";
 import type { Entrypoint } from "jsr:@denops/core@^7.0.0";
 
+const MIMIC_DISPATCHER_METHOD_DELAY = 100;
+
 export const main: Entrypoint = (denops) => {
   denops.dispatcher = {
     test: async (...args) => {
-      await delay(100);
+      await delay(MIMIC_DISPATCHER_METHOD_DELAY);
       await denops.cmd(
         `doautocmd <nomodeline> User DummyDispatcherPlugin:TestCalled:${
           JSON.stringify(args).replaceAll(/[ \\"]/g, "\\$&")

--- a/tests/denops/testdata/dummy_dispatcher_plugin.ts
+++ b/tests/denops/testdata/dummy_dispatcher_plugin.ts
@@ -6,9 +6,9 @@ export const main: Entrypoint = (denops) => {
     test: async (...args) => {
       await delay(100);
       await denops.cmd(
-        `execute 'doautocmd <nomodeline> User' fnameescape('DummyDispatcherPlugin:TestCalled:${
-          JSON.stringify(args)
-        }')`,
+        `doautocmd <nomodeline> User DummyDispatcherPlugin:TestCalled:${
+          JSON.stringify(args).replaceAll(/[ \\"]/g, "\\$&")
+        }`,
       );
       return { result: "OK", args };
     },

--- a/tests/denops/testdata/dummy_dispatcher_plugin.ts
+++ b/tests/denops/testdata/dummy_dispatcher_plugin.ts
@@ -1,0 +1,16 @@
+import { delay } from "jsr:@std/async@^1.0.1/delay";
+import type { Entrypoint } from "jsr:@denops/core@^7.0.0";
+
+export const main: Entrypoint = (denops) => {
+  denops.dispatcher = {
+    test: async (...args) => {
+      await delay(100);
+      await denops.cmd(
+        `execute 'doautocmd <nomodeline> User' fnameescape('DummyDispatcherPlugin:TestCalled:${
+          JSON.stringify(args)
+        }')`,
+      );
+      return { result: "OK", args };
+    },
+  };
+};

--- a/tests/denops/testdata/dummy_interrupt_plugin.ts
+++ b/tests/denops/testdata/dummy_interrupt_plugin.ts
@@ -1,11 +1,14 @@
 import type { Entrypoint } from "jsr:@denops/core@^7.0.0";
 import { delay } from "jsr:@std/async@^1.0.1/delay";
 
+const MIMIC_ABORT_DELAY = 100;
+
 export const main: Entrypoint = (denops) => {
+  /** Reset interrupt event handler. */
   function reset(): void {
     const signal = denops.interrupted;
     signal?.addEventListener("abort", async () => {
-      await delay(100);
+      await delay(MIMIC_ABORT_DELAY);
       await denops.cmd(
         `doautocmd <nomodeline> User DummyInterruptPlugin:Interrupted:${
           String(signal.reason).replaceAll(/[ \\"]/g, "\\$&")

--- a/tests/denops/testdata/dummy_interrupt_plugin.ts
+++ b/tests/denops/testdata/dummy_interrupt_plugin.ts
@@ -1,9 +1,11 @@
 import type { Entrypoint } from "jsr:@denops/core@^7.0.0";
+import { delay } from "jsr:@std/async@^1.0.1/delay";
 
 export const main: Entrypoint = (denops) => {
   function reset(): void {
     const signal = denops.interrupted;
     signal?.addEventListener("abort", async () => {
+      await delay(100);
       await denops.cmd(
         `doautocmd <nomodeline> User DummyInterruptPlugin:Interrupted:${signal.reason}`,
       );

--- a/tests/denops/testdata/dummy_interrupt_plugin.ts
+++ b/tests/denops/testdata/dummy_interrupt_plugin.ts
@@ -7,7 +7,9 @@ export const main: Entrypoint = (denops) => {
     signal?.addEventListener("abort", async () => {
       await delay(100);
       await denops.cmd(
-        `doautocmd <nomodeline> User DummyInterruptPlugin:Interrupted:${signal.reason}`,
+        `doautocmd <nomodeline> User DummyInterruptPlugin:Interrupted:${
+          String(signal.reason).replaceAll(/[ \\"]/g, "\\$&")
+        }`,
       );
     }, { once: true });
   }

--- a/tests/denops/testdata/dummy_interrupt_plugin.ts
+++ b/tests/denops/testdata/dummy_interrupt_plugin.ts
@@ -1,0 +1,17 @@
+import type { Entrypoint } from "jsr:@denops/core@^7.0.0";
+
+export const main: Entrypoint = (denops) => {
+  function reset(): void {
+    const signal = denops.interrupted;
+    signal?.addEventListener("abort", async () => {
+      await denops.cmd(
+        `doautocmd <nomodeline> User DummyInterruptPlugin:Interrupted:${signal.reason}`,
+      );
+    }, { once: true });
+  }
+  reset();
+
+  denops.dispatcher = {
+    reset,
+  };
+};


### PR DESCRIPTION
This is fixed re-opened PR of #421.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a comprehensive test suite for the `denops#interrupt()` function to validate its behavior under various conditions.
	- Added a dummy plugin to manage interruption signals, enhancing interactivity within the Denops environment.
	- Implemented new tests for the `denops#notify()` and `denops#request_async()` functions to ensure robust error handling and event validation.
	- Added a new dispatcher plugin to simulate asynchronous requests and improve event handling in tests.
	- Enhanced the testing of the `DenopsImpl` class with improved interruption logic validation.

- **Bug Fixes**
	- Improved the robustness of the tests for various functions, ensuring thorough validation of error handling.

- **Documentation**
	- Enhanced test structure for better clarity and coverage of interrupt functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->