### PR TITLE
👍 Show stack-trace on plugin error

### DIFF
--- a/denops/@denops-private/service.ts
+++ b/denops/@denops-private/service.ts
@@ -275,7 +275,9 @@ class Plugin {
     try {
       return await this.#denops.dispatcher[fn](...args);
     } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
+      const errMsg = err instanceof Error
+        ? err.stack ?? err.message // Prefer 'stack' if available
+        : String(err);
       throw new Error(
         `Failed to call '${fn}' API in '${this.name}': ${errMsg}`,
       );

--- a/tests/denops/runtime/functions/denops/request_async_test.ts
+++ b/tests/denops/runtime/functions/denops/request_async_test.ts
@@ -2,6 +2,7 @@ import {
   assertArrayIncludes,
   assertEquals,
   assertObjectMatch,
+  assertStringIncludes,
 } from "jsr:@std/assert@^1.0.1";
 import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
 import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
@@ -131,20 +132,33 @@ testHost({
 
         await t.step("calls failure callback", async () => {
           await wait(() => host.call("eval", "len(g:__test_denops_events)"));
+          const result = await host.call(
+            "eval",
+            "g:__test_denops_events",
+            // deno-lint-ignore no-explicit-any
+          ) as any[];
           assertObjectMatch(
-            await host.call("eval", "g:__test_denops_events") as unknown[],
+            result,
             {
               0: [
                 "TestDenopsRequestAsyncFailure:Called",
                 [
                   {
-                    message:
-                      "Failed to call 'fail' API in 'dummy': Dummy failure",
                     name: "Error",
                   },
                 ],
               ],
             },
+          );
+          const message = result[0][1][0].message as string;
+          assertStringIncludes(
+            message,
+            "Failed to call 'fail' API in 'dummy': Error: Dummy failure",
+          );
+          assertStringIncludes(
+            message,
+            "dummy_dispatcher_plugin.ts:19:13",
+            "Error message should include the where the original error occurred",
           );
         });
       });
@@ -165,20 +179,28 @@ testHost({
 
         await t.step("calls failure callback", async () => {
           await wait(() => host.call("eval", "len(g:__test_denops_events)"));
+          const result = await host.call(
+            "eval",
+            "g:__test_denops_events",
+            // deno-lint-ignore no-explicit-any
+          ) as any[];
           assertObjectMatch(
-            await host.call("eval", "g:__test_denops_events") as unknown[],
+            result,
             {
               0: [
                 "TestDenopsRequestAsyncFailure:Called",
                 [
                   {
-                    message:
-                      "Failed to call 'not_exist_method' API in 'dummy': this[#denops].dispatcher[fn] is not a function",
                     name: "Error",
                   },
                 ],
               ],
             },
+          );
+          const message = result[0][1][0].message as string;
+          assertStringIncludes(
+            message,
+            "Failed to call 'not_exist_method' API in 'dummy': TypeError: this[#denops].dispatcher[fn] is not a function",
           );
         });
       });

--- a/tests/denops/runtime/functions/denops/request_test.ts
+++ b/tests/denops/runtime/functions/denops/request_test.ts
@@ -66,6 +66,22 @@ testHost({
         assertEquals(result, { result: "OK", args: ["foo"] });
       });
 
+      await t.step("if the dispatcher method throws an error", async (t) => {
+        await t.step("throws an error", async () => {
+          await assertRejects(
+            () =>
+              host.call(
+                "denops#request",
+                "dummy",
+                "fail",
+                ["foo"],
+              ),
+            Error,
+            "Failed to call 'fail' API in 'dummy': Dummy failure",
+          );
+        });
+      });
+
       await t.step("if the dispatcher method is not exist", async (t) => {
         await t.step("throws an error", async () => {
           await assertRejects(

--- a/tests/denops/runtime/functions/denops/request_test.ts
+++ b/tests/denops/runtime/functions/denops/request_test.ts
@@ -77,7 +77,7 @@ testHost({
                 ["foo"],
               ),
             Error,
-            "Failed to call 'not_exist_method' API in 'dummy'",
+            "Failed to call 'not_exist_method' API in 'dummy': this[#denops].dispatcher[fn] is not a function",
           );
         });
       });

--- a/tests/denops/runtime/functions/denops/request_test.ts
+++ b/tests/denops/runtime/functions/denops/request_test.ts
@@ -1,4 +1,9 @@
-import { assertEquals, assertRejects } from "jsr:@std/assert@^1.0.1";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertStringIncludes,
+} from "jsr:@std/assert@^1.0.1";
 import { INVALID_PLUGIN_NAMES } from "/denops-testdata/invalid_plugin_names.ts";
 import { resolveTestDataPath } from "/denops-testdata/resolve.ts";
 import { testHost } from "/denops-testutil/host.ts";
@@ -68,16 +73,21 @@ testHost({
 
       await t.step("if the dispatcher method throws an error", async (t) => {
         await t.step("throws an error", async () => {
-          await assertRejects(
-            () =>
-              host.call(
-                "denops#request",
-                "dummy",
-                "fail",
-                ["foo"],
-              ),
-            Error,
-            "Failed to call 'fail' API in 'dummy': Dummy failure",
+          const result = await host.call(
+            "denops#request",
+            "dummy",
+            "fail",
+            ["foo"],
+          ).catch((e) => e);
+          assertInstanceOf(result, Error);
+          assertStringIncludes(
+            result.message,
+            "Failed to call 'fail' API in 'dummy': Error: Dummy failure",
+          );
+          assertStringIncludes(
+            result.message,
+            "dummy_dispatcher_plugin.ts:19:13",
+            "Error message should include the where the original error occurred",
           );
         });
       });
@@ -93,7 +103,7 @@ testHost({
                 ["foo"],
               ),
             Error,
-            "Failed to call 'not_exist_method' API in 'dummy': this[#denops].dispatcher[fn] is not a function",
+            "Failed to call 'not_exist_method' API in 'dummy': TypeError: this[#denops].dispatcher[fn] is not a function",
           );
         });
       });

