### PR TITLE
Fix for Deno v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
       verbose:
         type: boolean
         required: false
-        description: 'Enable verbose output'
+        description: "Enable verbose output"
         default: false
 
 defaults:
@@ -34,6 +34,7 @@ jobs:
           - ubuntu-latest
         version:
           - "1.x"
+          - "2.x"
     runs-on: ${{ matrix.runner }}
     steps:
       - run: git config --global core.autocrlf false
@@ -68,6 +69,7 @@ jobs:
         deno_version:
           - "1.45.0"
           - "1.x"
+          - "2.x"
         host_version:
           - vim: "v9.1.0448"
             nvim: "v0.10.0"

--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ can ask questions in English.
 
 ### YouTube
 
-[![Revolutionizing Vim/Neovim Plugin Development ~ An In-Depth Look into Denops
-](http://img.youtube.com/vi/hu9EN7jl2kA/0.jpg)](https://www.youtube.com/watch?v=hu9EN7jl2kA)<br>
-[English slide](https://bit.ly/4eQ8LH5) in a talk at [VimConf 2023 Tiny](https://vimconf.org/2023/) (with Japanese)
+[![Revolutionizing Vim/Neovim Plugin Development ~ An In-Depth Look into Denops](http://img.youtube.com/vi/hu9EN7jl2kA/0.jpg)](https://www.youtube.com/watch?v=hu9EN7jl2kA)<br>
+[English slide](https://bit.ly/4eQ8LH5) in a talk at
+[VimConf 2023 Tiny](https://vimconf.org/2023/) (with Japanese)
 
 ## Misc.
 

--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -275,7 +275,7 @@ class Plugin {
     try {
       return await this.#denops.dispatcher[fn](...args);
     } catch (err) {
-      const errMsg = err.message ?? err;
+      const errMsg = err instanceof Error ? err.message : String(err);
       throw new Error(
         `Failed to call '${fn}' API in '${this.name}': ${errMsg}`,
       );

--- a/tests/denops/testutil/mock.ts
+++ b/tests/denops/testutil/mock.ts
@@ -7,7 +7,8 @@ export function pendingPromise(): Promise<never> {
 }
 
 /** Returns a fake `TcpListener` instance. */
-export function createFakeTcpListener(): Deno.TcpListener {
+// NOTE: 'rid' is removed from Deno v2
+export function createFakeTcpListener(): { rid: unknown } & Deno.TcpListener {
   let closeWaiter: PromiseWithResolvers<never> | undefined = Promise
     .withResolvers();
   closeWaiter.promise.catch(() => {});
@@ -54,7 +55,8 @@ export function createFakeTcpListener(): Deno.TcpListener {
 }
 
 /** Returns a fake `TcpConn` instance. */
-export function createFakeTcpConn(): Deno.TcpConn {
+// NOTE: 'rid' is removed from Deno v2
+export function createFakeTcpConn(): { rid: unknown } & Deno.TcpConn {
   return {
     get localAddr() {
       return unimplemented();

--- a/tests/denops/testutil/mock_test.ts
+++ b/tests/denops/testutil/mock_test.ts
@@ -57,7 +57,11 @@ Deno.test("createFakeTcpListener()", async (t) => {
           close: 0,
           [Symbol.asyncIterator]: 0,
           [Symbol.dispose]: 0,
-        } as const satisfies Record<keyof Deno.TcpListener, 0>,
+        } as const satisfies Record<
+          // NOTE: 'rid' is removed from Deno v2
+          keyof { rid: unknown } & Deno.TcpListener,
+          0
+        >,
       );
       for (const key of keys) {
         await t.step(key.toString(), () => {
@@ -70,7 +74,10 @@ Deno.test("createFakeTcpListener()", async (t) => {
       const unimplementedProps = [
         "addr",
         "rid",
-      ] as const satisfies readonly GetterKeyOf<Deno.TcpListener>[];
+      ] as const satisfies readonly GetterKeyOf<
+        // NOTE: 'rid' is removed from Deno v2
+        { rid: unknown } & Deno.TcpListener
+      >[];
       for (const key of unimplementedProps) {
         await t.step(`.${key}`, () => {
           assertThrows(() => listener[key], Error, "Unimplemented");
@@ -230,7 +237,11 @@ Deno.test("createFakeTcpConn()", async (t) => {
           close: 0,
           closeWrite: 0,
           [Symbol.dispose]: 0,
-        } as const satisfies Record<keyof Deno.TcpConn, 0>,
+        } as const satisfies Record<
+          // NOTE: 'rid' is removed from Deno v2
+          keyof { rid: unknown } & Deno.TcpConn,
+          0
+        >,
       );
       for (const key of keys) {
         await t.step(key.toString(), () => {
@@ -246,7 +257,10 @@ Deno.test("createFakeTcpConn()", async (t) => {
         "rid",
         "readable",
         "writable",
-      ] as const satisfies readonly GetterKeyOf<Deno.TcpConn>[];
+      ] as const satisfies readonly GetterKeyOf<
+        // NOTE: 'rid' is removed from Deno v2
+        { rid: unknown } & Deno.TcpConn
+      >[];
       for (const key of unimplementedProps) {
         await t.step(`.${key}`, () => {
           assertThrows(() => conn[key], Error, "Unimplemented");


### PR DESCRIPTION
- `rid` is no longer exist in Deno v2
- `err` is `unknown` in Deno v2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced testing capabilities with support for Deno version "2.x".
  
- **Bug Fixes**
  - Improved error handling in plugin function calls for more robust error reporting.

- **Documentation**
  - Updated formatting in the README for better readability, particularly in the YouTube video section.

- **Tests**
  - Adjusted test assertions to reflect the removal of the `rid` property from fake TCP listener and connection objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->