### PR TITLE
Use String(err) instead

### DIFF
--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -275,9 +275,8 @@ class Plugin {
     try {
       return await this.#denops.dispatcher[fn](...args);
     } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
       throw new Error(
-        `Failed to call '${fn}' API in '${this.name}': ${errMsg}`,
+        `Failed to call '${fn}' API in '${this.name}': ${String(err)}`,
       );
     }
   }

--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -275,8 +275,19 @@ class Plugin {
     try {
       return await this.#denops.dispatcher[fn](...args);
     } catch (err) {
+      const message = (v: unknown) => {
+        if (v instanceof Error) {
+          // NOTE: In Deno, Prefer `Error.stack` because it contains
+          // `Error.message`.
+          return `${v.stack ?? v}`;
+        } else if (typeof v === "object") {
+          return JSON.stringify(v);
+        } else {
+          return `${v}`;
+        }
+      };
       throw new Error(
-        `Failed to call '${fn}' API in '${this.name}': ${String(err)}`,
+        `Failed to call '${fn}' API in '${this.name}': ${message(err)}`,
       );
     }
   }

--- a/tests/denops/runtime/functions/denops/request_async_test.ts
+++ b/tests/denops/runtime/functions/denops/request_async_test.ts
@@ -130,7 +130,7 @@ testHost({
         });
 
         const normalizeMessage = (events: unknown[]): unknown[] => {
-          return events.map(event => {
+          return events.map((event) => {
             if (!Array.isArray(event) || event.length < 2) {
               return event;
             }
@@ -140,10 +140,10 @@ testHost({
             }
             return [
               event[0],
-              errors.map(error => ({
+              errors.map((error) => ({
                 ...error,
-                message: error?.message?.replace(/\n.*/g, '') ?? error?.message
-              }))
+                message: error?.message?.replace(/\n.*/g, "") ?? error?.message,
+              })),
             ];
           });
         };
@@ -151,7 +151,7 @@ testHost({
         await t.step("calls failure callback", async () => {
           await wait(() => host.call("eval", "len(g:__test_denops_events)"));
           const normalizedEvents = normalizeMessage(
-            await host.call("eval", "g:__test_denops_events") as ErrorEvent[]
+            await host.call("eval", "g:__test_denops_events") as ErrorEvent[],
           );
           assertObjectMatch(
             normalizedEvents,

--- a/tests/denops/runtime/functions/denops/request_async_test.ts
+++ b/tests/denops/runtime/functions/denops/request_async_test.ts
@@ -129,17 +129,22 @@ testHost({
           );
         });
 
-        type ErrorEvent = {
-          message: string;
-          name: string;
-        };
-        const normalizeMessage = (events: unknown[]) => {
+        const normalizeMessage = (events: unknown[]): unknown[] => {
           return events.map(event => {
-            const error = (event as unknown[])[1] as ErrorEvent[];
-            if (error[0]?.message) {
-              error[0].message = error[0].message.replace(/\n.*/g, '');
+            if (!Array.isArray(event) || event.length < 2) {
+              return event;
             }
-            return event;
+            const errors = event[1];
+            if (!Array.isArray(errors) || errors.length === 0) {
+              return event;
+            }
+            return [
+              event[0],
+              errors.map(error => ({
+                ...error,
+                message: error?.message?.replace(/\n.*/g, '') ?? error?.message
+              }))
+            ];
           });
         };
 


### PR DESCRIPTION
Test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling logic for clearer and more contextual error messages.
	- Improved formatting of error messages based on error types for better clarity.
	- Updated test cases to ensure consistent formatting of error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->