### PR TITLE
:bug: fix missing imports

### DIFF
--- a/denops/@denops-private/deno.jsonc
+++ b/denops/@denops-private/deno.jsonc
@@ -2,6 +2,7 @@
   "imports": {
     "@core/asyncutil": "jsr:@core/asyncutil@^1.1.1",
     "@core/errorutil": "jsr:@core/errorutil@^1.2.1",
+    "@core/streamutil": "jsr:@core/streamutil@^1.0.0",
     "@core/unknownutil": "jsr:@core/unknownutil@^4.0.0",
     "@denops/core": "jsr:@denops/core@^7.0.0",
     "@denops/vim-channel-command": "jsr:@denops/vim-channel-command@^4.0.2",


### PR DESCRIPTION
# Background

denops.vim v7.1.0 raises these errors:

```
[denops] error: Uncaught (in worker "127.0.0.1:51903") Relative import path "@core/streamutil" not prefixed with / or ./ or ../ and not in import map from "file:///path/to/denops/@denops-private/worker.ts"
[denops]     at file:///path/to/denops/@denops-private/worker.ts:9:21
[denops] error: Uncaught (in promise) Error: Unhandled error in child worker.
[denops]     at Worker.#pollControl (ext:runtime/11_workers.js:204:19)
[denops]     at eventLoopTick (ext:core/01_core.js:178:7)
```

# Summary (Generated by Copilot)

This pull request includes a small change to the `deno.jsonc` file. The change adds a new import for the `@core/streamutil` module, specifying version `^1.0.0` to enhance functionality.