### PR TITLE
chore: bump @std/internal to 1.0.8

### DIFF
--- a/tests/denops/testdata/no_check/cli_constraint_error_on_issue_401.ts
+++ b/tests/denops/testdata/no_check/cli_constraint_error_on_issue_401.ts
@@ -6,4 +6,4 @@
 // See the tasks in *deno.jsonc* for details.
 //
 // DO NOT UPDATE THIS LINE.
-import * as _ from "jsr:@std/internal@1.0.0-non-existent-version";
+import * as _ from "jsr:@std/internal@1.0.8";


### PR DESCRIPTION
#### :package: @std/internal [1.0.0-non-existent-version](https://jsr.io/@std/internal/1.0.0-non-existent-version) → [1.0.8](https://jsr.io/@std/internal/1.0.8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue with an invalid package version reference to ensure proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->