### PR TITLE
Fix denops#cache#update()

### DIFF
--- a/autoload/denops/cache.vim
+++ b/autoload/denops/cache.vim
@@ -5,31 +5,31 @@ let s:job = v:null
 function! denops#cache#update(...) abort
   const l:options = extend(#{ reload: v:false }, a:0 ? a:1 : {})
   const l:plugins = denops#_internal#plugin#list()
-  const l:entryfiles = extend([s:mod], mapnew(l:plugins, { _, v -> v.script }))
 
-  let l:args = [g:denops#deno, 'cache']
-
-  if l:options.reload
-    let l:args = add(l:args, '--reload')
-    echomsg '[denops] Forcibly update cache of the following files.'
-  else
+  if !l:options.reload
     echomsg '[denops] Update cache of the following files. Call `denops#cache#update(#{reload: v:true})` to forcibly update.'
   endif
 
-  for l:entryfile in l:entryfiles
+  for l:entryfile in [s:mod] + mapnew(l:plugins, { _, v -> v.script })
     echomsg printf('[denops] %s', l:entryfile)
-  endfor
-  let l:args = extend(l:args, l:entryfiles)
 
-  let s:job = denops#_internal#job#start(l:args, #{
-        \ on_stderr: funcref('s:on_stderr'),
-        \ on_exit: funcref('s:on_exit'),
-        \ env: #{
-        \   NO_COLOR: 1,
-        \   DENO_NO_PROMPT: 1,
-        \ },
-        \})
-  call denops#_internal#wait#for(60 * 1000, { -> s:job is# v:null }, 100)
+    let l:args = [g:denops#deno, 'cache']
+    if l:options.reload
+      let l:args = add(l:args, '--reload')
+    endif
+    let l:args = add(l:args, l:entryfile)
+
+    let s:job = denops#_internal#job#start(l:args, #{
+          \ on_stderr: funcref('s:on_stderr'),
+          \ on_exit: funcref('s:on_exit'),
+          \ env: #{
+          \   NO_COLOR: 1,
+          \   DENO_NO_PROMPT: 1,
+          \ },
+          \})
+    call denops#_internal#wait#for(60 * 1000, { -> s:job is# v:null }, 100)
+  endfor
+
   echomsg '[denops] Deno cache is updated.'
 endfunction
 

--- a/autoload/denops/cache.vim
+++ b/autoload/denops/cache.vim
@@ -5,6 +5,7 @@ let s:job = v:null
 function! denops#cache#update(...) abort
   const l:options = extend(#{ reload: v:false }, a:0 ? a:1 : {})
   const l:plugins = denops#_internal#plugin#list()
+  let l:failures = []
 
   if !l:options.reload
     echomsg '[denops] Update cache of the following files. Call `denops#cache#update(#{reload: v:true})` to forcibly update.'
@@ -21,7 +22,7 @@ function! denops#cache#update(...) abort
 
     let s:job = denops#_internal#job#start(l:args, #{
           \ on_stderr: funcref('s:on_stderr'),
-          \ on_exit: funcref('s:on_exit'),
+          \ on_exit: funcref('s:on_exit', [l:failures, l:entryfile]),
           \ env: #{
           \   NO_COLOR: 1,
           \   DENO_NO_PROMPT: 1,
@@ -30,7 +31,16 @@ function! denops#cache#update(...) abort
     call denops#_internal#wait#for(60 * 1000, { -> s:job is# v:null }, 100)
   endfor
 
-  echomsg '[denops] Deno cache is updated.'
+  if empty(l:failures)
+    echomsg '[denops] Deno cache is updated.'
+  else
+    echohl WarningMsg
+    echomsg printf('[denops] Deno cache finished with errors: %d failure(s).', len(l:failures))
+    for l:f in l:failures
+      echomsg printf('[denops] failed: %s', l:f)
+    endfor
+    echohl None
+  endif
 endfunction
 
 function! s:on_stderr(job, data, event) abort
@@ -41,6 +51,9 @@ function! s:on_stderr(job, data, event) abort
   echohl None
 endfunction
 
-function! s:on_exit(job, status, event) abort
+function! s:on_exit(failures, entryfile, job, status, event) abort
+  if a:status != 0
+    call add(a:failures, a:entryfile)
+  endif
   let s:job = v:null
 endfunction


### PR DESCRIPTION
Use loop to fix import error like this.

```
[denops] Update cache of the following files. Call `denops#cache#update(#{reload: v:true})` to forcibly update.
[denops] /home/shougo/work/denops.vim/denops/@denops-private/mod.ts
[denops] /home/shougo/work/dpp.vim/denops/dpp/app.ts
[denops] /home/shougo/.cache/dpp/repos/github.com/lambdalisue/kensaku.vim/denops/kensaku/main.ts
[denops] /home/shougo/work/ddc.vim/denops/ddc/app.ts
[denops] /home/shougo/work/ddt.vim/denops/ddt/app.ts
[denops] /home/shougo/work/ddu.vim/denops/ddu/app.ts
[denops] Download https://jsr.io/@std/json/meta.json
[denops] Download https://jsr.io/@std/json/1.0.2_meta.json
[denops] Download https://jsr.io/@lambdalisue/workerio/4.0.1/types.ts
[denops] Download https://jsr.io/@std/json/1.0.2/types.ts
[denops] error: Relative import path "@core/unknownutil/is" not prefixed with / or ./ or ../ and not in import map from "file:///home/shougo/work/dpp.vim/denops/dpp/app.ts"
[denops]   hint: If you want to use a JSR or npm package, try running `deno add jsr:@core/unknownutil/is` or `deno add npm:@core/unknownutil/is`
[denops]     at file:///home/shougo/work/dpp.vim/denops/dpp/app.ts:21:20
[denops] Deno cache is updated.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Caching now processes each entry individually instead of one batch; each entry is handled and awaited separately.
  * Per-entry reload option applied per file; progress messages shown per entry.

* **Bug Fixes**
  * Added per-run summary reporting failures and listing failed entries when any occur.
  * Improved per-entry error reporting and clearer final success/failure notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->