--- a/tests/denops/testdata/dummy_dispatcher_plugin.ts
+++ b/tests/denops/testdata/dummy_dispatcher_plugin.ts
@@ -14,5 +14,9 @@ export const main: Entrypoint = (denops) => {
       );
       return { result: "OK", args };
     },
+    fail: async () => {
+      await delay(MIMIC_DISPATCHER_METHOD_DELAY);
+      throw new Error("Dummy failure");
+    },
   };
 };


### PR DESCRIPTION
Continue from #428 

The **After** shows that the original error was occcurred in `dummy_dispatcher_plugin.ts:19:13` but **Before**. This stack-trace will help developers to find a reason of issues.

##### Before

```
Failed to call 'fail' API in 'dummy': Dummy failure
```

##### After

```
Failed to call 'fail' API in 'dummy': Error: Dummy failure
    at Object.fail (file:///Users/alisue/ogh/vim-denops/denops.vim/tests/denops/testdata/dummy_dispatcher_plugin.ts:19:13)
    at eventLoopTick (ext:core/01_core.js:214:9)
    at async Plugin.call (file:///Users/alisue/ogh/vim-denops/denops.vim/denops/@denops-private/service.ts:276:14)
    at async Service.#dispatch (file:///Users/alisue/ogh/vim-denops/denops.vim/denops/@denops-private/service.ts:117:12)
    at async Service.dispatchAsync (file:///Users/alisue/ogh/vim-denops/denops.vim/denops/@denops-private/service.ts:141:17)
    at async dispatch (https://jsr.io/@lambdalisue/messagepack-rpc/2.4.0/dispatcher.ts:36:12)
    at async Session.#dispatch (https://jsr.io/@lambdalisue/messagepack-rpc/2.4.0/session.ts:255:22)
    at async Session.#handleNotificationMessage (https://jsr.io/@lambdalisue/messagepack-rpc/2.4.0/session.ts:310:25)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `fail` method in the dispatcher to simulate error scenarios.
  
- **Bug Fixes**
	- Enhanced error handling in test cases for dispatcher methods, providing clearer error messages for various failure scenarios.

- **Tests**
	- Added new test cases to validate error handling for dispatcher method failures in the test suite.
	- Improved error reporting in existing tests for better clarity on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->