### PR TITLE
The Deno official manual link in README is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ developers to write plugins in [TypeScript] / [JavaScript] powered by [Deno].
 ## For users
 
 Firstly, install the latest [Deno]. Refer to the
-[Deno official manual](https://deno.land/manual/getting_started/installation)
+[Deno official manual](https://docs.deno.com/runtime/getting_started/installation/)
 for details.
 
 Ensure that the `deno` command is executable from Vim / Neovim (hereafter, when


### PR DESCRIPTION
https://deno.land/manual/getting_started/installation is 404 Not Found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the URL for the Deno official manual to reflect the new documentation structure.
	- Minor formatting adjustments made for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->